### PR TITLE
[bitnami/pytorch] Add support for service.headless.annotations

### DIFF
--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -24,4 +24,4 @@ name: pytorch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pytorch
   - https://pytorch.org/
-version: 2.5.15
+version: 2.6.0

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -170,6 +170,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.extraPorts`               | Extra ports to expose in Pytorch service (normally used with the `sidecars` value) | `[]`        |
 | `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                   | `None`      |
 | `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                        | `{}`        |
+| `service.headless.annotations`     | Annotations for the headless service.                                              | `{}`        |
 
 ### Init Container Parameters
 

--- a/bitnami/pytorch/templates/headless-svc.yaml
+++ b/bitnami/pytorch/templates/headless-svc.yaml
@@ -7,6 +7,15 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  {{- if or .Values.commonAnnotations .Values.service.headless.annotations }}
+  annotations:
+    {{- if .Values.service.headless.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.headless.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -415,6 +415,12 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## Headless service properties
+  ##
+  headless:
+    ## @param service.headless.annotations Annotations for the headless service.
+    ##
+    annotations: {}
 
 ## @section Init Container Parameters
 ##


### PR DESCRIPTION
### Description of the change

Add support for the value `service.headless.annotations`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
