### PR TITLE
[bitnami/argo-cd] Fix typo applicationSet name on ServiceMonitor

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.4.14
+version: 4.4.15

--- a/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "argo-cd.applicationSet" . }}
+  name: {{ include "argocd.applicationSet" . }}
   {{- if .Values.applicationSet.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.applicationSet.metrics.serviceMonitor.namespace | quote }}
   {{- else }}


### PR DESCRIPTION
Fixes a typo error on service monitor name.