### PR TITLE
[bitnami/keycloak] Add support for service.headless.annotations

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 13.2.0
+version: 13.3.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -200,6 +200,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.annotations`              | Additional custom annotations for Keycloak service                                                                               | `{}`                     |
 | `service.extraPorts`               | Extra port to expose on Keycloak service                                                                                         | `[]`                     |
 | `service.extraHeadlessPorts`       | Extra ports to expose on Keycloak headless service                                                                               | `[]`                     |
+| `service.headless.annotations`     | Annotations for the headless service.                                                                                            | `{}`                     |
+| `service.headless.extraPorts`      | Extra ports to expose on Keycloak headless service                                                                               | `[]`                     |
 | `ingress.enabled`                  | Enable ingress record generation for Keycloak                                                                                    | `false`                  |
 | `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |

--- a/bitnami/keycloak/templates/headless-service.yaml
+++ b/bitnami/keycloak/templates/headless-service.yaml
@@ -8,8 +8,14 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.service.headless.annotations }}
+  annotations:
+    {{- if .Values.service.headless.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.headless.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: ClusterIP
@@ -27,6 +33,9 @@ spec:
     {{- end }}
     {{- if .Values.service.extraHeadlessPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraHeadlessPorts "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   publishNotReadyAddresses: true
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/keycloak/templates/headless-service.yaml
+++ b/bitnami/keycloak/templates/headless-service.yaml
@@ -34,8 +34,8 @@ spec:
     {{- if .Values.service.extraHeadlessPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraHeadlessPorts "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- if .Values.service.headless.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.headless.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   publishNotReadyAddresses: true
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -510,10 +510,19 @@ service:
   ## @param service.extraPorts Extra port to expose on Keycloak service
   ##
   extraPorts: []
+  # DEPRECATED service.extraHeadlessPorts will be removed in a future release, please use service.headless.extraPorts instead
   ## @param service.extraHeadlessPorts Extra ports to expose on Keycloak headless service
   ##
   extraHeadlessPorts: []
-
+  ## Headless service properties
+  ##
+  headless:
+    ## @param service.headless.annotations Annotations for the headless service.
+    ##
+    annotations: {}
+    ## @param service.headless.extraPorts Extra ports to expose on Keycloak headless service
+    ##
+    extraPorts: []
 ## Keycloak ingress parameters
 ## ref: https://kubernetes.io/docs/user-guide/ingress/
 ##
@@ -980,7 +989,7 @@ keycloakConfigCli:
 postgresql:
   enabled: true
   auth:
-    postgresPassword: ""  
+    postgresPassword: ""
     username: bn_keycloak
     password: ""
     database: bitnami_keycloak


### PR DESCRIPTION
### Description of the change

Add support for the value `service.headless.annotations`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
