### PR TITLE
[bitnami/argo-cd] Fix cannot add TLS certificate: configmap argocd-tls-certs-cm not found

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.5.2
+version: 4.5.3

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -808,7 +808,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `config.createExtraKnownHosts`                 | Whether to create or not the extra known hosts configmap                                              | `true` |
 | `config.styles`                                | Custom CSS styles                                                                                     | `""`   |
 | `config.existingStylesConfigmap`               | Use an existing styles configmap                                                                      | `""`   |
-| `config.tlsCerts`                              | TLS certificates used to verify the authenticity of the repository servers                            | `{}`   |
+| `config.tls.annotations             `          | Annotations to be added to argocd-tls-certs-cm configmap                                              | `{}`   |
+| `config.tls.certificates`                      | TLS certificates used to verify the authenticity of the repository servers                            | `{}`   |
 | `config.gpgKeys`                               | GnuPG public keys to add to the keyring                                                               | `{}`   |
 | `config.secret.create`                         | Whether to create or not the secret                                                                   | `true` |
 | `config.secret.annotations`                    | General secret extra annotations                                                                      | `{}`   |

--- a/bitnami/argo-cd/templates/applicationset/deployment.yaml
+++ b/bitnami/argo-cd/templates/applicationset/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           volumeMounts:
             - mountPath: /app/config/ssh
               name: ssh-known-hosts
-            {{- if .Values.config.tlsCerts }}
+            {{- if .Values.config.tls.certificates }}
             - mountPath: /app/config/tls
               name: tls-certs
             {{- end }}
@@ -165,7 +165,7 @@ spec:
         - name: ssh-known-hosts
           configMap:
             name: argocd-ssh-known-hosts-cm
-        {{- if .Values.config.tlsCerts }}
+        {{- if .Values.config.tls.certificates }}
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm

--- a/bitnami/argo-cd/templates/notifications/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           securityContext: {{- omit .Values.notifications.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.config.tlsCerts }}
+            {{- if .Values.config.tls.certificates }}
             - mountPath: /app/config/tls
               name: tls-certs
             {{- end }}
@@ -110,7 +110,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.notifications.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
       volumes:
-        {{- if .Values.config.tlsCerts }}
+        {{- if .Values.config.tls.certificates }}
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -234,7 +234,7 @@ spec:
             # Ref: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#ssh-known-host-public-keys
             - name: ssh-known-hosts
               mountPath: /app/config/ssh
-            {{- if .Values.config.tlsCerts }}
+            {{- if .Values.config.tls.certificates }}
             # Mounting into a path that will be read by Argo CD
             # Ref: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repositories-using-self-signed-tls-certificates-or-are-signed-by-custom-ca
             - mountPath: /app/config/tls
@@ -259,7 +259,7 @@ spec:
         - name: ssh-known-hosts
           configMap:
             name: argocd-ssh-known-hosts-cm
-        {{- if .Values.config.tlsCerts }}
+        {{- if .Values.config.tls.certificates }}
         - configMap:
             name: argocd-tls-certs-cm
           name: tls-certs

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -236,7 +236,7 @@ spec:
               subPath: "custom.styles.css"
               name: custom-styles
             {{- end }}
-            {{- if .Values.config.tlsCerts }}
+            {{- if .Values.config.tls.certificates }}
             # Mounting into a path that will be read by Argo CD
             # Ref: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repositories-using-self-signed-tls-certificates-or-are-signed-by-custom-ca
             - mountPath: /app/config/tls
@@ -262,7 +262,7 @@ spec:
             name: {{ include "argocd.custom-styles.fullname" . }}
           name: custom-styles
         {{- end }}
-        {{- if .Values.config.tlsCerts }}
+        {{- if .Values.config.tls.certificates }}
         - configMap:
             name: argocd-tls-certs-cm
           name: tls-certs

--- a/bitnami/argo-cd/templates/tls-certs-cm.yaml
+++ b/bitnami/argo-cd/templates/tls-certs-cm.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.config.tlsCerts }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,9 +12,8 @@ metadata:
     # Mandatory label
     # Ref: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#atomic-configuration
     app.kubernetes.io/part-of: argocd
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if .Values.config.tls.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.config.tls.annotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- include "common.tplvalues.render" (dict "value" .Values.config.tlsCerts "context" $) | nindent 2 }}
-{{- end }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.config.tls.certificates  "context" $) | nindent 2 }}

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -3164,19 +3164,27 @@ config:
   ##
   existingStylesConfigmap: ""
 
-  ## @param config.tlsCerts TLS certificates used to verify the authenticity of the repository servers
-  ## E.g:
-  ## tlsCerts:
-  ##   argocd-1.example.com: |
-  ##     -----BEGIN CERTIFICATE-----
-  ##     (...)
-  ##     -----END CERTIFICATE-----
-  ##   argocd-2.example.com: |
-  ##     -----BEGIN CERTIFICATE-----
-  ##     (...)
-  ##     -----END CERTIFICATE-----
+  ## Argo CD repository TLS certificates
+  ## config.tlsCerts DEPRECATED. Moved to config.tls.certificates
+  ## Ref: https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml#L422
   ##
-  tlsCerts: {}
+  tls:
+    ## @param config.tls.annotations Annotations to be added to argocd-tls-certs-cm configmap
+    ##
+    annotations: {}
+    ## @param config.tls.certificates TLS certificates used to verify the authenticity of the repository servers. Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories-using-self-signed-tls-certificates-or-are-signed-by-custom-ca
+    ##
+    certificates: {}
+    ## E.g:
+    ## certificates:
+    ##   argocd-1.example.com: |
+    ##     -----BEGIN CERTIFICATE-----
+    ##     (...)
+    ##     -----END CERTIFICATE-----
+    ##   argocd-2.example.com: |
+    ##     -----BEGIN CERTIFICATE-----
+    ##     (...)
+    ##     -----END CERTIFICATE-----
 
   ## @param config.gpgKeys GnuPG public keys to add to the keyring
   ## Note: Public keys should be exported with `gpg --export --armor <KEY>`


### PR DESCRIPTION
### Description of the change

Logical redefinition to implement `tlsCert` in ArgoCD chart. A issue has been encountered in the GUI when trying to generate a new Certificate in `Settings > Repository Certificates and Known Hosts`.

### Applicable issues

This change fix `Cannot add TLS certificate: configmap "argocd-tls-certs-cm" not found`
- fixes #13400 #15736 

### Additional information

From upstream, the way [TLS certificates](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories-using-self-signed-tls-certificates-or-are-signed-by-custom-ca) are handled has changed.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
