### PR TITLE
[bitnami/mongodb] Fix chart upgrade when auth.enable=false

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.8.2
+version: 13.8.3

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.auth.enabled }}
 {{- $replicaCount := int .Values.replicaCount }}
 {{- $port := .Values.service.ports.mongodb }}
 {{- $host := include "mongodb.service.nameOverride" . }}
@@ -123,5 +124,6 @@ data:
   password: {{ print $currentPassword | b64enc | quote }}
   database: {{ print $currentDatabase | b64enc | quote }}
   uri: {{ printf "mongodb://%s:%s@%s/%s" $currentUser $currentPassword $hostForURI $currentDatabase | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Execute credentials search and all the `ServiceBinding` logic when auth is enabled. 

### Benefits

Users can upgrade charts when authentication is not enabled. Please see how to reproduce the issue in #15311

### Possible drawbacks

None identified.

### Applicable issues

- fixes #15311

### Additional information

The issue was introduced in #14910

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
