### PR TITLE
[bitnami/external-dns] Add RBAC to support F5 VirtualServer external-dns source

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/containers/tree/main/bitnami/external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.15.1
+version: 6.16.0

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/containers/tree/main/bitnami/external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.15.0
+version: 6.15.1

--- a/bitnami/external-dns/templates/clusterrole.yaml
+++ b/bitnami/external-dns/templates/clusterrole.yaml
@@ -104,6 +104,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - cis.f5.com
+    resources:
+      - virtualservers
+    verbs:
+      - get
+      - watch
+      - list
   {{- if or .Values.crd.create .Values.crd.apiversion }}
   - apiGroups:
       {{- if .Values.crd.create }}


### PR DESCRIPTION
### Description of the change

With these recently merged PRs in upstream:
https://github.com/kubernetes-sigs/external-dns/pull/3503 - RBAC added upstream in `external-dns` helm chart.
https://github.com/kubernetes-sigs/external-dns/pull/3162 - code changes in `external-dns`.

we now need to add the same RBAC to this chart to be able to configure `external-dns` to list F5 `VirtualServer` objects in the cluster.

### Benefits

We'll be able to configure the `--source=f5-virtualserver` flag which instructs `external-dns` to list all `VirtualServer` objects in the cluster, these objects will be used as a source to create DNS records in the given provider.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
