### PR TITLE
[bitnami/*] Update VIB pipelines

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -189,8 +189,8 @@ jobs:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
           VIB_ENV_S3_URL: s3://${{ secrets.AWS_S3_BUCKET }}/bitnami
-          VIB_ENV_S3_USERNAME: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          VIB_ENV_S3_PASSWORD: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          VIB_ENV_S3_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          VIB_ENV_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   update-index:
     runs-on: ubuntu-latest
     needs:

--- a/.vib/airflow/vib-publish.json
+++ b/.vib/airflow/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/airflow/goss"
             },
             "remote": {
-              "workload": "deploy-airflow-web"
+              "pod": {
+                "workload": "deploy-airflow-web"
+              }
             }
           }
         },
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/airflow/vib-verify.json
+++ b/.vib/airflow/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/airflow/goss"
             },
             "remote": {
-              "workload": "deploy-airflow-web"
+              "pod": {
+                "workload": "deploy-airflow-web"
+              }
             }
           }
         },

--- a/.vib/apache/vib-publish.json
+++ b/.vib/apache/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/apache/goss"
             },
             "remote": {
-              "workload": "deploy-apache"
+              "pod": {
+                "workload": "deploy-apache"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/apache/vib-verify.json
+++ b/.vib/apache/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/apache/goss"
             },
             "remote": {
-              "workload": "deploy-apache"
+              "pod": {
+                "workload": "deploy-apache"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/appsmith/vib-publish.json
+++ b/.vib/appsmith/vib-publish.json
@@ -46,7 +46,9 @@
               "path": "/.vib/appsmith/goss"
             },
             "remote": {
-              "workload": "deploy-appsmith"
+              "pod": {
+                "workload": "deploy-appsmith"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/appsmith/vib-verify.json
+++ b/.vib/appsmith/vib-verify.json
@@ -46,7 +46,9 @@
               "path": "/.vib/appsmith/goss"
             },
             "remote": {
-              "workload": "deploy-appsmith"
+              "pod": {
+                "workload": "deploy-appsmith"
+              }
             }
           }
         },

--- a/.vib/argo-cd/vib-publish.json
+++ b/.vib/argo-cd/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/argo-cd/goss"
             },
             "remote": {
-              "workload": "deploy-argo-cd-server"
+              "pod": {
+                "workload": "deploy-argo-cd-server"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/argo-cd/vib-verify.json
+++ b/.vib/argo-cd/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/argo-cd/goss"
             },
             "remote": {
-              "workload": "deploy-argo-cd-server"
+              "pod": {
+                "workload": "deploy-argo-cd-server"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/argo-workflows/vib-publish.json
+++ b/.vib/argo-workflows/vib-publish.json
@@ -58,8 +58,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/aspnet-core/vib-publish.json
+++ b/.vib/aspnet-core/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-aspnet-core"
+              "pod": {
+                "workload": "deploy-aspnet-core"
+              }
             }
           }
         },
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/aspnet-core/vib-verify.json
+++ b/.vib/aspnet-core/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-aspnet-core"
+              "pod": {
+                "workload": "deploy-aspnet-core"
+              }
             }
           }
         },

--- a/.vib/cassandra/vib-publish.json
+++ b/.vib/cassandra/vib-publish.json
@@ -45,7 +45,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-cassandra"
+              "pod": {
+                "workload": "sts-cassandra"
+              }
             }
           }
         }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/cassandra/vib-verify.json
+++ b/.vib/cassandra/vib-verify.json
@@ -45,7 +45,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-cassandra"
+              "pod": {
+                "workload": "sts-cassandra"
+              }
             }
           }
         }

--- a/.vib/cert-manager/vib-publish.json
+++ b/.vib/cert-manager/vib-publish.json
@@ -51,7 +51,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-cert-manager-controller"
+              "pod": {
+                "workload": "deploy-cert-manager-controller"
+              }
             }
           }
         }
@@ -65,8 +67,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/cert-manager/vib-verify.json
+++ b/.vib/cert-manager/vib-verify.json
@@ -51,7 +51,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-cert-manager-controller"
+              "pod": {
+                "workload": "deploy-cert-manager-controller"
+              }
             }
           }
         }

--- a/.vib/clickhouse/vib-publish.json
+++ b/.vib/clickhouse/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-clickhouse-shard0"
+              "pod": {
+                "workload": "sts-clickhouse-shard0"
+              }
             }
           }
         },
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/clickhouse/vib-verify.json
+++ b/.vib/clickhouse/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-clickhouse-shard0"
+              "pod": {
+                "workload": "sts-clickhouse-shard0"
+              }
             }
           }
         },

--- a/.vib/concourse/vib-publish.json
+++ b/.vib/concourse/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/concourse/goss/web"
             },
             "remote": {
-              "workload": "deploy-concourse-web"
+              "pod": {
+                "workload": "deploy-concourse-web"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -57,7 +59,9 @@
               "path": "/.vib/concourse/goss/worker"
             },
             "remote": {
-              "workload": "deploy-concourse-worker"
+              "pod": {
+                "workload": "deploy-concourse-worker"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -82,8 +86,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/concourse/vib-verify.json
+++ b/.vib/concourse/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/concourse/goss/web"
             },
             "remote": {
-              "workload": "deploy-concourse-web"
+              "pod": {
+                "workload": "deploy-concourse-web"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -57,7 +59,9 @@
               "path": "/.vib/concourse/goss/worker"
             },
             "remote": {
-              "workload": "deploy-concourse-worker"
+              "pod": {
+                "workload": "deploy-concourse-worker"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/consul/vib-publish.json
+++ b/.vib/consul/vib-publish.json
@@ -59,7 +59,9 @@
               "path": "/.vib/consul/goss"
             },
             "remote": {
-              "workload": "sts-consul"
+              "pod": {
+                "workload": "sts-consul"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/consul/vib-verify.json
+++ b/.vib/consul/vib-verify.json
@@ -59,7 +59,9 @@
               "path": "/.vib/consul/goss"
             },
             "remote": {
-              "workload": "sts-consul"
+              "pod": {
+                "workload": "sts-consul"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/contour-operator/vib-publish.json
+++ b/.vib/contour-operator/vib-publish.json
@@ -56,8 +56,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/contour/vib-publish.json
+++ b/.vib/contour/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/contour/goss"
             },
             "remote": {
-              "workload": "deploy-contour-contour"
+              "pod": {
+                "workload": "deploy-contour-contour"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/contour/vib-verify.json
+++ b/.vib/contour/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/contour/goss"
             },
             "remote": {
-              "workload": "deploy-contour-contour"
+              "pod": {
+                "workload": "deploy-contour-contour"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/discourse/vib-publish.json
+++ b/.vib/discourse/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/discourse/goss"
             },
             "remote": {
-              "workload": "deploy-discourse"
+              "pod": {
+                "workload": "deploy-discourse"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/discourse/vib-verify.json
+++ b/.vib/discourse/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/discourse/goss"
             },
             "remote": {
-              "workload": "deploy-discourse"
+              "pod": {
+                "workload": "deploy-discourse"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/dokuwiki/vib-publish.json
+++ b/.vib/dokuwiki/vib-publish.json
@@ -59,7 +59,9 @@
               "path": "/.vib/dokuwiki/goss"
             },
             "remote": {
-              "workload": "deploy-dokuwiki"
+              "pod": {
+                "workload": "deploy-dokuwiki"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/dokuwiki/vib-verify.json
+++ b/.vib/dokuwiki/vib-verify.json
@@ -59,7 +59,9 @@
               "path": "/.vib/dokuwiki/goss"
             },
             "remote": {
-              "workload": "deploy-dokuwiki"
+              "pod": {
+                "workload": "deploy-dokuwiki"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/drupal/vib-publish.json
+++ b/.vib/drupal/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/drupal/goss"
             },
             "remote": {
-              "workload": "deploy-drupal"
+              "pod": {
+                "workload": "deploy-drupal"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/drupal/vib-verify.json
+++ b/.vib/drupal/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/drupal/goss"
             },
             "remote": {
-              "workload": "deploy-drupal"
+              "pod": {
+                "workload": "deploy-drupal"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/ejbca/vib-publish.json
+++ b/.vib/ejbca/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/ejbca/goss"
             },
             "remote": {
-              "workload": "deploy-ejbca"
+              "pod": {
+                "workload": "deploy-ejbca"
+              }
             },
             "vars_file": "vars.yaml",
             "wait": {
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/ejbca/vib-verify.json
+++ b/.vib/ejbca/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/ejbca/goss"
             },
             "remote": {
-              "workload": "deploy-ejbca"
+              "pod": {
+                "workload": "deploy-ejbca"
+              }
             },
             "vars_file": "vars.yaml",
             "wait": {

--- a/.vib/elasticsearch/vib-publish.json
+++ b/.vib/elasticsearch/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/elasticsearch/goss"
             },
             "remote": {
-              "workload": "sts-elasticsearch-master"
+              "pod": {
+                "workload": "sts-elasticsearch-master"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/elasticsearch/vib-verify.json
+++ b/.vib/elasticsearch/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/elasticsearch/goss"
             },
             "remote": {
-              "workload": "sts-elasticsearch-master"
+              "pod": {
+                "workload": "sts-elasticsearch-master"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/etcd/vib-publish.json
+++ b/.vib/etcd/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/etcd/goss"
             },
             "remote": {
-              "workload": "sts-etcd"
+              "pod": {
+                "workload": "sts-etcd"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/etcd/vib-verify.json
+++ b/.vib/etcd/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/etcd/goss"
             },
             "remote": {
-              "workload": "sts-etcd"
+              "pod": {
+                "workload": "sts-etcd"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/external-dns/vib-publish.json
+++ b/.vib/external-dns/vib-publish.json
@@ -38,7 +38,9 @@
               "path": "/.vib/external-dns/goss"
             },
             "remote": {
-              "workload": "deploy-external-dns"
+              "pod": {
+                "workload": "deploy-external-dns"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/external-dns/vib-verify.json
+++ b/.vib/external-dns/vib-verify.json
@@ -38,7 +38,9 @@
               "path": "/.vib/external-dns/goss"
             },
             "remote": {
-              "workload": "deploy-external-dns"
+              "pod": {
+                "workload": "deploy-external-dns"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/fluentd/vib-publish.json
+++ b/.vib/fluentd/vib-publish.json
@@ -46,7 +46,9 @@
               "path": "/.vib/fluentd/goss"
             },
             "remote": {
-              "workload": "ds-fluentd"
+              "pod": {
+                "workload": "ds-fluentd"
+              }
             }
           }
         }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -46,7 +46,9 @@
               "path": "/.vib/fluentd/goss"
             },
             "remote": {
-              "workload": "ds-fluentd"
+              "pod": {
+                "workload": "ds-fluentd"
+              }
             }
           }
         }

--- a/.vib/ghost/vib-publish.json
+++ b/.vib/ghost/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-ghost"
+              "pod": {
+                "workload": "deploy-ghost"
+              }
             }
           }
         },
@@ -75,8 +77,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/ghost/vib-verify.json
+++ b/.vib/ghost/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-ghost"
+              "pod": {
+                "workload": "deploy-ghost"
+              }
             }
           }
         },

--- a/.vib/gitea/vib-publish.json
+++ b/.vib/gitea/vib-publish.json
@@ -46,7 +46,9 @@
               "path": "/.vib/gitea/goss"
             },
             "remote": {
-              "workload": "deploy-gitea"
+              "pod": {
+                "workload": "deploy-gitea"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/gitea/vib-verify.json
+++ b/.vib/gitea/vib-verify.json
@@ -46,7 +46,9 @@
               "path": "/.vib/gitea/goss"
             },
             "remote": {
-              "workload": "deploy-gitea"
+              "pod": {
+                "workload": "deploy-gitea"
+              }
             }
           }
         },

--- a/.vib/grafana-loki/vib-publish.json
+++ b/.vib/grafana-loki/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana-loki/goss/promtail"
             },
             "remote": {
-              "workload": "ds-grafana-loki-promtail"
+              "pod": {
+                "workload": "ds-grafana-loki-promtail"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -57,7 +59,9 @@
               "path": "/.vib/grafana-loki/goss/querier"
             },
             "remote": {
-              "workload": "sts-grafana-loki-querier"
+              "pod": {
+                "workload": "sts-grafana-loki-querier"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -82,8 +86,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/grafana-loki/vib-verify.json
+++ b/.vib/grafana-loki/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana-loki/goss/promtail"
             },
             "remote": {
-              "workload": "ds-grafana-loki-promtail"
+              "pod": {
+                "workload": "ds-grafana-loki-promtail"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -57,7 +59,9 @@
               "path": "/.vib/grafana-loki/goss/querier"
             },
             "remote": {
-              "workload": "sts-grafana-loki-querier"
+              "pod": {
+                "workload": "sts-grafana-loki-querier"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/grafana-mimir/vib-publish.json
+++ b/.vib/grafana-mimir/vib-publish.json
@@ -72,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/grafana-operator/vib-publish.json
+++ b/.vib/grafana-operator/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana-operator/goss"
             },
             "remote": {
-              "workload": "deploy-grafana-operator"
+              "pod": {
+                "workload": "deploy-grafana-operator"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/grafana-operator/vib-verify.json
+++ b/.vib/grafana-operator/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana-operator/goss"
             },
             "remote": {
-              "workload": "deploy-grafana-operator"
+              "pod": {
+                "workload": "deploy-grafana-operator"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/grafana-tempo/vib-publish.json
+++ b/.vib/grafana-tempo/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana-tempo/goss"
             },
             "remote": {
-              "workload": "deploy-grafana-tempo-compactor"
+              "pod": {
+                "workload": "deploy-grafana-tempo-compactor"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -92,8 +94,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/grafana-tempo/vib-verify.json
+++ b/.vib/grafana-tempo/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana-tempo/goss"
             },
             "remote": {
-              "workload": "deploy-grafana-tempo-compactor"
+              "pod": {
+                "workload": "deploy-grafana-tempo-compactor"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/grafana/vib-publish.json
+++ b/.vib/grafana/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana/goss"
             },
             "remote": {
-              "workload": "deploy-grafana"
+              "pod": {
+                "workload": "deploy-grafana"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/grafana/vib-verify.json
+++ b/.vib/grafana/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/grafana/goss"
             },
             "remote": {
-              "workload": "deploy-grafana"
+              "pod": {
+                "workload": "deploy-grafana"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/haproxy/vib-publish.json
+++ b/.vib/haproxy/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/haproxy/goss"
             },
             "remote": {
-              "workload": "deploy-haproxy"
+              "pod": {
+                "workload": "deploy-haproxy"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -69,8 +71,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/haproxy/vib-verify.json
+++ b/.vib/haproxy/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/haproxy/goss"
             },
             "remote": {
-              "workload": "deploy-haproxy"
+              "pod": {
+                "workload": "deploy-haproxy"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/harbor/vib-publish.json
+++ b/.vib/harbor/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/harbor/goss"
             },
             "remote": {
-              "workload": "deploy-harbor-registry"
+              "pod": {
+                "workload": "deploy-harbor-registry"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/harbor/vib-verify.json
+++ b/.vib/harbor/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/harbor/goss"
             },
             "remote": {
-              "workload": "deploy-harbor-registry"
+              "pod": {
+                "workload": "deploy-harbor-registry"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/influxdb/vib-publish.json
+++ b/.vib/influxdb/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/influxdb/goss"
             },
             "remote": {
-              "workload": "deploy-influxdb"
+              "pod": {
+                "workload": "deploy-influxdb"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -76,8 +78,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/influxdb/vib-verify.json
+++ b/.vib/influxdb/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/influxdb/goss"
             },
             "remote": {
-              "workload": "deploy-influxdb"
+              "pod": {
+                "workload": "deploy-influxdb"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/jaeger/vib-publish.json
+++ b/.vib/jaeger/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jaeger/goss"
             },
             "remote": {
-              "workload": "deploy-jaeger--agent"
+              "pod": {
+                "workload": "deploy-jaeger--agent"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/jaeger/vib-verify.json
+++ b/.vib/jaeger/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jaeger/goss"
             },
             "remote": {
-              "workload": "deploy-jaeger--agent"
+              "pod": {
+                "workload": "deploy-jaeger--agent"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/jasperreports/vib-publish.json
+++ b/.vib/jasperreports/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jasperreports/goss"
             },
             "remote": {
-              "workload": "deploy-jasperreports"
+              "pod": {
+                "workload": "deploy-jasperreports"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/jasperreports/vib-verify.json
+++ b/.vib/jasperreports/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jasperreports/goss"
             },
             "remote": {
-              "workload": "deploy-jasperreports"
+              "pod": {
+                "workload": "deploy-jasperreports"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/jenkins/vib-publish.json
+++ b/.vib/jenkins/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jenkins/goss"
             },
             "remote": {
-              "workload": "deploy-jenkins"
+              "pod": {
+                "workload": "deploy-jenkins"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/jenkins/vib-verify.json
+++ b/.vib/jenkins/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jenkins/goss"
             },
             "remote": {
-              "workload": "deploy-jenkins"
+              "pod": {
+                "workload": "deploy-jenkins"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/joomla/vib-publish.json
+++ b/.vib/joomla/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/joomla/goss"
             },
             "remote": {
-              "workload": "deploy-joomla"
+              "pod": {
+                "workload": "deploy-joomla"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/joomla/vib-verify.json
+++ b/.vib/joomla/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/joomla/goss"
             },
             "remote": {
-              "workload": "deploy-joomla"
+              "pod": {
+                "workload": "deploy-joomla"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/jupyterhub/vib-publish.json
+++ b/.vib/jupyterhub/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jupyterhub/goss"
             },
             "remote": {
-              "workload": "deploy-jupyterhub-hub"
+              "pod": {
+                "workload": "deploy-jupyterhub-hub"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/jupyterhub/vib-verify.json
+++ b/.vib/jupyterhub/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/jupyterhub/goss"
             },
             "remote": {
-              "workload": "deploy-jupyterhub-hub"
+              "pod": {
+                "workload": "deploy-jupyterhub-hub"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/kafka/vib-publish.json
+++ b/.vib/kafka/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/kafka/goss"
             },
             "remote": {
-              "workload": "sts-kafka"
+              "pod": {
+                "workload": "sts-kafka"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kafka/vib-verify.json
+++ b/.vib/kafka/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/kafka/goss"
             },
             "remote": {
-              "workload": "sts-kafka"
+              "pod": {
+                "workload": "sts-kafka"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/keycloak/vib-publish.json
+++ b/.vib/keycloak/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/keycloak/goss"
             },
             "remote": {
-              "workload": "sts-keycloak"
+              "pod": {
+                "workload": "sts-keycloak"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/keycloak/vib-verify.json
+++ b/.vib/keycloak/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/keycloak/goss"
             },
             "remote": {
-              "workload": "sts-keycloak"
+              "pod": {
+                "workload": "sts-keycloak"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/kiam/vib-publish.json
+++ b/.vib/kiam/vib-publish.json
@@ -24,8 +24,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kibana/vib-publish.json
+++ b/.vib/kibana/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/kibana/goss"
             },
             "remote": {
-              "workload": "deploy-kibana"
+              "pod": {
+                "workload": "deploy-kibana"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kibana/vib-verify.json
+++ b/.vib/kibana/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/kibana/goss"
             },
             "remote": {
-              "workload": "deploy-kibana"
+              "pod": {
+                "workload": "deploy-kibana"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/kong/vib-publish.json
+++ b/.vib/kong/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/kong/goss"
             },
             "remote": {
-              "workload": "deploy-kong"
+              "pod": {
+                "workload": "deploy-kong"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -75,8 +77,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kong/vib-verify.json
+++ b/.vib/kong/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/kong/goss"
             },
             "remote": {
-              "workload": "deploy-kong"
+              "pod": {
+                "workload": "deploy-kong"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/kube-prometheus/vib-publish.json
+++ b/.vib/kube-prometheus/vib-publish.json
@@ -55,7 +55,9 @@
               "path": "/.vib/kube-prometheus/goss"
             },
             "remote": {
-              "workload": "deploy-kube-prometheus-operator"
+              "pod": {
+                "workload": "deploy-kube-prometheus-operator"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kube-prometheus/vib-verify.json
+++ b/.vib/kube-prometheus/vib-verify.json
@@ -55,7 +55,9 @@
               "path": "/.vib/kube-prometheus/goss"
             },
             "remote": {
-              "workload": "deploy-kube-prometheus-operator"
+              "pod": {
+                "workload": "deploy-kube-prometheus-operator"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/kube-state-metrics/vib-publish.json
+++ b/.vib/kube-state-metrics/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-kube-state-metrics"
+              "pod": {
+                "workload": "deploy-kube-state-metrics"
+              }
             }
           }
         }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kube-state-metrics/vib-verify.json
+++ b/.vib/kube-state-metrics/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-kube-state-metrics"
+              "pod": {
+                "workload": "deploy-kube-state-metrics"
+              }
             }
           }
         }

--- a/.vib/kubeapps/vib-publish.json
+++ b/.vib/kubeapps/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/kubeapps/goss"
             },
             "remote": {
-              "workload": "deploy-kubeapps-internal-kubeappsapis"
+              "pod": {
+                "workload": "deploy-kubeapps-internal-kubeappsapis"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kubeapps/vib-verify.json
+++ b/.vib/kubeapps/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/kubeapps/goss"
             },
             "remote": {
-              "workload": "deploy-kubeapps-internal-kubeappsapis"
+              "pod": {
+                "workload": "deploy-kubeapps-internal-kubeappsapis"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/kubernetes-event-exporter/vib-publish.json
+++ b/.vib/kubernetes-event-exporter/vib-publish.json
@@ -38,7 +38,9 @@
               "path": "/.vib/kubernetes-event-exporter/goss"
             },
             "remote": {
-              "workload": "deploy-kubernetes-event-exporter"
+              "pod": {
+                "workload": "deploy-kubernetes-event-exporter"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -66,8 +68,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/kubernetes-event-exporter/vib-verify.json
+++ b/.vib/kubernetes-event-exporter/vib-verify.json
@@ -38,7 +38,9 @@
               "path": "/.vib/kubernetes-event-exporter/goss"
             },
             "remote": {
-              "workload": "deploy-kubernetes-event-exporter"
+              "pod": {
+                "workload": "deploy-kubernetes-event-exporter"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/logstash/vib-publish.json
+++ b/.vib/logstash/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/logstash/goss"
             },
             "remote": {
-              "workload": "sts-logstash"
+              "pod": {
+                "workload": "sts-logstash"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/logstash/vib-verify.json
+++ b/.vib/logstash/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/logstash/goss"
             },
             "remote": {
-              "workload": "sts-logstash"
+              "pod": {
+                "workload": "sts-logstash"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/magento/vib-publish.json
+++ b/.vib/magento/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/magento/goss"
             },
             "remote": {
-              "workload": "deploy-magento"
+              "pod": {
+                "workload": "deploy-magento"
+              }
             }
           }
         },
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/magento/vib-verify.json
+++ b/.vib/magento/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/magento/goss"
             },
             "remote": {
-              "workload": "deploy-magento"
+              "pod": {
+                "workload": "deploy-magento"
+              }
             }
           }
         },

--- a/.vib/mariadb-galera/vib-publish.json
+++ b/.vib/mariadb-galera/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-mariadb-galera"
+              "pod": {
+                "workload": "sts-mariadb-galera"
+              }
             }
           }
         }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mariadb-galera/vib-verify.json
+++ b/.vib/mariadb-galera/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-mariadb-galera"
+              "pod": {
+                "workload": "sts-mariadb-galera"
+              }
             }
           }
         }

--- a/.vib/mariadb/vib-publish.json
+++ b/.vib/mariadb/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-mariadb-primary"
+              "pod": {
+                "workload": "sts-mariadb-primary"
+              }
             }
           }
         }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mariadb/vib-verify.json
+++ b/.vib/mariadb/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-mariadb-primary"
+              "pod": {
+                "workload": "sts-mariadb-primary"
+              }
             }
           }
         }

--- a/.vib/mastodon/vib-publish.json
+++ b/.vib/mastodon/vib-publish.json
@@ -46,7 +46,9 @@
               "path": "/.vib/mastodon/goss"
             },
             "remote": {
-              "workload": "deploy-mastodon-web"
+              "pod": {
+                "workload": "deploy-mastodon-web"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mastodon/vib-verify.json
+++ b/.vib/mastodon/vib-verify.json
@@ -46,7 +46,9 @@
               "path": "/.vib/mastodon/goss"
             },
             "remote": {
-              "workload": "deploy-mastodon-web"
+              "pod": {
+                "workload": "deploy-mastodon-web"
+              }
             }
           }
         },

--- a/.vib/matomo/vib-publish.json
+++ b/.vib/matomo/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/matomo/goss"
             },
             "remote": {
-              "workload": "deploy-matomo"
+              "pod": {
+                "workload": "deploy-matomo"
+              }
             }
           }
         },
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/matomo/vib-verify.json
+++ b/.vib/matomo/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/matomo/goss"
             },
             "remote": {
-              "workload": "deploy-matomo"
+              "pod": {
+                "workload": "deploy-matomo"
+              }
             }
           }
         },

--- a/.vib/mediawiki/vib-publish.json
+++ b/.vib/mediawiki/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-mediawiki"
+              "pod": {
+                "workload": "deploy-mediawiki"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mediawiki/vib-verify.json
+++ b/.vib/mediawiki/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-mediawiki"
+              "pod": {
+                "workload": "deploy-mediawiki"
+              }
             }
           }
         },

--- a/.vib/memcached/vib-publish.json
+++ b/.vib/memcached/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/memcached/goss"
             },
             "remote": {
-              "workload": "deploy-memcached"
+              "pod": {
+                "workload": "deploy-memcached"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/memcached/vib-verify.json
+++ b/.vib/memcached/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/memcached/goss"
             },
             "remote": {
-              "workload": "deploy-memcached"
+              "pod": {
+                "workload": "deploy-memcached"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/metallb/vib-publish.json
+++ b/.vib/metallb/vib-publish.json
@@ -51,7 +51,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-metallb-controller"
+              "pod": {
+                "workload": "deploy-metallb-controller"
+              }
             }
           }
         }
@@ -65,8 +67,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/metallb/vib-verify.json
+++ b/.vib/metallb/vib-verify.json
@@ -51,7 +51,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-metallb-controller"
+              "pod": {
+                "workload": "deploy-metallb-controller"
+              }
             }
           }
         }

--- a/.vib/metrics-server/vib-publish.json
+++ b/.vib/metrics-server/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/metrics-server/goss"
             },
             "remote": {
-              "workload": "deploy-metrics-server"
+              "pod": {
+                "workload": "deploy-metrics-server"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/metrics-server/vib-verify.json
+++ b/.vib/metrics-server/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/metrics-server/goss"
             },
             "remote": {
-              "workload": "deploy-metrics-server"
+              "pod": {
+                "workload": "deploy-metrics-server"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/minio/vib-publish.json
+++ b/.vib/minio/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-minio"
+              "pod": {
+                "workload": "deploy-minio"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/minio/vib-verify.json
+++ b/.vib/minio/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-minio"
+              "pod": {
+                "workload": "deploy-minio"
+              }
             }
           }
         },

--- a/.vib/mongodb-sharded/vib-publish.json
+++ b/.vib/mongodb-sharded/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/mongodb-sharded/goss"
             },
             "remote": {
-              "workload": "sts-mongodb-sharded-mongos"
+              "pod": {
+                "workload": "sts-mongodb-sharded-mongos"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mongodb-sharded/vib-verify.json
+++ b/.vib/mongodb-sharded/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/mongodb-sharded/goss"
             },
             "remote": {
-              "workload": "sts-mongodb-sharded-mongos"
+              "pod": {
+                "workload": "sts-mongodb-sharded-mongos"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/mongodb/vib-publish.json
+++ b/.vib/mongodb/vib-publish.json
@@ -45,7 +45,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-mongodb"
+              "pod": {
+                "workload": "deploy-mongodb"
+              }
             }
           }
         }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mongodb/vib-verify.json
+++ b/.vib/mongodb/vib-verify.json
@@ -45,7 +45,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-mongodb"
+              "pod": {
+                "workload": "deploy-mongodb"
+              }
             }
           }
         }

--- a/.vib/moodle/vib-publish.json
+++ b/.vib/moodle/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/moodle/goss"
             },
             "remote": {
-              "workload": "deploy-moodle"
+              "pod": {
+                "workload": "deploy-moodle"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/moodle/vib-verify.json
+++ b/.vib/moodle/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/moodle/goss"
             },
             "remote": {
-              "workload": "deploy-moodle"
+              "pod": {
+                "workload": "deploy-moodle"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/mxnet/vib-publish.json
+++ b/.vib/mxnet/vib-publish.json
@@ -38,7 +38,9 @@
               "path": "/.vib/mxnet/goss"
             },
             "remote": {
-              "workload": "deploy-mxnet"
+              "pod": {
+                "workload": "deploy-mxnet"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -53,8 +55,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mxnet/vib-verify.json
+++ b/.vib/mxnet/vib-verify.json
@@ -38,7 +38,9 @@
               "path": "/.vib/mxnet/goss"
             },
             "remote": {
-              "workload": "deploy-mxnet"
+              "pod": {
+                "workload": "deploy-mxnet"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/mysql/vib-publish.json
+++ b/.vib/mysql/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/mysql/goss"
             },
             "remote": {
-              "workload": "sts-mysql-primary"
+              "pod": {
+                "workload": "sts-mysql-primary"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/mysql/vib-verify.json
+++ b/.vib/mysql/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/mysql/goss"
             },
             "remote": {
-              "workload": "sts-mysql-primary"
+              "pod": {
+                "workload": "sts-mysql-primary"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/nats/vib-publish.json
+++ b/.vib/nats/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/nats/goss"
             },
             "remote": {
-              "workload": "sts-nats"
+              "pod": {
+                "workload": "sts-nats"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/nats/vib-verify.json
+++ b/.vib/nats/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/nats/goss"
             },
             "remote": {
-              "workload": "sts-nats"
+              "pod": {
+                "workload": "sts-nats"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/nginx-ingress-controller/vib-publish.json
+++ b/.vib/nginx-ingress-controller/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/nginx-ingress-controller/goss"
             },
             "remote": {
-              "workload": "deploy-nginx-ingress-controller"
+              "pod": {
+                "workload": "deploy-nginx-ingress-controller"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -75,8 +77,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/nginx-ingress-controller/vib-verify.json
+++ b/.vib/nginx-ingress-controller/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/nginx-ingress-controller/goss"
             },
             "remote": {
-              "workload": "deploy-nginx-ingress-controller"
+              "pod": {
+                "workload": "deploy-nginx-ingress-controller"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/nginx/vib-publish.json
+++ b/.vib/nginx/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-nginx"
+              "pod": {
+                "workload": "deploy-nginx"
+              }
             }
           }
         },
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/nginx/vib-verify.json
+++ b/.vib/nginx/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-nginx"
+              "pod": {
+                "workload": "deploy-nginx"
+              }
             }
           }
         },

--- a/.vib/node-exporter/vib-publish.json
+++ b/.vib/node-exporter/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/node-exporter/goss"
             },
             "remote": {
-              "workload": "ds-node-exporter"
+              "pod": {
+                "workload": "ds-node-exporter"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/node-exporter/vib-verify.json
+++ b/.vib/node-exporter/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/node-exporter/goss"
             },
             "remote": {
-              "workload": "ds-node-exporter"
+              "pod": {
+                "workload": "ds-node-exporter"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/oauth2-proxy/vib-publish.json
+++ b/.vib/oauth2-proxy/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/oauth2-proxy/goss"
             },
             "remote": {
-              "workload": "deploy-oauth2-proxy"
+              "pod": {
+                "workload": "deploy-oauth2-proxy"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -75,8 +77,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/oauth2-proxy/vib-verify.json
+++ b/.vib/oauth2-proxy/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/oauth2-proxy/goss"
             },
             "remote": {
-              "workload": "deploy-oauth2-proxy"
+              "pod": {
+                "workload": "deploy-oauth2-proxy"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/odoo/vib-publish.json
+++ b/.vib/odoo/vib-publish.json
@@ -59,7 +59,9 @@
               "path": "/.vib/odoo/goss"
             },
             "remote": {
-              "workload": "deploy-odoo"
+              "pod": {
+                "workload": "deploy-odoo"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/odoo/vib-verify.json
+++ b/.vib/odoo/vib-verify.json
@@ -59,7 +59,9 @@
               "path": "/.vib/odoo/goss"
             },
             "remote": {
-              "workload": "deploy-odoo"
+              "pod": {
+                "workload": "deploy-odoo"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/opencart/vib-publish.json
+++ b/.vib/opencart/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-opencart"
+              "pod": {
+                "workload": "deploy-opencart"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/opencart/vib-verify.json
+++ b/.vib/opencart/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-opencart"
+              "pod": {
+                "workload": "deploy-opencart"
+              }
             }
           }
         },

--- a/.vib/osclass/vib-publish.json
+++ b/.vib/osclass/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/osclass/goss"
             },
             "remote": {
-              "workload": "deploy-osclass"
+              "pod": {
+                "workload": "deploy-osclass"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/osclass/vib-verify.json
+++ b/.vib/osclass/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/osclass/goss"
             },
             "remote": {
-              "workload": "deploy-osclass"
+              "pod": {
+                "workload": "deploy-osclass"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/parse/vib-publish.json
+++ b/.vib/parse/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/parse/goss/server"
             },
             "remote": {
-              "workload": "deploy-parse-server"
+              "pod": {
+                "workload": "deploy-parse-server"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -56,7 +58,9 @@
               "path": "/.vib/parse/goss/dashboard"
             },
             "remote": {
-              "workload": "deploy-parse-dashboard"
+              "pod": {
+                "workload": "deploy-parse-dashboard"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -85,8 +89,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/parse/vib-verify.json
+++ b/.vib/parse/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/parse/goss/server"
             },
             "remote": {
-              "workload": "deploy-parse-server"
+              "pod": {
+                "workload": "deploy-parse-server"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -56,7 +58,9 @@
               "path": "/.vib/parse/goss/dashboard"
             },
             "remote": {
-              "workload": "deploy-parse-dashboard"
+              "pod": {
+                "workload": "deploy-parse-dashboard"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/phpbb/vib-publish.json
+++ b/.vib/phpbb/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/phpbb/goss"
             },
             "remote": {
-              "workload": "deploy-phpbb"
+              "pod": {
+                "workload": "deploy-phpbb"
+              }
             }
           }
         },
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/phpbb/vib-verify.json
+++ b/.vib/phpbb/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/phpbb/goss"
             },
             "remote": {
-              "workload": "deploy-phpbb"
+              "pod": {
+                "workload": "deploy-phpbb"
+              }
             }
           }
         },

--- a/.vib/phpmyadmin/vib-publish.json
+++ b/.vib/phpmyadmin/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-phpmyadmin"
+              "pod": {
+                "workload": "deploy-phpmyadmin"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/phpmyadmin/vib-verify.json
+++ b/.vib/phpmyadmin/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-phpmyadmin"
+              "pod": {
+                "workload": "deploy-phpmyadmin"
+              }
             }
           }
         },

--- a/.vib/pinniped/vib-publish.json
+++ b/.vib/pinniped/vib-publish.json
@@ -61,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/postgresql-ha/vib-publish.json
+++ b/.vib/postgresql-ha/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/postgresql-ha/goss/repmgr"
             },
             "remote": {
-              "workload": "sts-postgresql-ha-postgresql"
+              "pod": {
+                "workload": "sts-postgresql-ha-postgresql"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -56,7 +58,9 @@
               "path": "/.vib/postgresql-ha/goss/pgpool"
             },
             "remote": {
-              "workload": "deploy-postgresql-ha-pgpool"
+              "pod": {
+                "workload": "deploy-postgresql-ha-pgpool"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -71,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/postgresql-ha/vib-verify.json
+++ b/.vib/postgresql-ha/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/postgresql-ha/goss/repmgr"
             },
             "remote": {
-              "workload": "sts-postgresql-ha-postgresql"
+              "pod": {
+                "workload": "sts-postgresql-ha-postgresql"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -56,7 +58,9 @@
               "path": "/.vib/postgresql-ha/goss/pgpool"
             },
             "remote": {
-              "workload": "deploy-postgresql-ha-pgpool"
+              "pod": {
+                "workload": "deploy-postgresql-ha-pgpool"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/postgresql/vib-publish.json
+++ b/.vib/postgresql/vib-publish.json
@@ -45,7 +45,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-postgresql-ptest"
+              "pod": {
+                "workload": "sts-postgresql-ptest"
+              }
             }
           }
         }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/postgresql/vib-verify.json
+++ b/.vib/postgresql/vib-verify.json
@@ -45,7 +45,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "sts-postgresql-ptest"
+              "pod": {
+                "workload": "sts-postgresql-ptest"
+              }
             }
           }
         }

--- a/.vib/prestashop/vib-publish.json
+++ b/.vib/prestashop/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-prestashop"
+              "pod": {
+                "workload": "deploy-prestashop"
+              }
             }
           }
         },
@@ -75,8 +77,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/prestashop/vib-verify.json
+++ b/.vib/prestashop/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-prestashop"
+              "pod": {
+                "workload": "deploy-prestashop"
+              }
             }
           }
         },

--- a/.vib/pytorch/vib-publish.json
+++ b/.vib/pytorch/vib-publish.json
@@ -38,7 +38,9 @@
               "path": "/.vib/pytorch/goss"
             },
             "remote": {
-              "workload": "deploy-pytorch"
+              "pod": {
+                "workload": "deploy-pytorch"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -53,8 +55,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/pytorch/vib-verify.json
+++ b/.vib/pytorch/vib-verify.json
@@ -38,7 +38,9 @@
               "path": "/.vib/pytorch/goss"
             },
             "remote": {
-              "workload": "deploy-pytorch"
+              "pod": {
+                "workload": "deploy-pytorch"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/rabbitmq-cluster-operator/vib-publish.json
+++ b/.vib/rabbitmq-cluster-operator/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/rabbitmq-cluster-operator/goss"
             },
             "remote": {
-              "workload": "sts-ve-testing-server"
+              "pod": {
+                "workload": "sts-ve-testing-server"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/rabbitmq-cluster-operator/vib-verify.json
+++ b/.vib/rabbitmq-cluster-operator/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/rabbitmq-cluster-operator/goss"
             },
             "remote": {
-              "workload": "sts-ve-testing-server"
+              "pod": {
+                "workload": "sts-ve-testing-server"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/rabbitmq/vib-publish.json
+++ b/.vib/rabbitmq/vib-publish.json
@@ -59,7 +59,9 @@
               "path": "/.vib/rabbitmq/goss"
             },
             "remote": {
-              "workload": "sts-rabbitmq"
+              "pod": {
+                "workload": "sts-rabbitmq"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -75,8 +77,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/rabbitmq/vib-verify.json
+++ b/.vib/rabbitmq/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/rabbitmq/goss"
             },
             "remote": {
-              "workload": "sts-rabbitmq"
+              "pod": {
+                "workload": "sts-rabbitmq"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/redis-cluster/vib-publish.json
+++ b/.vib/redis-cluster/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/redis-cluster/goss"
             },
             "remote": {
-              "workload": "sts-redis-cluster"
+              "pod": {
+                "workload": "sts-redis-cluster"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -59,8 +61,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/redis-cluster/vib-verify.json
+++ b/.vib/redis-cluster/vib-verify.json
@@ -44,7 +44,9 @@
               "path": "/.vib/redis-cluster/goss"
             },
             "remote": {
-              "workload": "sts-redis-cluster"
+              "pod": {
+                "workload": "sts-redis-cluster"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/redis/vib-publish.json
+++ b/.vib/redis/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/redis/goss"
             },
             "remote": {
-              "workload": "sts-redis-master"
+              "pod": {
+                "workload": "sts-redis-master"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -60,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/redis/vib-verify.json
+++ b/.vib/redis/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/redis/goss"
             },
             "remote": {
-              "workload": "sts-redis-master"
+              "pod": {
+                "workload": "sts-redis-master"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/redmine/vib-publish.json
+++ b/.vib/redmine/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-redmine"
+              "pod": {
+                "workload": "deploy-redmine"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/redmine/vib-verify.json
+++ b/.vib/redmine/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-redmine"
+              "pod": {
+                "workload": "deploy-redmine"
+              }
             }
           }
         },

--- a/.vib/schema-registry/vib-publish.json
+++ b/.vib/schema-registry/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/schema-registry/goss"
             },
             "remote": {
-              "workload": "sts-schema-registry"
+              "pod": {
+                "workload": "sts-schema-registry"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/schema-registry/vib-verify.json
+++ b/.vib/schema-registry/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/schema-registry/goss"
             },
             "remote": {
-              "workload": "sts-schema-registry"
+              "pod": {
+                "workload": "sts-schema-registry"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/sealed-secrets/vib-publish.json
+++ b/.vib/sealed-secrets/vib-publish.json
@@ -70,8 +70,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/solr/vib-publish.json
+++ b/.vib/solr/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/solr/goss"
             },
             "remote": {
-              "workload": "sts-solr"
+              "pod": {
+                "workload": "sts-solr"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/solr/vib-verify.json
+++ b/.vib/solr/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/solr/goss"
             },
             "remote": {
-              "workload": "sts-solr"
+              "pod": {
+                "workload": "sts-solr"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/sonarqube/vib-publish.json
+++ b/.vib/sonarqube/vib-publish.json
@@ -59,7 +59,9 @@
               "path": "/.vib/sonarqube/goss"
             },
             "remote": {
-              "workload": "deploy-sonarqube"
+              "pod": {
+                "workload": "deploy-sonarqube"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/sonarqube/vib-verify.json
+++ b/.vib/sonarqube/vib-verify.json
@@ -59,7 +59,9 @@
               "path": "/.vib/sonarqube/goss"
             },
             "remote": {
-              "workload": "deploy-sonarqube"
+              "pod": {
+                "workload": "deploy-sonarqube"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/spark/vib-publish.json
+++ b/.vib/spark/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/spark/goss"
             },
             "remote": {
-              "workload": "sts-spark-worker"
+              "pod": {
+                "workload": "sts-spark-worker"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/spark/vib-verify.json
+++ b/.vib/spark/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/spark/goss"
             },
             "remote": {
-              "workload": "sts-spark-worker"
+              "pod": {
+                "workload": "sts-spark-worker"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/spring-cloud-dataflow/vib-publish.json
+++ b/.vib/spring-cloud-dataflow/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/spring-cloud-dataflow/goss"
             },
             "remote": {
-              "workload": "deploy-spring-cloud-dataflow-server"
+              "pod": {
+                "workload": "deploy-spring-cloud-dataflow-server"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/spring-cloud-dataflow/vib-verify.json
+++ b/.vib/spring-cloud-dataflow/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/spring-cloud-dataflow/goss"
             },
             "remote": {
-              "workload": "deploy-spring-cloud-dataflow-server"
+              "pod": {
+                "workload": "deploy-spring-cloud-dataflow-server"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/suitecrm/vib-publish.json
+++ b/.vib/suitecrm/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/suitecrm/goss"
             },
             "remote": {
-              "workload": "deploy-suitecrm"
+              "pod": {
+                "workload": "deploy-suitecrm"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/suitecrm/vib-verify.json
+++ b/.vib/suitecrm/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/suitecrm/goss"
             },
             "remote": {
-              "workload": "deploy-suitecrm"
+              "pod": {
+                "workload": "deploy-suitecrm"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/supabase/vib-publish.json
+++ b/.vib/supabase/vib-publish.json
@@ -75,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/supabase/vib-verify.json
+++ b/.vib/supabase/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/supabase/goss"
             },
             "remote": {
-              "workload": "deploy-supabase-kong"
+              "pod": {
+                "workload": "deploy-supabase-kong"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/tensorflow-resnet/vib-publish.json
+++ b/.vib/tensorflow-resnet/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/tensorflow-resnet/goss"
             },
             "remote": {
-              "workload": "deploy-tensorflow-resnet"
+              "pod": {
+                "workload": "deploy-tensorflow-resnet"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/tensorflow-resnet/vib-verify.json
+++ b/.vib/tensorflow-resnet/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/tensorflow-resnet/goss"
             },
             "remote": {
-              "workload": "deploy-tensorflow-resnet"
+              "pod": {
+                "workload": "deploy-tensorflow-resnet"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/thanos/vib-publish.json
+++ b/.vib/thanos/vib-publish.json
@@ -62,8 +62,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/tomcat/vib-publish.json
+++ b/.vib/tomcat/vib-publish.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-tomcat"
+              "pod": {
+                "workload": "deploy-tomcat"
+              }
             }
           }
         },
@@ -74,8 +76,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/tomcat/vib-verify.json
+++ b/.vib/tomcat/vib-verify.json
@@ -46,7 +46,9 @@
             },
             "vars_file": "vars.yaml",
             "remote": {
-              "workload": "deploy-tomcat"
+              "pod": {
+                "workload": "deploy-tomcat"
+              }
             }
           }
         },

--- a/.vib/wavefront-adapter-for-istio/vib-publish.json
+++ b/.vib/wavefront-adapter-for-istio/vib-publish.json
@@ -24,8 +24,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/wavefront-hpa-adapter/vib-publish.json
+++ b/.vib/wavefront-hpa-adapter/vib-publish.json
@@ -63,8 +63,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/wavefront-prometheus-storage-adapter/vib-publish.json
+++ b/.vib/wavefront-prometheus-storage-adapter/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/wavefront-prometheus-storage-adapter/goss"
             },
             "remote": {
-              "workload": "deploy-wavefront-prometheus-storage-adapter"
+              "pod": {
+                "workload": "deploy-wavefront-prometheus-storage-adapter"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -73,8 +75,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/wavefront-prometheus-storage-adapter/vib-verify.json
+++ b/.vib/wavefront-prometheus-storage-adapter/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/wavefront-prometheus-storage-adapter/goss"
             },
             "remote": {
-              "workload": "deploy-wavefront-prometheus-storage-adapter"
+              "pod": {
+                "workload": "deploy-wavefront-prometheus-storage-adapter"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/wavefront/vib-publish.json
+++ b/.vib/wavefront/vib-publish.json
@@ -39,7 +39,9 @@
               "path": "/.vib/wavefront/goss"
             },
             "remote": {
-              "workload": "deploy-wavefront-proxy"
+              "pod": {
+                "workload": "deploy-wavefront-proxy"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -69,8 +71,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/wavefront/vib-verify.json
+++ b/.vib/wavefront/vib-verify.json
@@ -39,7 +39,9 @@
               "path": "/.vib/wavefront/goss"
             },
             "remote": {
-              "workload": "deploy-wavefront-proxy"
+              "pod": {
+                "workload": "deploy-wavefront-proxy"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/wildfly/vib-publish.json
+++ b/.vib/wildfly/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/wildfly/goss"
             },
             "remote": {
-              "workload": "deploy-wildfly"
+              "pod": {
+                "workload": "deploy-wildfly"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -70,8 +72,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/wildfly/vib-verify.json
+++ b/.vib/wildfly/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/wildfly/goss"
             },
             "remote": {
-              "workload": "deploy-wildfly"
+              "pod": {
+                "workload": "deploy-wildfly"
+              }
             },
             "vars_file": "vars.yaml"
           }

--- a/.vib/wordpress/vib-publish.json
+++ b/.vib/wordpress/vib-publish.json
@@ -45,7 +45,9 @@
               "path": "/.vib/wordpress/goss"
             },
             "remote": {
-              "workload": "deploy-wordpress"
+              "pod": {
+                "workload": "deploy-wordpress"
+              }
             },
             "vars_file": "vars.yaml",
             "wait": {
@@ -92,8 +94,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/wordpress/vib-verify.json
+++ b/.vib/wordpress/vib-verify.json
@@ -45,7 +45,9 @@
               "path": "/.vib/wordpress/goss"
             },
             "remote": {
-              "workload": "deploy-wordpress"
+              "pod": {
+                "workload": "deploy-wordpress"
+              }
             },
             "vars_file": "vars.yaml",
             "wait": {

--- a/.vib/zookeeper/vib-publish.json
+++ b/.vib/zookeeper/vib-publish.json
@@ -44,7 +44,9 @@
               "path": "/.vib/zookeeper/goss"
             },
             "remote": {
-              "workload": "sts-zookeeper"
+              "pod": {
+                "workload": "sts-zookeeper"
+              }
             },
             "vars_file": "vars.yaml"
           }
@@ -65,8 +67,10 @@
             "repository": {
               "kind": "S3",
               "url": "{VIB_ENV_S3_URL}",
-              "username": "{VIB_ENV_S3_USERNAME}",
-              "password": "{VIB_ENV_S3_PASSWORD}"
+              "authn": {
+                "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+              }
             }
           }
         }

--- a/.vib/zookeeper/vib-verify.json
+++ b/.vib/zookeeper/vib-verify.json
@@ -38,7 +38,9 @@
               "path": "/.vib/zookeeper/goss"
             },
             "remote": {
-              "workload": "sts-zookeeper"
+              "pod": {
+                "workload": "sts-zookeeper"
+              }
             },
             "vars_file": "vars.yaml"
           }


### PR DESCRIPTION
### Description of the change

The usage of `remote.workload`, `repository.username` and `repository.pasword` parameters in pipeline definitions are marked as deprecated. This PR updates the pipelines to the new semantics.

### Benefits

Up-to-date pipeline definitions, no warnings in actions summary.

### Possible drawbacks

None.

### Applicable issues

N/A

### Additional information

Tested in:
- [vib-verify](https://github.com/joancafom/charts/actions/runs/4323749748) action run in fork.
- [vib-publish](https://github.com/joancafom/charts/actions/runs/4324548602) action run in fork.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
