### PR TITLE
[bitnami/metallb] crds.yaml update to 0.13.9 (#15745 fix)

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -29,4 +29,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
-version: 4.1.21
+version: 4.1.22

--- a/bitnami/metallb/templates/controller/crds.yaml
+++ b/bitnami/metallb/templates/controller/crds.yaml
@@ -1,4 +1,4 @@
-# Based on: https://github.com/metallb/metallb/blob/v0.13.7/charts/metallb/charts/crds/templates/crds.yaml
+# Based on: https://github.com/metallb/metallb/blob/v0.13.9/charts/metallb/charts/crds/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -773,6 +773,10 @@ spec:
               sourceAddress:
                 description: Source address to use when establishing the session.
                 type: string
+              vrf:
+                description: To set if we want to peer with the BGPPeer using an interface
+                  belonging to a host vrf
+                type: string
             required:
             - myASN
             - peerASN
@@ -850,6 +854,130 @@ spec:
                 description: AvoidBuggyIPs prevents addresses ending with .0 and .255
                   to be used by a pool.
                 type: boolean
+              serviceAllocation:
+                description: AllocateTo makes ip pool allocation to specific namespace
+                  and/or service. The controller will use the pool with lowest value
+                  of priority in case of multiple matches. A pool with no priority
+                  set will be used only if the pools with priority can't be used.
+                  If multiple matching IPAddressPools are available it will check
+                  for the availability of IPs sorting the matching IPAddressPools
+                  by priority, starting from the highest to the lowest. If multiple
+                  IPAddressPools have the same priority, choice will be random.
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors list of label selectors to select
+                      namespace(s) for ip pool, an alternative to using namespace
+                      list.
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                  namespaces:
+                    description: Namespaces list of namespace(s) on which ip pool
+                      can be attached.
+                    items:
+                      type: string
+                    type: array
+                  priority:
+                    description: Priority priority given for ip pool while ip allocation
+                      on a service.
+                    type: integer
+                  serviceSelectors:
+                    description: ServiceSelectors list of label selector to select
+                      service(s) for which ip pool can be used for ip allocation.
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                type: object
             required:
             - addresses
             type: object

--- a/bitnami/metallb/templates/controller/crds.yaml
+++ b/bitnami/metallb/templates/controller/crds.yaml
@@ -1,4 +1,4 @@
-# Based on: https://github.com/metallb/metallb/blob/v0.13.4/charts/metallb/charts/crds/templates/crds.yaml
+# Based on: https://github.com/metallb/metallb/blob/v0.13.7/charts/metallb/charts/crds/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -907,6 +907,13 @@ spec:
           spec:
             description: L2AdvertisementSpec defines the desired state of L2Advertisement.
             properties:
+              interfaces:
+                description: A list of interfaces to announce from. The LB IP will
+                  be announced only from these interfaces. If the field is not set,
+                  we advertise from all the interfaces on the host.
+                items:
+                  type: string
+                type: array
               ipAddressPoolSelectors:
                 description: A selector for the IPAddressPools which would get advertised
                   via this advertisement. If no IPAddressPool is selected by this


### PR DESCRIPTION
Fix for issue #15745 and extends to fix to version 0.13.9

### Description of the change

L2Advertisements were missing "interfaces" parameters. This finding lead me to believe that the crds.yaml was not updated.
The comment shows 0.13.4 whereas the chart references 0.13.9 images.

Not only does this fix the L2Advertisement issue but it adds all crds features left out between 0.13.4 (current crds.yaml in chart) and the 0.13.9 version, which this chart claims to be.

### Benefits

The benefit of having a metallb version with all intended features, instead of the newest chart with inaccessible settings/features.

### Possible drawbacks

None that come to mind

### Applicable issues

- fixes #15745 
- fixes metallb up to version 0.13.9

### Additional information

PLEASE UPDATE THE CRDS.YAML ON EACH VERSION UPDATE!!!

Copied crds.yaml from metallb into this project keeping bitnami specific modifications.
Diffs between 0.13.4 bitnami and 0.13.4 metallb found that keep release parameters correct in this chart. These bitnami modifications were left intact for the commits made by me.

### Tests

The addition of the interfaces block (commit 0.13.4 to 0.13.7) is being used by me in a project.
The 0.13.7 to 0.13.9 commit has not yet been tested.
The added yaml is directly from metallb and as intended by the metallb team. 


