### PR TITLE
[bitnami/keycloak] Added nodeSelector and option to automatic cleanup finished jobs to the keycloak-config-cli job

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 13.3.0
+version: 13.4.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -297,6 +297,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `keycloakConfigCli.podLabels`                             | Pod extra labels                                                                                                              | `{}`                          |
 | `keycloakConfigCli.podAnnotations`                        | Annotations for job pod                                                                                                       | `{}`                          |
 | `keycloakConfigCli.extraEnvVars`                          | Additional environment variables to set                                                                                       | `[]`                          |
+| `keycloakConfigCli.nodeSelector`                          | Node labels for pod assignment                                                                                                | `{}`                          |
 | `keycloakConfigCli.podTolerations`                        | Tolerations for job pod assignment                                                                                            | `[]`                          |
 | `keycloakConfigCli.extraEnvVarsCM`                        | ConfigMap with extra environment variables                                                                                    | `""`                          |
 | `keycloakConfigCli.extraEnvVarsSecret`                    | Secret with extra environment variables                                                                                       | `""`                          |
@@ -306,6 +307,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `keycloakConfigCli.sidecars`                              | Add additional sidecar containers to the Keycloak config cli pod                                                              | `[]`                          |
 | `keycloakConfigCli.configuration`                         | keycloak-config-cli realms configuration                                                                                      | `{}`                          |
 | `keycloakConfigCli.existingConfigmap`                     | ConfigMap with keycloak-config-cli configuration. This will override `keycloakConfigCli.config`                               | `""`                          |
+| `keycloakConfigCli.cleanupAfterFinished.enabled`          | Enables Cleanup for Finished Jobs                                                                                             | `false`                       |
+| `keycloakConfigCli.cleanupAfterFinished.seconds`          | Sets the value of ttlSecondsAfterFinished                                                                                     | `600`                         |
 
 ### Database parameters
 

--- a/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
+++ b/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   backoffLimit: {{ .Values.keycloakConfigCli.backoffLimit }}
+  {{- if .Values.keycloakConfigCli.cleanupAfterFinished.enabled }}
+  ttlSecondsAfterFinished: {{ .Values.keycloakConfigCli.cleanupAfterFinished.seconds }}
+  {{- end }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
@@ -39,6 +42,9 @@ spec:
       {{- end }}
       {{- if .Values.keycloakConfigCli.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.keycloakConfigCli.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.keycloakConfigCli.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.keycloakConfigCli.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.keycloakConfigCli.podTolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.keycloakConfigCli.podTolerations "context" .) | nindent 8 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -915,6 +915,11 @@ keycloakConfigCli:
   ##   - name: FOO
   ##     value: "bar"
   ##
+  ## @param keycloakConfigCli.nodeSelector Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ##
   ## @param keycloakConfigCli.podTolerations Tolerations for job pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
@@ -973,6 +978,14 @@ keycloakConfigCli:
   ## NOTE: This will override keycloakConfigCli.configuration
   ##
   existingConfigmap: ""
+  ## Automatic Cleanup for Finished Jobs
+  ## @param keycloakConfigCli.cleanupAfterFinished.enabled Enables Cleanup for Finished Jobs
+  ## @param keycloakConfigCli.cleanupAfterFinished.seconds Sets the value of ttlSecondsAfterFinished
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
+  ##
+  cleanupAfterFinished:
+    enabled: false
+    seconds: 600
 
 ## @section Database parameters
 


### PR DESCRIPTION
### Description of the change
* Added the value `keycloakConfigCli.nodeSelector` this functionality was missing.
* Added [Automatic Cleanup for Finished Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/), this is configured with two values;
  * `keycloakConfigCli.cleanupAfterFinished.enabled` which enables or disabled the addition of the `.spec.ttlSecondsAfterFinished` field.
  * `keycloakConfigCli.cleanupAfterFinished.seconds` which sets the value of the `.spec.ttlSecondsAfterFinished` field.

### Benefits
* The keycloak-config-cli job can now run on clusters that use both Linux and Windows (or any other supported OS).
* Jobs can now be cleaned up if so desired.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
