### PR TITLE
[bitnami/charts] Reduce GitHub API requests

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -13,12 +13,13 @@ jobs:
     steps:
       - id: get-asset
         name: Get modified assets
+        env:
+          DIFF_URL: "${{github.event.pull_request.diff_url}}"
+          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
         run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL")
-          files_changed="$(echo $files_changed_data | jq -r '.[] | .filename')"
+          # This request doesn't consume API calls.
+          curl -Lkso $TEMP_FILE $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
           # Adding || true to avoid "Process exited with code 1" errors
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*).*|\1|p" | sort | uniq || true))
 
@@ -42,6 +43,6 @@ jobs:
             }
       - name: Labeling
         if: ${{ steps.get-asset.outputs.result == 'ok' }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: "${{ steps.get-asset.outputs.name }}"

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -30,12 +30,13 @@ jobs:
     steps:
       - id: get-chart
         name: Get modified charts
+        env:
+          DIFF_URL: "${{github.event.pull_request.diff_url}}"
+          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
         run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
-          PR_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$PR_URL")
-          files_changed="$(echo $files_changed_data | jq -r '.[] | .filename')"
+          # This request doesn't consume API calls.
+          curl -Lkso $TEMP_FILE $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
           # Adding || true to avoid "Process exited with code 1" errors
           charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
           # Using grep -c as a better alternative to wc -l when dealing with empty strings."

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -18,18 +18,12 @@ jobs:
       - name: Send to the Solved column
         id: send-solved
         uses: peter-evans/create-or-update-project-card@v2
+        # Send to solve only the issues and PRs created by users or the automated PRs with human review required
+        if: |
+          (github.event.issue != null && github.event.issue.user.login != 'bitnami-bot') ||
+          (github.event.issue == null && (github.event.pull_request.user.login != 'bitnami-bot' || contains(github.event.pull_request.labels.*.name, 'review-required')))
         with:
           project-name: Support
           column-name: 'Solved'
           token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
-      - name: Remove cards from automated PRs
-        if: |
-          (github.event.issue != null && github.event.issue.user.login == 'bitnami-bot') ||
-          (github.event.issue == null && github.event.pull_request.user.login == 'bitnami-bot')
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.projects.deleteCard({
-              card_id: ${{ steps.send-solved.outputs.card-id }}
-            });

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -54,43 +54,43 @@ jobs:
       - name: Triage labeling
         # Only if moved into triage
         if: ${{ github.event.project_card.column_id == env.TRIAGE_COLUMN_ID }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: triage
           remove-labels: on-hold, in-progress, solved
       - name: From Bitnami labeling
         if: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type == 'pull_request') && 'automated, auto-merge' || 'bitnami' }}
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
-        # Consecutive calls were fixed in fmulero/labeler@1.0.5, see https://github.com/fmulero/labeler/pull/2
+        # Consecutive calls were fixed in fmulero/labeler@1.1.0, see https://github.com/fmulero/labeler/pull/2
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           add-labels: verify
       - name: Build Maintenance labeling
         if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: review-required
           remove-labels: auto-merge
       - name: On hold labeling
         # Only if moved into on hold
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: on-hold
           remove-labels: triage, in-progress, solved
       - name: In progress labeling
         # Only if moved into In progress
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: in-progress
           remove-labels: on-hold, triage, solved
@@ -99,7 +99,7 @@ jobs:
         if: |
           github.event.project_card.column_id == env.SOLVED_COLUMN_ID &&
           (needs.get-issue.outputs.author != 'bitnami-bot')
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: solved
           # Triage is not on the list to know how many issues/PRs are solved

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,6 +9,9 @@ on:
     types:
       - reopened
       - opened
+permissions:
+  issues: write
+  pull-requests: write
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
@@ -31,9 +34,12 @@ jobs:
         run: |
           author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
           number="${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}"
+          type="${{ github.event_name != 'issues' && 'pull_request' || 'issue' }}"
           echo "author=${author}" >> $GITHUB_OUTPUT
           echo "number=${number}" >> $GITHUB_OUTPUT
+          echo "type=${type}" >> $GITHUB_OUTPUT
       - name: Send to the board
+        if: ${{steps.get-issue.outputs.author != 'bitnami-bot' || steps.get-issue.outputs.type != 'pull_request'}}
         uses: peter-evans/create-or-update-project-card@v2
         with:
           project-name: Support
@@ -41,3 +47,17 @@ jobs:
           column-name: ${{ (contains(fromJson(env.BITNAMI_TEAM), steps.get-issue.outputs.author)) && 'From Bitnami' || 'Triage' }}
           token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ steps.get-issue.outputs.number }}
+      # The project API is not efficient and requires several requests to create the project card. For that reason we decided to create
+      # a card for the automated PRs only when it is needed.
+      - name: From Bitnami labeling
+        if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
+        uses: fmulero/labeler@1.1.0
+        with:
+          add-labels: 'automated, auto-merge'
+      - name: Verify labeling
+        if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
+        uses: fmulero/labeler@1.1.0
+        with:
+          # Bitnami bot token is required to trigger CI workflows
+          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          add-labels: verify


### PR DESCRIPTION
### Description of the change

Modify workflows involved in automated PRs to reduce the number of requests to the GitHub API. With these changes we remove 10 API requests for each automated PR.

Take advantage of the latest changes in the labeler action. We are mainly interested on https://github.com/fmulero/labeler/pull/3.

### Benefits

Reduce errors due to the API rate limit. Also, the workflows involving the labeler action will fail clearly if API rate limit is reached and the user can retry the actions failed.

### Possible drawbacks

None identified.

### Additional information

* Related to: https://github.com/bitnami/containers/pull/28187
* Related to: https://github.com/bitnami/containers/pull/27835

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
