### PR TITLE
[bitnami/mastodon] Better minio s3 TLS and Secure WebSocket support when using cert-manager to terminate TLS

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -42,4 +42,4 @@ name: mastodon
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mastodon
   - https://github.com/mastodon/mastodon/
-version: 1.1.4
+version: 1.2.0

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -42,4 +42,4 @@ name: mastodon
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mastodon
   - https://github.com/mastodon/mastodon/
-version: 1.1.3
+version: 1.1.4

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -105,6 +105,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraConfigExistingSecret`      | The name of an existing Secret with your extra configuration for Mastodon                                                    | `""`                                 |
 | `enableSearches`                 | Enable the search engine (uses Elasticsearch under the hood)                                                                 | `true`                               |
 | `enableS3`                       | Enable the S3 storage engine                                                                                                 | `true`                               |
+| `s3ForceHttps`                   | Force Mastodon's S3_PROTOCOL to be https (Useful when TLS is terminated using cert-manager/Ingress)                          | `false`                              |
 | `local_https`                    | Set this instance to advertise itself to the fediverse using HTTPS rather than HTTP URLs. This should almost always be true. | `true`                               |
 | `localDomain`                    | The domain name used by accounts on this instance. Unless you're using                                                       | `""`                                 |
 | `webDomain`                      | Optional alternate domain used when you want to host Mastodon at a                                                           | `""`                                 |

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -106,6 +106,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `enableSearches`                 | Enable the search engine (uses Elasticsearch under the hood)                                                                 | `true`                               |
 | `enableS3`                       | Enable the S3 storage engine                                                                                                 | `true`                               |
 | `s3ForceHttps`                   | Force Mastodon's S3_PROTOCOL to be https (Useful when TLS is terminated using cert-manager/Ingress)                          | `false`                              |
+| `useSecureWebSocket`             | Set Mastodon's STREAMING_API_BASE_URL to use secure websocket (wss:// instead of ws://)                                      | `false`                              |
 | `local_https`                    | Set this instance to advertise itself to the fediverse using HTTPS rather than HTTP URLs. This should almost always be true. | `true`                               |
 | `localDomain`                    | The domain name used by accounts on this instance. Unless you're using                                                       | `""`                                 |
 | `webDomain`                      | Optional alternate domain used when you want to host Mastodon at a                                                           | `""`                                 |

--- a/bitnami/mastodon/templates/_helpers.tpl
+++ b/bitnami/mastodon/templates/_helpers.tpl
@@ -52,7 +52,11 @@ Return the proper Mastodon streaming fullname
 Return Mastodon streaming url
 */}}
 {{- define "mastodon.streaming.url" -}}
-{{- printf "ws://%s" (include "mastodon.web.domain" .) | trunc 63 | trimSuffix "-" -}}
+  {{- if .Values.useSecureWebSocket -}}
+    {{- printf "wss://%s" (include "mastodon.web.domain" .) | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- printf "ws://%s" (include "mastodon.web.domain" .) | trunc 63 | trimSuffix "-" -}}
+  {{- end -}}  
 {{- end -}}
 
 {{/*

--- a/bitnami/mastodon/templates/_helpers.tpl
+++ b/bitnami/mastodon/templates/_helpers.tpl
@@ -153,10 +153,14 @@ Return the S3 bucket
 Return the S3 protocol
 */}}
 {{- define "mastodon.s3.protocol" -}}
-    {{- if .Values.minio.enabled -}}
-        {{- ternary "https" "http" .Values.minio.tls.enabled  -}}
+    {{- if .Values.s3ForceHttps -}}
+        {{- print "https" -}}
     {{- else -}}
-        {{- print .Values.externalS3.protocol -}}
+    	{{- if .Values.minio.enabled -}}
+            {{- ternary "https" "http" .Values.minio.tls.enabled  -}}
+    	{{- else -}}
+            {{- print .Values.externalS3.protocol -}}
+       {{- end -}}
     {{- end -}}
 {{- end -}}
 

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -194,6 +194,9 @@ enableS3: true
 ##
 s3ForceHttps: false
 
+## @param useSecureWebSocket Set Mastodon's STREAMING_API_BASE_URL to use secure websocket (wss:// instead of ws://)
+useSecureWebSocket: false
+
 ## @param local_https Set this instance to advertise itself to the fediverse using HTTPS rather than HTTP URLs. This should almost always be true.
 ##
 local_https: true

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -190,6 +190,10 @@ enableSearches: true
 ##
 enableS3: true
 
+## @param s3ForceHttps Force Mastodon's S3_PROTOCOL to be https (Useful when TLS is terminated using cert-manager/Ingress)
+##
+s3ForceHttps: false
+
 ## @param local_https Set this instance to advertise itself to the fediverse using HTTPS rather than HTTP URLs. This should almost always be true.
 ##
 local_https: true


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change introduces 2 settings in values.yaml to allow mastodon-web to work when used with cert-manager or another ingress that terminates TLS.  In this case mastodon-web can incorrectly create broken links to S3 when using minio instead of an external S3 Object Store and also break web socket connections by defaulting to the insecure ws:// protocol.

useSecureWebSocket - defaults to false.  When set to true it will set STREAMING_API_BASE_URL using the secure web socket protocol (was://) instead of ws://.  This will allow the Streaming URL to work when the page is served as TLS.

forceS3Https - defaults to false.  When set to true Mastodon's S3_PROTOCOL will always use https as a protocol.  When using an external S3 provider this usually isn't a problem setting S3_PROTOCOL but when minio is used and is TLS terminated prior to the deployment S3_PROTOCOL will be set to http which causes profile pictures img URLS served by mastodon-web to use use the wrong protocol.
### Benefits

<!-- What benefits will be realized by the code change? -->

When using cert-manager to manage and provision TLS where an ingress terminates TLS prior to the container this allows mastodon-web to correctly generate links that won't be blocked by the browser's Content Security Policy.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Ideally I would have used minio.tls.enabled but that then causes the the chart to either have auto generated self signed certificates which are rejected by the browser or minio.tls.existingSecret which isn't used.  

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
