### PR TITLE
[bitnami/kafka] kraft.clusterId format docs

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -473,11 +473,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                            | Description                                                                             | Value                    |
 | ------------------------------- | --------------------------------------------------------------------------------------- | ------------------------ |
-| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                    | `false`                  |
-| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them. | `broker,controller`      |
-| `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`             |
-| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `kafka_cluster_id_test1` |
-| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.         | `""`                     |
+| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                                                            | `false`                  |
+| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them.                                         | `broker,controller`      |
+| `kraft.controllerListenerNames` | Controller listener names                                                                                                       | `CONTROLLER`             |
+| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node and it should match the regex `[a-zA-Z0-9_\-]{22}` | `kafka_cluster_id_test1` |
+| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.                                                 | `""`                     |
 
 ### ZooKeeper chart parameters
 


### PR DESCRIPTION

### Description of the change

Docs/Readme clarification

### Benefits

Less wasted time on invalid configuration

### Possible drawbacks

None (docs addition)

### Applicable issues

#13624 (see comments)

### Additional information

The example/default turns out to be a valid ID but that is entirely not obvious from looking at it (without knowing the required format).

### Checklist

- [ x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
