### PR TITLE
[bitnami/charts] Fix charts path in CD pipeline

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -183,7 +183,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           runtime_parameters_file=""
-          if [[ -f ".vib/${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml" ]]; then
+          if [[ -f "charts/.vib/${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml" ]]; then
             # The path is relative to the .vib folder
             runtime_parameters_file="${{ needs.get-chart.outputs.chart }}/runtime-parameters.yaml"
           fi


### PR DESCRIPTION
### Description of the change

Amend charts path in CD pipeline.

### Benefits

Fix broken pipelines

### Possible drawbacks

None

### Applicable issues
- Related to this failure: https://github.com/bitnami/charts/actions/runs/4610178340/attempts/2

### Additional information

Follow up: #15960
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
