### PR TITLE
[bitnami/mongodb] Change static DNS entry to clusterDomain variable

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.9.2
+version: 13.9.3

--- a/bitnami/mongodb/templates/common-scripts-cm.yaml
+++ b/bitnami/mongodb/templates/common-scripts-cm.yaml
@@ -72,9 +72,9 @@ data:
     DNS.1 = $svc
     DNS.2 = $my_hostname
     {{- if eq .Values.architecture "replicaset" }}
-    DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.cluster.local
+    DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.{{ .Values.clusterDomain }}
     {{- else }}
-    DNS.3 = $svc.$MY_POD_NAMESPACE.svc.cluster.local
+    DNS.3 = $svc.$MY_POD_NAMESPACE.svc.{{ .Values.clusterDomain }}
     {{- end }}
     DNS.4 = localhost
     IP.0 = ${MY_POD_HOST_IP}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
- change in MongoDB Chart the alternate DNS entry from static to clusterDomain variable

### Benefits

<!-- What benefits will be realized by the code change? -->
- if not using cluster.local as default Cluster Domain, the created MongoDB Cert is still valid
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
