### PR TITLE
[bitnami/charts] Allow empty runtime-parameters

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -181,14 +181,20 @@ jobs:
           if [[ -f $config_file ]]; then
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
+          runtime_parameters_file=""
+          if [[ -f ".vib/${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml" ]]; then
+            # The path is relative to the .vib folder
+            runtime_parameters_file="${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml"
+          fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
+          echo "runtime_parameters_file=${runtime_parameters_file}" >> $GITHUB_OUTPUT
       - uses: vmware-labs/vmware-image-builder-action@v0
         name: Verify and publish ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json
           config: charts/.vib/
           verification-mode: ${{ steps.get-asset-vib-config.outputs.verification_mode }}
-          runtime-parameters-file: ${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml
+          runtime-parameters-file: ${{ steps.get-asset-vib-config.outputs.runtime_parameters_file }}
         env:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -119,13 +119,19 @@ jobs:
           if [[ -f $config_file ]]; then
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
+          runtime_parameters_file=""
+          if [[ -f ".vib/${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml" ]]; then
+            # The path is relative to the .vib folder
+            runtime_parameters_file="${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml"
+          fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
+          echo "runtime_parameters_file=${runtime_parameters_file}" >> $GITHUB_OUTPUT
       - uses: vmware-labs/vmware-image-builder-action@v0
         name: Verify ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
           verification-mode: ${{ steps.get-asset-vib-config.outputs.verification_mode }}
-          runtime-parameters-file: ${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml
+          runtime-parameters-file: ${{ steps.get-asset-vib-config.outputs.runtime_parameters_file }}
         env:
           # Target-Platform used by default
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}


### PR DESCRIPTION
### Description of the change

Don't set runtime-parameters.yaml file when it doesn't exist.

### Benefits

Prevent pipeline failures because the file doesnt exist.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Releated to #15855


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
