### PR TITLE
[bitnami/nginx-ingress-controller] Adapt ginkgo tests for non-GKE

### DIFF
--- a/.vib/nginx-ingress-controller/ginkgo/integration_suite_test.go
+++ b/.vib/nginx-ingress-controller/ginkgo/integration_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netcv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
@@ -130,6 +131,31 @@ func hasIPAssigned(ctx context.Context, c netcv1.NetworkingV1Interface, resource
 		return true, err
 	} else {
 		return false, err
+	}
+}
+
+func resolvesToDeployment(ctx context.Context, address string) (bool, error) {
+	var client http.Client
+	resp, err := client.Get(address)
+	if err != nil {
+		fmt.Printf("There was an error during the GET request: %q", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return true, err
+	} else {
+		return false, err
+	}
+}
+
+func returnValidHost(ingress v1.LoadBalancerIngress) string {
+	if ingress.IP != "" {
+		return ingress.IP + ".nip.io"
+	} else if ingress.Hostname != "" {
+		return ingress.Hostname
+	} else {
+		panic("No valid host found for the provided ingress")
 	}
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adapts Ginkgo tests to allow for the usage of hosts in the services LB. This is necessary for the tests to succeed in AWS-based clusters.

### Benefits

Improves test compatibility.

### Additional information

Changes tested in fork: https://github.com/FraPazGal/charts/pull/146

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
