### PR TITLE
[bitnami/minio] Fix minio policy to version minio:2023.3.20 

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
-version: 12.2.1
+version: 12.2.2

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -98,7 +98,7 @@ spec:
                 mc admin user add {{ $minioAlias }} "${username}" "${password}";
 
                 if [ "${set_policies}" == "true" ]; then
-                  mc admin policy attach {{ $minioAlias }} "${policies_list}" user="${username}";
+                  mc admin policy attach {{ $minioAlias }} "${policies_list}" --user="${username}";
                 else
                   IFS=',' read -r -a POLICIES <<< "${policies_list}";
                   for policy in "${POLICIES[@]}"; do
@@ -137,7 +137,7 @@ spec:
               {{- range $user := .Values.provisioning.users }}
               mc admin user add {{ $minioAlias }} {{ $user.username }} {{ $user.password }};
               {{- if $user.setPolicies }}
-              mc admin policy attach {{ $minioAlias }} "{{ join "," $user.policies }}" user={{ $user.username }};
+              mc admin policy attach {{ $minioAlias }} "{{ join "," $user.policies }}" --user={{ $user.username }};
               {{- else }}
               {{- range $policy := $user.policies }}
               addPolicy user {{ $user.username }} {{ $policy }};
@@ -155,7 +155,7 @@ spec:
               {{- range $group := .Values.provisioning.groups }}
               mc admin group add {{ $minioAlias }} {{ $group.name }} {{ join " " $group.members }};
               {{- if $group.setPolicies }}
-              mc admin policy attach {{ $minioAlias }} "{{ join "," $group.policies }}" group={{ $group.name }};
+              mc admin policy attach {{ $minioAlias }} "{{ join "," $group.policies }}" --group={{ $group.name }};
               {{- else }}
               {{- range $policy := $group.policies }}
               addPolicy group {{ $group.name }} {{ $policy }};

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -84,7 +84,7 @@ spec:
                 local tmp=$(mc admin $1 info {{ $minioAlias }} $2 | sed -n -e 's/^Policy.*: \(.*\)$/\1/p');
                 IFS=',' read -r -a CURRENT_POLICIES <<< "$tmp";
                 if [[ ! "${CURRENT_POLICIES[*]}" =~ "$3" ]]; then
-                  mc admin policy update {{ $minioAlias }} $3 $1=$2;
+                  mc admin policy attach {{ $minioAlias }} $3 $1=$2;
                 fi;
               };
 
@@ -98,7 +98,7 @@ spec:
                 mc admin user add {{ $minioAlias }} "${username}" "${password}";
 
                 if [ "${set_policies}" == "true" ]; then
-                  mc admin policy set {{ $minioAlias }} "${policies_list}" user="${username}";
+                  mc admin policy attach {{ $minioAlias }} "${policies_list}" user="${username}";
                 else
                   IFS=',' read -r -a POLICIES <<< "${policies_list}";
                   for policy in "${POLICIES[@]}"; do
@@ -131,13 +131,13 @@ spec:
               mc admin service restart {{ $minioAlias }};
 
               {{- range $policy := .Values.provisioning.policies }}
-              mc admin policy add {{ $minioAlias }} {{ $policy.name }} /etc/ilm/policy-{{ $policy.name }}.json;
+              mc admin policy create {{ $minioAlias }} {{ $policy.name }} /etc/ilm/policy-{{ $policy.name }}.json;
               {{- end }}
 
               {{- range $user := .Values.provisioning.users }}
               mc admin user add {{ $minioAlias }} {{ $user.username }} {{ $user.password }};
               {{- if $user.setPolicies }}
-              mc admin policy set {{ $minioAlias }} "{{ join "," $user.policies }}" user={{ $user.username }};
+              mc admin policy attach {{ $minioAlias }} "{{ join "," $user.policies }}" user={{ $user.username }};
               {{- else }}
               {{- range $policy := $user.policies }}
               addPolicy user {{ $user.username }} {{ $policy }};
@@ -155,7 +155,7 @@ spec:
               {{- range $group := .Values.provisioning.groups }}
               mc admin group add {{ $minioAlias }} {{ $group.name }} {{ join " " $group.members }};
               {{- if $group.setPolicies }}
-              mc admin policy set {{ $minioAlias }} "{{ join "," $group.policies }}" group={{ $group.name }};
+              mc admin policy attach {{ $minioAlias }} "{{ join "," $group.policies }}" group={{ $group.name }};
               {{- else }}
               {{- range $policy := $group.policies }}
               addPolicy group {{ $group.name }} {{ $policy }};

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -84,7 +84,7 @@ spec:
                 local tmp=$(mc admin $1 info {{ $minioAlias }} $2 | sed -n -e 's/^Policy.*: \(.*\)$/\1/p');
                 IFS=',' read -r -a CURRENT_POLICIES <<< "$tmp";
                 if [[ ! "${CURRENT_POLICIES[*]}" =~ "$3" ]]; then
-                  mc admin policy attach {{ $minioAlias }} $3 $1=$2;
+                  mc admin policy attach {{ $minioAlias }} $3 --$1=$2;
                 fi;
               };
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix minio policy provisioning error:
```
Incorrect command. Please use 'mc admin policy attach'
```

### Applicable issues

- fixes #15675

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
