### PR TITLE
[bitnami/minio] Bumb version of chart for resolve issue #15718.

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
-version: 12.2.2
+version: 12.2.3


### PR DESCRIPTION
Bumb version of chart for resolve issue #15718.

It is as written by @justusbunsi. Auto merge bumb version before accepting pull request and ci pipeline does not release a fixed version of helm chart.


### Description of the change

- Bumb version for release new helm chart version

### Benefits

Final fix issue #15718

### Possible drawbacks

<!-- Describe any known limitations with your change -->

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #15718

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
