### PR TITLE
[bitnami/metallb] Provide a flag for disabling BGP speakers

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -29,4 +29,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
-version: 4.2.0
+version: 4.3.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -184,7 +184,8 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Speaker parameters
 
 | Name                                                        | Description                                                                                                                                 | Value                     |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+|-------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
+| `speaker.enabled`                                           | MetalLB enable Speaker                                                                                                                      | `true`                    |
 | `speaker.image.registry`                                    | MetalLB Speaker image registry                                                                                                              | `docker.io`               |
 | `speaker.image.repository`                                  | MetalLB Speaker image repository                                                                                                            | `bitnami/metallb-speaker` |
 | `speaker.image.tag`                                         | MetalLB Speaker  image tag (immutable tags are recommended)                                                                                 | `0.13.9-debian-11-r11`    |

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -184,8 +184,8 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Speaker parameters
 
 | Name                                                        | Description                                                                                                                                 | Value                     |
-|-------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
-| `speaker.enabled`                                           | MetalLB enable Speaker                                                                                                                      | `true`                    |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `speaker.enabled`                                           | Whether to enable BGP speakers or not                                                                                                       | `true`                    |
 | `speaker.image.registry`                                    | MetalLB Speaker image registry                                                                                                              | `docker.io`               |
 | `speaker.image.repository`                                  | MetalLB Speaker image repository                                                                                                            | `bitnami/metallb-speaker` |
 | `speaker.image.tag`                                         | MetalLB Speaker  image tag (immutable tags are recommended)                                                                                 | `0.13.9-debian-11-r11`    |

--- a/bitnami/metallb/templates/rbac.yaml
+++ b/bitnami/metallb/templates/rbac.yaml
@@ -38,7 +38,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "metallb.controller.serviceAccountName" . }}
 {{- end }}
-{{- if .Values.speaker.rbac.create }}
+{{- if and .Values.speaker.enabled .Values.speaker.rbac.create }}
   - kind: ServiceAccount
     name: {{ include "metallb.speaker.serviceAccountName" . }}
 {{- end }}

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.speaker.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -162,3 +163,4 @@ spec:
       {{- if .Values.speaker.extraVolumes }}
       volumes: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/bitnami/metallb/templates/speaker/psp.yaml
+++ b/bitnami/metallb/templates/speaker/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.speaker.enabled }}
 {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
 {{- if and $pspAvailable .Values.psp.create .Values.speaker.psp.create -}}
 apiVersion: policy/v1beta1
@@ -40,4 +41,5 @@ spec:
   - configMap
   - secret
   - emptyDir
+{{- end -}}
 {{- end -}}

--- a/bitnami/metallb/templates/speaker/rbac.yaml
+++ b/bitnami/metallb/templates/speaker/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.speaker.rbac.create -}}
+{{- if and .Values.speaker.enabled .Values.rbac.create .Values.speaker.rbac.create -}}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:

--- a/bitnami/metallb/templates/speaker/secret.yaml
+++ b/bitnami/metallb/templates/speaker/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.speaker.enabled }}
 {{- if not .Values.speaker.secretName }}
 apiVersion: v1
 kind: Secret
@@ -17,4 +18,5 @@ metadata:
     {{- end }}
 data:
   {{ include "metallb.speaker.secretKey" . }}: {{ include "common.secrets.passwords.manage" (dict "secret" ( include "metallb.speaker.secretName" .) "key" ( include "metallb.speaker.secretKey" .) "providedValues" (list "speaker.secretValue") "length" 256 "context" $) }}
+{{- end }}
 {{- end }}

--- a/bitnami/metallb/templates/speaker/service.yaml
+++ b/bitnami/metallb/templates/speaker/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.speaker.metrics.enabled }}
+{{- if and .Values.speaker.enabled .Values.speaker.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/bitnami/metallb/templates/speaker/serviceaccount.yaml
+++ b/bitnami/metallb/templates/speaker/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.speaker.serviceAccount.create }}
+{{- if and .Values.speaker.enabled .Values.speaker.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/metallb/templates/speaker/servicemonitor.yaml
+++ b/bitnami/metallb/templates/speaker/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.speaker.metrics.enabled .Values.speaker.metrics.serviceMonitor.enabled }}
+{{- if and .Values.speaker.enabled .Values.speaker.metrics.enabled .Values.speaker.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -448,6 +448,11 @@ controller:
 ## ref: https://hub.docker.com/r/bitnami/metallb-speaker/tags
 ##
 speaker:
+  ## @param speaker.enabled Whether to enable BGP speakers or not
+  ## ref: https://metallb.universe.tf/configuration/calico/#the-easy-way
+  ## Some CNI implementations (e.g. Calico) does not require speakers
+  ##
+  enabled: true
   ## @param speaker.image.registry MetalLB Speaker image registry
   ## @param speaker.image.repository MetalLB Speaker image repository
   ## @param speaker.image.tag MetalLB Speaker  image tag (immutable tags are recommended)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Provide an option for disabling BGP speakers. Some CNIs (most prominent being calico) do not need speakers and Metallb recommends disabling speakers when working with calico installation.

Reference: https://metallb.universe.tf/configuration/calico/#the-easy-way

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Clusters using Calico can disable metallb speakers and save resources

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #8742

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
