### PR TITLE
[bitnami/mongodb]  Update statefulset.yaml in MongoDB chart

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.8.2
+version: 13.8.3

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -294,6 +294,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `persistence.storageClass`                    | PVC Storage Class for MongoDB(&reg;) data volume                                                                                      | `""`                |
 | `persistence.accessModes`                     | PV Access Mode                                                                                                                        | `["ReadWriteOnce"]` |
 | `persistence.size`                            | PVC Storage Request for MongoDB(&reg;) data volume                                                                                    | `8Gi`               |
+| `persistence.labels`                          | Persistent Volume Claim Labels                                                                                                        | `{}`                |
 | `persistence.annotations`                     | PVC annotations                                                                                                                       | `{}`                |
 | `persistence.mountPath`                       | Path to mount the volume at                                                                                                           | `/bitnami/mongodb`  |
 | `persistence.subPath`                         | Subdirectory of the volume to mount at                                                                                                | `""`                |

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -537,6 +537,11 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: datadir
+        labels: {{- include "common.labels.matchLabels" . | nindent 10 }}
+          app.kubernetes.io/managed-by: {{ .Release.Service }}
+          {{- if .Values.persistence.labels }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
+          {{- end }}        
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -1003,6 +1003,9 @@ persistence:
   ## @param persistence.size PVC Storage Request for MongoDB(&reg;) data volume
   ##
   size: 8Gi
+  ## @param persistence.labels Persistent Volume Claim Labels
+  ##
+  labels: {}
   ## @param persistence.annotations PVC annotations
   ##
   annotations: {}


### PR DESCRIPTION

### Description of the change

Adds support for labelling PVCs to MongoDB chart.

Only needed on replicaset - already there for standalone.

### Benefits

Adds label support for PVCs

### Possible drawbacks

None AFAIK

### Applicable issues

Fix for  #15358 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
