### PR TITLE
[bitnami/minio] Change value 'networkPolicy.extraFromClauses' from object to array

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
-version: 12.1.10
+version: 12.1.11

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -235,7 +235,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `apiIngress.extraRules`            | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
 | `networkPolicy.enabled`            | Enable the default NetworkPolicy policy                                                                                          | `false`                  |
 | `networkPolicy.allowExternal`      | Don't require client label for connections                                                                                       | `true`                   |
-| `networkPolicy.extraFromClauses`   | Allows to add extra 'from' clauses to the NetworkPolicy                                                                          | `{}`                     |
+| `networkPolicy.extraFromClauses`   | Allows to add extra 'from' clauses to the NetworkPolicy                                                                          | `[]`                     |
 
 ### Persistence parameters
 

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -865,7 +865,7 @@ networkPolicy:
   ##
   allowExternal: true
   ## @param networkPolicy.extraFromClauses Allows to add extra 'from' clauses to the NetworkPolicy
-  extraFromClauses: {}
+  extraFromClauses: []
   ## Example
   ## extraFromClauses:
   ## - podSelector:


### PR DESCRIPTION
### Description of the change

Replace default value for 'networkPolicy.extraFromClauses' from object to array.

### Applicable issues

- fixes #15314

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
