### PR TITLE
[bitnami/metallb] add option to skip CRD install

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -29,4 +29,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
-version: 4.1.23
+version: 4.2.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -74,6 +74,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`        |
 | `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)              | `["sleep"]`    |
 | `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                 | `["infinity"]` |
+| `installCRDs`            | Flag to install metallb CRDs                                                            | `true`         |
 
 ### MetalLB parameters
 

--- a/bitnami/metallb/templates/crds.yaml
+++ b/bitnami/metallb/templates/crds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 # Based on: https://github.com/metallb/metallb/blob/v0.13.9/charts/metallb/charts/crds/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1232,3 +1233,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -49,6 +49,9 @@ diagnosticMode:
   ##
   args:
     - infinity
+## @param installCRDs Flag to install metallb CRDs
+##
+installCRDs: true
 ## @section MetalLB parameters
 
 ## RBAC creation for controller and speaker


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add a flag to skip CRD install in te metallb chart, for example if CRDs are managed externally.
### Benefits

Allows management of CRDs by other resources than helm or before this chart gets applied.
### Possible drawbacks

none
### Applicable issues

none

### Additional information

none
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
