### PR TITLE
[bitnami/spring-cloud-dataflow] bump kafka dependency

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 11.5.3
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 20.1.1
+  version: 21.4.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.2.4
-digest: sha256:4d8a30b38422275c278eead5e9e7ac3f81a2de3f901a64f8bd5cfbe8af86d77f
-generated: "2023-03-08T17:46:14.250723562Z"
+digest: sha256:1483963605f5c71ba9a2217ab36f2e8a6bb11ae516d06aab6ad56fd342ff2be9
+generated: "2023-03-17T08:33:46.069231+01:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - condition: kafka.enabled
     name: kafka
     repository: https://charts.bitnami.com/bitnami
-    version: 20.x.x
+    version: 21.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 15.0.6
+version: 16.0.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -659,6 +659,10 @@ Find more information about how to deal with common errors related to Bitnami He
 
 If you enabled RabbitMQ chart to be used as the messaging solution for Skipper to manage streaming content, then it's necessary to set the `rabbitmq.auth.password` and `rabbitmq.auth.erlangCookie` parameters when upgrading for readiness/liveness probes to work properly. Inspect the RabbitMQ secret to obtain the password and the Erlang cookie, then you can upgrade your chart using the command below:
 
+### To 16.0.0
+
+This major updates the Kafka subchart to its newest major, 21.0.0. [Here](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2100) you can find more information about the changes introduced in that version.
+
 ### To 15.0.0
 
 This major updates the Kafka subchart to its newest major, 20.0.0. [Here](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2000) you can find more information about the changes introduced in that version.


### PR DESCRIPTION
### Description of the change

This major version updates the Kafka subchart to its newest major.

### Benefits

Keep charts up to date.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to #14943

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
