### PR TITLE
[bitnami/cert-manager] Remove condition from cert-manager webhook service

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager-webhook
   - https://github.com/bitnami/containers/tree/main/bitnami/cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.9.3
+version: 0.9.4

--- a/bitnami/cert-manager/templates/webhook/service.yaml
+++ b/bitnami/cert-manager/templates/webhook/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,4 +13,3 @@ spec:
     - name: https
       port: {{ .Values.webhook.httpsPort }}
       targetPort: {{ .Values.webhook.containerPort }}
-{{- end }}


### PR DESCRIPTION
### Description of the change
Removes condition to only deploy the webhook service if metrics are enabled. 
The service is also needed by the controller and thus only deploying it when metrics are enabled will break a deployment where metrics are disabled by the user.

### Benefits
The deployment also works when `.Values.metrics.enabled` is set to `false`

### Possible drawbacks
None that I am aware of

### Applicable issues
Possible fix for:
- cert-manager/cert-manager#3195
- cert-manager/cert-manager#4999

These issues are mentioned in the troubleshooting docs of cert-manager
https://cert-manager.io/docs/troubleshooting/webhook/#error-service-cert-managercert-manager-webhook-not-found

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
