### PR TITLE
[bitnami/etcd] Add support for service.headless.annotations

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/etcd
   - https://coreos.com/etcd/
-version: 8.7.7
+version: 8.8.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -210,6 +210,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.annotations`              | Additional annotations for the etcd service                                        | `{}`        |
 | `service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"               | `None`      |
 | `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                        | `{}`        |
+| `service.headless.annotations`     | Annotations for the headless service.                                              | `{}`        |
 
 ### Persistence parameters
 

--- a/bitnami/etcd/templates/svc-headless.yaml
+++ b/bitnami/etcd/templates/svc-headless.yaml
@@ -15,7 +15,6 @@ metadata:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
     {{- end }}
-  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/etcd/templates/svc-headless.yaml
+++ b/bitnami/etcd/templates/svc-headless.yaml
@@ -9,9 +9,13 @@ metadata:
     {{- end }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- if .Values.service.headless.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.headless.annotations "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -559,6 +559,12 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## Headless service properties
+  ##
+  headless:
+    ## @param service.headless.annotations Annotations for the headless service.
+    ##
+    annotations: {}
 
 ## @section Persistence parameters
 ##
@@ -747,7 +753,7 @@ metrics:
     ## @param metrics.podMonitor.relabelings [array] Prometheus relabeling rules
     ##
     relabelings: []
-  
+
   ## Prometheus Operator PrometheusRule configuration
   ##
   prometheusRule:


### PR DESCRIPTION
### Description of the change

Add support for the value `service.headless.annotations`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
