### PR TITLE
[bitnami/mongodb] Add support for service.headless.annotations

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.8.3
+version: 13.9.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -243,6 +243,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `service.externalTrafficPolicy`                               | service external traffic policy (only for standalone architecture)                                                                              | `Local`                |
 | `service.sessionAffinity`                                     | Control where client requests go, to the same pod or round-robin                                                                                | `None`                 |
 | `service.sessionAffinityConfig`                               | Additional settings for the sessionAffinity                                                                                                     | `{}`                   |
+| `service.headless.annotations`                                | Annotations for the headless service.                                                                                                           | `{}`                   |
 | `externalAccess.enabled`                                      | Enable Kubernetes external cluster access to MongoDB(&reg;) nodes (only for replicaset architecture)                                            | `false`                |
 | `externalAccess.autoDiscovery.enabled`                        | Enable using an init container to auto-detect external IPs by querying the K8s API                                                              | `false`                |
 | `externalAccess.autoDiscovery.image.registry`                 | Init container auto-discovery image registry                                                                                                    | `docker.io`            |
@@ -406,6 +407,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `arbiter.service.ports.mongodb`                 | MongoDB(&reg;) service port                                                                       | `27017`         |
 | `arbiter.service.extraPorts`                    | Extra ports to expose (normally used with the `sidecar` value)                                    | `[]`            |
 | `arbiter.service.annotations`                   | Provide any additional annotations that may be required                                           | `{}`            |
+| `arbiter.service.headless.annotations`          | Annotations for the headless service.                                                             | `{}`            |
 
 ### Hidden Node parameters
 
@@ -494,6 +496,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `hidden.service.ports.mongodb`                       | MongoDB(&reg;) service port                                                                          | `27017`             |
 | `hidden.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                       | `[]`                |
 | `hidden.service.annotations`                         | Provide any additional annotations that may be required                                              | `{}`                |
+| `hidden.service.headless.annotations`                | Annotations for the headless service.                                                                | `{}`                |
 
 ### Metrics parameters
 

--- a/bitnami/mongodb/templates/arbiter/headless-svc.yaml
+++ b/bitnami/mongodb/templates/arbiter/headless-svc.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.arbiter.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.arbiter.service.headless.annotations }}
   annotations:
-    {{- if .Values.arbiter.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.arbiter.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.arbiter.service.headless.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.arbiter.service.headless.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/mongodb/templates/hidden/headless-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/headless-svc.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.hidden.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.hidden.service.headless.annotations }}
   annotations:
-    {{- if .Values.hidden.service.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.hidden.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.hidden.service.headless.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.hidden.service.headless.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.service.headless.annotations }}
   annotations:
-    {{- if .Values.service.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.service.headless.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.headless.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -737,7 +737,7 @@ service:
   ## @param service.allocateLoadBalancerNodePorts Wheter to allocate node ports when service type is LoadBalancer
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
   ##
-  allocateLoadBalancerNodePorts: true 
+  allocateLoadBalancerNodePorts: true
   ## @param service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
   ##
   extraPorts: []
@@ -759,6 +759,12 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## Headless service properties
+  ##
+  headless:
+    ## @param service.headless.annotations Annotations for the headless service.
+    ##
+    annotations: {}
 ## External Access to MongoDB(&reg;) nodes configuration
 ##
 externalAccess:
@@ -855,7 +861,7 @@ externalAccess:
     ## @param externalAccess.service.allocateLoadBalancerNodePorts Wheter to allocate node ports when service type is LoadBalancer
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
     ##
-    allocateLoadBalancerNodePorts: true 
+    allocateLoadBalancerNodePorts: true
     ## @param externalAccess.service.externalTrafficPolicy MongoDB(&reg;) service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
@@ -930,7 +936,7 @@ externalAccess:
       ## @param externalAccess.hidden.service.allocateLoadBalancerNodePorts Wheter to allocate node ports when service type is LoadBalancer
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
       ##
-      allocateLoadBalancerNodePorts: true 
+      allocateLoadBalancerNodePorts: true
       ## @param externalAccess.hidden.service.externalTrafficPolicy MongoDB(&reg;) service external traffic policy
       ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
       ##
@@ -1510,6 +1516,12 @@ arbiter:
     ## @param arbiter.service.annotations Provide any additional annotations that may be required
     ##
     annotations: {}
+    ## Headless service properties
+    ##
+    headless:
+      ## @param arbiter.service.headless.annotations Annotations for the headless service.
+      ##
+      annotations: {}
 
 ## @section Hidden Node parameters
 ##
@@ -1876,6 +1888,12 @@ hidden:
     ## @param hidden.service.annotations Provide any additional annotations that may be required
     ##
     annotations: {}
+    ## Headless service properties
+    ##
+    headless:
+      ## @param hidden.service.headless.annotations Annotations for the headless service.
+      ##
+      annotations: {}
 
 ## @section Metrics parameters
 ##


### PR DESCRIPTION
### Description of the change

Add support for the value `service.headless.annotations`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
