### PR TITLE
update keycloak cli job image tag

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 13.4.0
+version: 13.4.1

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -839,7 +839,7 @@ keycloakConfigCli:
   image:
     registry: docker.io
     repository: bitnami/keycloak-config-cli
-    tag: 5.5.0-debian-11-r36
+    tag: 5.6.1-debian-11-r4
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->


### Description of the change

Bump the keycloak default cli image tag in values.yaml

The current image tag doesn't work out of the box


### Possible drawbacks

None

### Additional information

When job tries to run it doesn't find the `keycloak-config-cli-20.0.5.jar` image is too old


The cli job specified using the Chart version with is `20.0.5`
```
          command:
            - java
            - -jar
            - {{ printf "/opt/bitnami/keycloak-config-cli/keycloak-config-cli-%s.jar" .Chart.AppVersion }}
```

Current image `5.5.0-debian-11-r36`
```
$ ls -l
total 77160
-rw-r--r-- 1 root root 19744842 Feb 15 14:37 keycloak-config-cli-17.0.1.jar
-rw-r--r-- 1 root root 19746655 Feb 15 14:37 keycloak-config-cli-18.0.2.jar
-rw-r--r-- 1 root root 19749083 Feb 15 14:37 keycloak-config-cli-19.0.3.jar
-rw-r--r-- 1 root root 19758510 Feb 15 14:38 keycloak-config-cli-20.0.1.jar
lrwxrwxrwx 1 root root       63 Feb 15 14:38 keycloak-config-cli.jar -> /opt/bitnami/keycloak-config-cli/keycloak-config-cli-20.0.1.jar
drwxr-xr-x 2 root root     4096 Feb 15 15:10 licenses
```

The new image proposed `5.6.1-debian-11-r4`
```
$ ls -l
total 77272
-rw-r--r-- 1 root root 19768316 Mar 16 18:26 keycloak-config-cli-18.0.2.jar
-rw-r--r-- 1 root root 19770745 Mar 16 18:26 keycloak-config-cli-19.0.3.jar
-rw-r--r-- 1 root root 19780174 Mar 16 18:26 keycloak-config-cli-20.0.5.jar
-rw-r--r-- 1 root root 19791700 Mar 16 18:27 keycloak-config-cli-21.0.1.jar
lrwxrwxrwx 1 root root       63 Mar 16 18:27 keycloak-config-cli.jar -> /opt/bitnami/keycloak-config-cli/keycloak-config-cli-21.0.1.jar
```
### Benefits

Makes the chart functional when keycloack config is specified.
The current image tag is too old and it doesn't have the jar version for the keycloak that is being updated.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
