### PR TITLE
[bitnami/schema-registry] Add support for service.headless.annotations

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/schema-registry
-version: 8.0.8
+version: 8.1.0

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -189,6 +189,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.extraPorts`               | Extra ports to expose in Schema Registry service (normally used with the `sidecars` value)            | `[]`                     |
 | `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                      | `None`                   |
 | `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                           | `{}`                     |
+| `service.headless.annotations`     | Annotations for the headless service.                                                                 | `{}`                     |
 | `ingress.enabled`                  | Enable ingress controller resource                                                                    | `false`                  |
 | `ingress.hostname`                 | Default host for the ingress resource                                                                 | `schema-registry.local`  |
 | `ingress.annotations`              | Ingress annotations                                                                                   | `{}`                     |

--- a/bitnami/schema-registry/templates/headless-service.yaml
+++ b/bitnami/schema-registry/templates/headless-service.yaml
@@ -6,10 +6,10 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.service.headless.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if .Values.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.service.headless.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.headless.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -493,6 +493,12 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## Headless service properties
+  ##
+  headless:
+    ## @param service.headless.annotations Annotations for the headless service.
+    ##
+    annotations: {}
 ## @param ingress.enabled                Enable ingress controller resource
 ## @param ingress.hostname               Default host for the ingress resource
 ## @param ingress.annotations            Ingress annotations


### PR DESCRIPTION
### Description of the change

Add support for the value `service.headless.annotations`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
