### PR TITLE
[bitnami/charts] Allow CD pipeline retries

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -1,5 +1,15 @@
 name: '[CI/CD] CD Pipeline'
+run-name: "${{ github.event_name == 'workflow_dispatch' && (inputs.title != '' && inputs.title || format('Retrying SHA: {0}', inputs.sha)) || '' }}"
 on: # rebuild any PRs and main branch changes
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit to retry'
+        required: true
+        default: 'HEAD'
+      title:
+        description: 'Workflow title'
+        required: false
   push:
     branches:
       - main
@@ -126,6 +136,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: charts
+          ref: ${{github.event_name == 'workflow_dispatch' && inputs.sha || '' }}
           fetch-depth: 2 # to be able to obtain files changed in the latest commit
       - id: get-chart
         name: 'Get modified charts'
@@ -171,6 +182,7 @@ jobs:
         name: Checkout Repository
         with:
           path: charts
+          ref: ${{github.event_name == 'workflow_dispatch' && inputs.sha || '' }}
       - id: get-asset-vib-config
         name: Get asset-specific configuration for VIB action
         run: |


### PR DESCRIPTION
### Description of the change

Change CD pipeline workflow to listen on `workflow_dispacth` events. 

### Benefits

This will allow us to retry particular commits with latest workflow code. Useful to retry particular commits after an error in the implementation of the workflow.

### Possible drawbacks

None identified

### Applicable issues

Useful to retry failed executions like these:
- https://github.com/bitnami/charts/actions/runs/4610178340
- https://github.com/bitnami/charts/actions/runs/4610256619
- https://github.com/bitnami/charts/actions/runs/4611773086

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
