### PR TITLE
[bitnami/mariadb] nodePort only accepts integer values

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 11.5.5
+version: 11.5.6

--- a/bitnami/mariadb/templates/primary/svc.yaml
+++ b/bitnami/mariadb/templates/primary/svc.yaml
@@ -45,8 +45,6 @@ spec:
       targetPort: mysql
       {{- if (and (or (eq .Values.primary.service.type "NodePort") (eq .Values.primary.service.type "LoadBalancer")) (coalesce .Values.primary.service.nodePorts.mysql .Values.primary.service.nodePort)) }}
       nodePort: {{ coalesce .Values.primary.service.nodePorts.mysql .Values.primary.service.nodePort }}
-      {{- else if eq .Values.primary.service.type "ClusterIP" }}
-      nodePort: null
       {{- end }}
     {{- if and .Values.metrics.enabled (gt (.Values.primary.service.ports.metrics | int) 0) }}
     - name: metrics

--- a/bitnami/mariadb/templates/secondary/svc.yaml
+++ b/bitnami/mariadb/templates/secondary/svc.yaml
@@ -46,8 +46,6 @@ spec:
       targetPort: mysql
       {{- if (and (or (eq .Values.secondary.service.type "NodePort") (eq .Values.secondary.service.type "LoadBalancer")) (coalesce .Values.secondary.service.nodePorts.mysql .Values.secondary.service.nodePort)) }}
       nodePort: {{ coalesce .Values.secondary.service.nodePorts.mysql .Values.secondary.service.nodePort }}
-      {{- else if eq .Values.secondary.service.type "ClusterIP" }}
-      nodePort: null
       {{- end }}
     {{- if and .Values.metrics.enabled (gt (.Values.secondary.service.ports.metrics | int) 0) }}
     - name: metrics


### PR DESCRIPTION
### Description of the change

This is not an error. This is just removing setting nodePort to null, to ensure generated manifest will pass validation.

Removes setting NodePort to null, when Service is of type ClusterIP.
`null` is not valid. nodePort expects integer.

```
Incorrect type. Expected "integer".yaml-schema: kubernetes://schema/io.k8s.api.core.v1.serviceport
```

### Benefits

Ensures that if future versions of Kubernetes will enforce valid values will not trigger an unexpected error.

### Possible drawbacks

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
