### PR TITLE
bitnami/redis | Fix liveness and readiness commands

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.8.3
+version: 17.8.4

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -204,7 +204,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_liveness_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}
+                - '/health/ping_liveness_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}'
           {{- end }}
           {{- if .Values.master.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customReadinessProbe "context" $) | nindent 12 }}
@@ -219,7 +219,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_readiness_local.sh {{ .Values.master.readinessProbe.timeoutSeconds }}
+                - '/health/ping_readiness_local.sh {{ .Values.master.readinessProbe.timeoutSeconds }}'
           {{- end }}
           {{- end }}
           {{- if .Values.master.resources }}

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -235,7 +235,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_liveness_local.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}
+                - '/health/ping_liveness_local.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}'
           {{- end }}
           {{- if .Values.replica.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.replica.customLivenessProbe "context" $) | nindent 12 }}
@@ -250,7 +250,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_liveness_local.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}
+                - '/health/ping_liveness_local.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}'
           {{- end }}
           {{- if .Values.replica.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.replica.customReadinessProbe "context" $) | nindent 12 }}
@@ -265,7 +265,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_readiness_local.sh {{ .Values.replica.readinessProbe.timeoutSeconds }}
+                - '/health/ping_readiness_local.sh {{ .Values.replica.readinessProbe.timeoutSeconds }}'
           {{- end }}
           {{- end }}
           {{- if .Values.replica.resources }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Readiness and  Liveness are failing. The reason is the command used `sh -c /health/ping_readiness_local.sh 1`

The command treating `/health/ping_readiness_local.sh` and `1` as separate arguments. Quoting with `''` will make it as one argument and `ping_readiness_local.sh` will get the approproate value.

Error I am getting -
`Readiness probe failed: command "sh -c /health/ping_readiness_local.sh 1" timed out`
`Liveness probe failed: command "sh -c /health/ping_liveness_local.sh 5" timed out`

<!-- Describe the scope of your change - i.e. what the change does. -->

Fix Readiness and  Liveness probes command.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
