### PR TITLE
[bitnami/*] Fix quoting for runtime-params k8s templates and injected configs

### DIFF
--- a/.vib/contour-operator/runtime-parameters.yaml
+++ b/.vib/contour-operator/runtime-parameters.yaml
@@ -1,14 +1,14 @@
 extraDeploy:
 - |
-  {{- $ca := genCA contour-ca 365 }}
-  {{- $contour_hostname := contour }}
+  {{- $ca := genCA "contour-ca" 365 }}
+  {{- $contour_hostname := "contour" }}
   {{- $contour_cert := genSignedCert $contour_hostname nil (list $contour_hostname) 365 $ca }}
   apiVersion: v1
   kind: Secret
   metadata:
     # Only necessary for the ingress to enable HTTPS ports
     name: fake-tls-certificates
-    namespace: {{ include common.names.namespace $ | quote }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
   type: kubernetes.io/tls
   data:
     tls.crt: {{ $contour_cert.Cert | b64enc | quote }}

--- a/.vib/kubeapps/runtime-parameters.yaml
+++ b/.vib/kubeapps/runtime-parameters.yaml
@@ -15,7 +15,7 @@ dashboard:
     |-
     - name: token
       secret:
-        secretName: {{ include common.names.fullname.namespace . }}-vib-token
+        secretName: {{ include "common.names.fullname.namespace" . }}-vib-token
   extraVolumeMounts:
     - name: token
       mountPath: /app/static/token/token.txt
@@ -59,40 +59,40 @@ extraDeploy:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
-      name: {{ include common.names.fullname.namespace . }}-vib
+      name: {{ include "common.names.fullname.namespace" . }}-vib
       namespace: {{ .Release.Namespace }}
   - |-
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: {{ include common.names.fullname.namespace . }}-vib-view
+      name: {{ include "common.names.fullname.namespace" . }}-vib-view
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
       name: view
     subjects:
     - kind: ServiceAccount
-      name: {{ include common.names.fullname.namespace . }}-vib
+      name: {{ include "common.names.fullname.namespace" . }}-vib
       namespace: {{ .Release.Namespace }}
   - |-
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: {{ include common.names.fullname.namespace . }}-vib-edit
+      name: {{ include "common.names.fullname.namespace" . }}-vib-edit
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
       name: edit
     subjects:
     - kind: ServiceAccount
-      name: {{ include common.names.fullname.namespace . }}-vib
+      name: {{ include "common.names.fullname.namespace" . }}-vib
       namespace: {{ .Release.Namespace }}
   - |-
     apiVersion: v1
     kind: Secret
     type: kubernetes.io/service-account-token
     metadata:
-      name: {{ include common.names.fullname.namespace . }}-vib-token
+      name: {{ include "common.names.fullname.namespace" . }}-vib-token
       namespace: {{ .Release.Namespace }}
       annotations:
-        kubernetes.io/service-account.name: {{ include common.names.fullname.namespace . }}-vib
+        kubernetes.io/service-account.name: {{ include "common.names.fullname.namespace" . }}-vib

--- a/.vib/logstash/runtime-parameters.yaml
+++ b/.vib/logstash/runtime-parameters.yaml
@@ -3,20 +3,20 @@ monitoringAPIPort: 9600
 input: |-
   http { port => 8081 }
   file {
-    path => /tmp/test_input
-    mode => tail
+    path => "/tmp/test_input"
+    mode => "tail"
   }
 filter: |-
   grok {
-    match => { message => %{COMBINEDAPACHELOG} }
+    match => { "message" => "%{COMBINEDAPACHELOG}" }
   }
   date {
-    match => [ timestamp , dd/MMM/yyyy:HH:mm:ss Z ]
+    match => [ "timestamp" , "dd/MMM/yyyy:HH:mm:ss Z" ]
   }
 output: |-
   stdout {}
   file {
-    path => /tmp/test_log
+    path => "/tmp/test_log"
   }
 serviceAccount:
   create: true

--- a/.vib/oauth2-proxy/runtime-parameters.yaml
+++ b/.vib/oauth2-proxy/runtime-parameters.yaml
@@ -6,13 +6,13 @@ configuration:
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
   cookieSecret: vib-tests-cookie
   content: |
-    email_domains = [ * ]
-    provider = oidc
-    oidc_issuer_url = http://vmware-oauth2-proxy.my:5556/dex
-    redirect_url = http://vmware-oauth2-proxy.my/oauth2/callback
+    email_domains = [ "*" ]
+    provider = "oidc"
+    oidc_issuer_url = "http://vmware-oauth2-proxy.my:5556/dex"
+    redirect_url = "http://vmware-oauth2-proxy.my/oauth2/callback"
     cookie_secure = false
-    skip_auth_routes = [ ^\/dex\/.* ]
-    upstreams = [ file:///bitnami/oauth2-proxy/conf/, http://vmware-oauth2-proxy.my:5556/dex/ ]
+    skip_auth_routes = [ "^\/dex\/.*" ]
+    upstreams = [ "file:///bitnami/oauth2-proxy/conf/", "http://vmware-oauth2-proxy.my:5556/dex/" ]
 containerPort: 4181
 hostAliases:
   - ip: 127.0.0.1
@@ -65,7 +65,7 @@ extraDeploy:
         staticClients:
           - id: vib-dex-client
             redirectURIs:
-              - http://vmware-oauth2-proxy.my/oauth2/callback
+              - "http://vmware-oauth2-proxy.my/oauth2/callback"
             name: 'VIB-Dex'
             secret: ZXhhbXBsZS1hcHAtc2VjcmV0
         connectors:
@@ -74,7 +74,7 @@ extraDeploy:
             name: Example
         enablePasswordDB: true
         staticPasswords:
-          - email: admin@example.com
-            hash: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
-            username: admin
-            userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
+          - email: "admin@example.com"
+            hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+            username: "admin"
+            userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/.vib/pinniped/runtime-parameters.yaml
+++ b/.vib/pinniped/runtime-parameters.yaml
@@ -21,27 +21,27 @@ concierge:
     create: true
 extraDeploy:
 - |
-  {{- $ca := genCA pinniped-ca 365 }}
-  {{- $pinniped_hostname := pinniped-supervisor }}
+  {{- $ca := genCA "pinniped-ca" 365 }}
+  {{- $pinniped_hostname := "pinniped-supervisor" }}
   {{- $pinniped_cert := genSignedCert $pinniped_hostname nil (list $pinniped_hostname) 365 $ca }}
   apiVersion: v1
   kind: Secret
   metadata:
     name: pinniped-supervisor-default-tls-certificate
-    namespace: {{ include common.names.namespace $ | quote }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
   type: kubernetes.io/tls
   data:
     tls.crt: {{ $pinniped_cert.Cert | b64enc | quote }}
     tls.key: {{ $pinniped_cert.Key | b64enc | quote }}
     ca.crt: {{ $ca.Cert | b64enc | quote }}
   ---
-  {{- $openldap_hostname := (printf openldap.%s.svc.cluster.local .Release.Namespace) }}
+  {{- $openldap_hostname := (printf "openldap.%s.svc.cluster.local" .Release.Namespace) }}
   {{- $openldap_cert := genSignedCert $openldap_hostname nil (list $openldap_hostname) 365 $ca }}
   apiVersion: v1
   kind: Secret
   metadata:
     name: openldap-certs
-    namespace: {{ include common.names.namespace $ | quote }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
   type: kubernetes.io/tls
   data:
     tls.crt: {{ $openldap_cert.Cert | b64enc | quote }}
@@ -54,7 +54,7 @@ extraDeploy:
   kind: FederationDomain
   metadata:
     name: my-provider
-    namespace: {{ include common.names.namespace $ | quote }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
   spec:
     issuer: https://pinniped-supervisor/demo-issuer
   ---
@@ -94,27 +94,27 @@ extraDeploy:
               failureThreshold: 9
             env:
               - name: LDAP_ADMIN_USERNAME
-                value: admin
+                value: "admin"
               - name: LDAP_ADMIN_PASSWORD
-                value: admin123
+                value: "admin123"
               - name: LDAP_ROOT
-                value: dc=pinniped-supervisor
+                value: "dc=pinniped-supervisor"
               - name: LDAP_USER_DC
-                value: users
+                value: "users"
               - name: LDAP_USERS
-                value: vibuser
+                value: "vibuser"
               - name: LDAP_PASSWORDS
-                value: vibUser123
+                value: "vibUser123"
               - name: LDAP_GROUP
-                value: users
+                value: "users"
               - name: LDAP_ENABLE_TLS
-                value: yes
+                value: "yes"
               - name: LDAP_TLS_CERT_FILE
-                value: /var/certs/tls.crt
+                value: "/var/certs/tls.crt"
               - name: LDAP_TLS_KEY_FILE
-                value: /var/certs/tls.key
+                value: "/var/certs/tls.key"
               - name: LDAP_TLS_CA_FILE
-                value: /var/certs/ca.crt
+                value: "/var/certs/ca.crt"
             volumeMounts:
               - name: certs
                 mountPath: /var/certs
@@ -145,20 +145,20 @@ extraDeploy:
   metadata:
     name: openldap
   spec:
-    host: openldap.{{ .Release.Namespace }}.svc.cluster.local
+    host: "openldap.{{ .Release.Namespace }}.svc.cluster.local"
     tls:
       certificateAuthorityData: {{ $ca.Cert | b64enc | quote }}
     userSearch:
-      base: ou=users,dc=pinniped-supervisor
-      filter: &(objectClass=inetOrgPerson)(uid={})
+      base: "ou=users,dc=pinniped-supervisor"
+      filter: "&(objectClass=inetOrgPerson)(uid={})"
       attributes:
-        username: uid
-        uid: uidNumber
+        username: "uid"
+        uid: "uidNumber"
     groupSearch:
-      base: ou=users,dc=pinniped-supervisor
-      filter: &(objectClass=groupOfNames)(member={})
+      base: "ou=users,dc=pinniped-supervisor"
+      filter: "&(objectClass=groupOfNames)(member={})"
       attributes:
-        groupName: cn
+        groupName: "cn"
     bind:
       secretName: openldap-bind-account
   ---
@@ -168,8 +168,8 @@ extraDeploy:
     name: openldap-bind-account
   type: kubernetes.io/basic-auth
   stringData:
-    username: cn=admin,dc=pinniped-supervisor
-    password: admin123
+    username: "cn=admin,dc=pinniped-supervisor"
+    password: "admin123"
   ---
   ## Ref: https://pinniped.dev/docs/howto/configure-concierge-jwt/
   ##
@@ -177,9 +177,9 @@ extraDeploy:
   kind: JWTAuthenticator
   metadata:
     name: supervisor-jwt-authenticator
-    namespace: {{ include common.names.namespace $ | quote }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
   spec:
-    issuer: https://pinniped-supervisor/demo-issuer
+    issuer: "https://pinniped-supervisor/demo-issuer"
     audience: vib-ed9de33c370981f61e9c
     tls:
       certificateAuthorityData: {{ $ca.Cert | b64enc | quote }}

--- a/.vib/thanos/runtime-parameters.yaml
+++ b/.vib/thanos/runtime-parameters.yaml
@@ -2,7 +2,7 @@ objstoreConfig: |-
   type: s3
   config:
     bucket: thanos-test
-    endpoint: {{ include thanos.minio.fullname . }}.{{ .Release.Namespace }}.svc.cluster.local:9000
+    endpoint: {{ include "thanos.minio.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9000
     access_key: minio-vib
     secret_key: minio123
     insecure: true

--- a/.vib/wildfly/runtime-parameters.yaml
+++ b/.vib/wildfly/runtime-parameters.yaml
@@ -14,17 +14,17 @@ initContainers:
      - name: MAVEN_VERSION
        value: 3.8.6
      - name: APP_VERSION
-       value: {{ .Chart.AppVersion }}
-   command: ['bash', '-c', cd /opt/bitnami && \
+       value: "{{ .Chart.AppVersion }}"
+   command: ['bash', '-c', "cd /opt/bitnami && \
      install_packages curl ca-certificates && \
-     curl -L \https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz\ -o /opt/bitnami/maven.tar.gz && \
+     curl -L \"https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz\" -o /opt/bitnami/maven.tar.gz && \
      tar -xzf /opt/bitnami/maven.tar.gz && \
-     export PATH=\/opt/bitnami/apache-maven-${MAVEN_VERSION}/bin:$PATH\ && \
-     curl -L \https://github.com/wildfly/quickstart/archive/refs/tags/${APP_VERSION}.Final.tar.gz\ -o /opt/bitnami/wildfly-quickstart.tar.gz && \
+     export PATH=\"/opt/bitnami/apache-maven-${MAVEN_VERSION}/bin:$PATH\" && \
+     curl -L \"https://github.com/wildfly/quickstart/archive/refs/tags/${APP_VERSION}.Final.tar.gz\" -o /opt/bitnami/wildfly-quickstart.tar.gz && \
      tar -xzf /opt/bitnami/wildfly-quickstart.tar.gz && \
      cd /opt/bitnami/quickstart-${APP_VERSION}.Final/helloworld && \
      mvn clean package && \
-     cp /opt/bitnami/quickstart-${APP_VERSION}.Final/helloworld/target/helloworld.war /bitnami/wildfly/helloworld.war]
+     cp /opt/bitnami/quickstart-${APP_VERSION}.Final/helloworld/target/helloworld.war /bitnami/wildfly/helloworld.war"]
    volumeMounts:
      - name: data
        mountPath: /bitnami/wildfly


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

A follow-up of #15510, this PRs fixes quoting issues in `runtime-parameters.yaml` files when a configuration block or k8s templating is used.

The migration from the old base64 string to the `.yaml` file removed the double quotes of the strings. This is not an issue for standard strings in yaml, but can create issues for complex configuration blocks or k8s templates.

### Benefits

Fixes faulty code

### Possible drawbacks

Additional assets may be impacted by the `"` removal.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
