### PR TITLE
[bitnami/redis-cluster] Use SIGTERM on timeout for probes

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
   - http://redis.io/
-version: 8.3.10
+version: 8.3.11

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -24,7 +24,7 @@ data:
     if [ ! -z "$REDIS_PASSWORD" ]; then export REDISCLI_AUTH=$REDIS_PASSWORD; fi;
     {{- end }}
     response=$(
-      timeout -s 3 $1 \
+      timeout -s 15 $1 \
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}
@@ -49,7 +49,7 @@ data:
 {{- if not .Values.cluster.externalAccess.enabled }}
     if [ ! -f "$REDIS_STATUS_FILE" ]; then
       response=$(
-        timeout -s 3 $1 \
+        timeout -s 15 $1 \
         redis-cli \
           -h localhost \
   {{- if .Values.tls.enabled }}
@@ -86,7 +86,7 @@ data:
     if [ ! -z "$REDIS_PASSWORD" ]; then export REDISCLI_AUTH=$REDIS_PASSWORD; fi;
     {{- end }}
     response=$(
-      timeout -s 3 $1 \
+      timeout -s 15 $1 \
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

 Change signal to [SIGTERM](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html) on probes
> The SIGTERM signal is a generic signal used to cause program termination. Unlike SIGKILL, this signal can be blocked, handled, and ignored. It is the normal way to politely ask a program to terminate.
>
> The shell command kill generates SIGTERM by default. 

It is the same changes like we recently did for the redis #15057


### Benefits

 Using `SIGTERM` instead of the `SIGQUIT` on probes will remove unnecessary coredumps.


### Possible drawbacks

 Probably nothing and in the case of the issue, `redis-cli` will generate a proper coredump.


### Applicable issues

Similar to the #15055


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
