### PR TITLE
[bitnami/grafana-mimir] Fix wrong gateway configuration when alertmanager.enabled=true

### DIFF
--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -48,4 +48,4 @@ name: grafana-mimir
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-mimir
   - https://github.com/grafana/mimir
-version: 0.2.0
+version: 0.2.1

--- a/bitnami/grafana-mimir/templates/gateway/configmap-http.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/configmap-http.yaml
@@ -83,7 +83,7 @@ data:
           }
           {{- if .Values.alertmanager.enabled }}
           # Alertmanager endpoints
-          location {{ .Values.mimir.httpPrefix.prometheus }} {
+          location {{ .Values.mimir.httpPrefix.alertmanager }} {
             proxy_pass      http://{{ template "grafana-mimir.alertmanager.fullname" . }}-headless.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.alertmanager.service.ports.http }}$request_uri;
           }
           location = /multitenant_alertmanager/status {


### PR DESCRIPTION
### Description of the change

Amend gateway configuration for alertmanager.

### Benefits

Bugfix

### Possible drawbacks

None

### Applicable issues

- fixes #15369

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
