### PR TITLE
[bitnami/harbor] Update ingress portal path to the last

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
-version: 16.4.9
+version: 16.4.10

--- a/bitnami/harbor/templates/ingress/core-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/core-ingress.yaml
@@ -91,12 +91,6 @@ spec:
             pathType: {{ .Values.ingress.core.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
-          - path: {{ .portal_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
-            pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
-
     {{- end }}
     {{- range .Values.ingress.core.extraHosts }}
     - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}

--- a/bitnami/harbor/templates/ingress/core-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/core-ingress.yaml
@@ -61,11 +61,6 @@ spec:
           {{- if .Values.ingress.core.extraPaths }}
           {{- toYaml .Values.ingress.core.extraPaths | nindent 10 }}
           {{- end }}
-          - path: {{ .portal_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
-            pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
           - path: {{ .api_path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
@@ -91,6 +86,17 @@ spec:
             pathType: {{ .Values.ingress.core.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
+          - path: {{ .portal_path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.core.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
+          - path: {{ .portal_path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.core.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
+
     {{- end }}
     {{- range .Values.ingress.core.extraHosts }}
     - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}


### PR DESCRIPTION
### Description of the change
Change ingress portal_path to the last path to support ingress ALB load balancer.
The problem is the same at [issue](https://github.com/goharbor/harbor-helm/issues/485) at harbor official helm chart and fixed [here](https://github.com/goharbor/harbor-helm/commit/3036f2bf4f7f3b6e679805073c8fe43cdb67f7da5).

### Benefits
Can use harbor throught AWS ALB ingress controller

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
