### PR TITLE
[bitnami/grafana-tempo] Adapt ginkgo tests for non-GKE

### DIFF
--- a/.vib/grafana-tempo/ginkgo/grafana_tempo_test.go
+++ b/.vib/grafana-tempo/ginkgo/grafana_tempo_test.go
@@ -26,19 +26,17 @@ var _ = Describe("Grafana Tempo", func() {
 
 	Context("through its API", func() {
 		var frontendHost, serviceName string
-		var hasIP bool
-		var err error
 
 		BeforeEach(func() {
 			serviceName = "grafana-tempo-query-frontend"
 
-			hasIP, err = retry("isServiceReady", 6, 20*time.Second, func() (bool, error) {
+			isReady, err := retry("isServiceReady", 6, 20*time.Second, func() (bool, error) {
 				return isServiceReady(ctx, c, serviceName)
 			})
 			if err != nil {
 				panic(fmt.Sprintf("There was an error checking whether the testing service had an IP assigned: %q", err))
 			}
-			Expect(hasIP).To(BeTrue())
+			Expect(isReady).To(BeTrue())
 
 			frontendSvc, err := c.Services(*namespace).Get(ctx, serviceName, metav1.GetOptions{})
 			if err != nil {

--- a/.vib/grafana-tempo/ginkgo/grafana_tempo_test.go
+++ b/.vib/grafana-tempo/ginkgo/grafana_tempo_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Grafana Tempo", func() {
 	})
 
 	Context("through its API", func() {
-		var queryFrontendIp, serviceName string
+		var frontendHost, serviceName string
 		var hasIP bool
 		var err error
 
@@ -40,12 +40,12 @@ var _ = Describe("Grafana Tempo", func() {
 			}
 			Expect(hasIP).To(BeTrue())
 
-			queryFrontendSvc, err := c.Services(*namespace).Get(ctx, serviceName, metav1.GetOptions{})
+			frontendSvc, err := c.Services(*namespace).Get(ctx, serviceName, metav1.GetOptions{})
 			if err != nil {
 				panic(fmt.Sprintf("There was an error retrieving the Query Frontend service: %q", err))
 			}
 
-			queryFrontendIp = returnValidHost(queryFrontendSvc.Status.LoadBalancer.Ingress[0])
+			frontendHost = returnValidHost(frontendSvc.Status.LoadBalancer.Ingress[0])
 		})
 
 		It("allows to access registered tracing spans", func() {
@@ -60,7 +60,7 @@ var _ = Describe("Grafana Tempo", func() {
 			route = findFirstPattern(containerLogs, `route (\/\w+)`, 1)
 			Expect(route).NotTo(BeEmpty())
 
-			responseBody := getResponseBodyOrDie(ctx, fmt.Sprintf("http://%s:%s/api/traces/%s", queryFrontendIp, *apiPort, traceID))
+			responseBody := getResponseBodyOrDie(ctx, fmt.Sprintf("http://%s:%s/api/traces/%s", frontendHost, *apiPort, traceID))
 			Expect(containsString(responseBody, route)).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adapts Ginkgo tests to allow for the usage of hosts in the services LB. This is necessary for the tests to succeed in AWS-based clusters.

### Benefits

Improves test compatibility.

### Additional information

Changes tested in fork: https://github.com/FraPazGal/charts/pull/145

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
