### PR TITLE
[bitnami/charts] Use Main Catalog Testing CSP Org for GitHub testing pipelines

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 env:
   CSP_API_URL: https://console.cloud.vmware.com
-  CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}
+  CSP_API_TOKEN: ${{ secrets.CSP_API_TESTING_TOKEN }}
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 # Avoid concurrency over the same PR
 concurrency:


### PR DESCRIPTION
### Description of the change

Use Main Catalog Testing CSP org for testing workflows.

### Benefits

Split production and testing workflows.

### Possible drawbacks

To diagnose broken pipelines we could need to change our Organization in CSP or use the artifacts attached to workflow execution.

### Applicable issues


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
