### PR TITLE
[bitnami/kube-prometheus] Use actual nulls in alertmanager config

### DIFF
--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -1751,13 +1751,13 @@ alertmanager:
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 12h
-      receiver: 'null'
+      receiver: null
       routes:
         - match:
             alertname: Watchdog
-          receiver: 'null'
+          receiver: null
     receivers:
-      - name: 'null'
+      - name: null
   ## @param alertmanager.templateFiles Extra files to be added inside the `alertmanager-{{ template "kube-prometheus.alertmanager.fullname" . }}` secret.
   ##
   templateFiles: {}


### PR DESCRIPTION
On start, alertmanager spits out error
```
undefined receiver "null" used in route
```
the solution is use actual null's instead of null strings

https://stackoverflow.com/questions/65387198/prometheus-undefined-receiver-null-used-in-route

### Description of the change
Use actual nulls instead of null strings

### Benefits
There is no error on startup on alertmanager and you can reload config without problems.

### Possible drawbacks
None to my knowledge

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
