### PR TITLE
[bitnami/kafka] Keep intermediate certs in PEM server certificate chain

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 21.4.4
+version: 21.4.5

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -192,7 +192,8 @@ data:
                 exit 1
             fi
             echo $FIND_CA_RESULT | sort | xargs cat >> "$PEM_CA_LOCATION"
-            cat ${CERT_DIR}/xx00 > "$PEM_CERT_LOCATION"
+            # keep whole chain in kafka.keystore.pem
+            cp "$PEM_CERT" "$PEM_CERT_LOCATION"
         {{- else }}
             if [[ -f "$PEM_CA" ]]; then
                 cp "$PEM_CA" "$PEM_CA_LOCATION"


### PR DESCRIPTION
### Description of the change

The *setup.sh* script from the *scripts-configmap* currently removes all intermediary certificates from the configured server certificate chain provided in a tls.crt PEM file as created by k8s cert-manager.

This effectively prevents the kafka broker to include any of the intermediary certificates in a TLS handshake with a peer/client.

### Benefits

The PEM file is now being copied as-is to the kafka container.

However, this change alone does not fix the issue yet because the kafka_configure_ssl() function from the "libkafka.sh" bitnami kafka container helper library transforms the keystore PEM file to a multi-line string to be include in the server.properties in a way that is not compatible with the regular expression used by kafka's DefaultSslEngineFactory$PemParser.pemEntries() method when starting up the broker. The regular expression only matches the last certificate in the chain which leads to the broker only serving this certificate in TLS handshakes.

### Applicable issues

This is a pre-requisite for fixing #14600

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
