### PR TITLE
[bitnami/fluentd] Fix `resourceNames` attribute in `ClusterRole` to use correct name of PSP

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
-version: 5.6.3
+version: 5.6.4

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
     resources:
       - "podsecuritypolicies"
     resourceNames:
-      - {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "forwarder" | trunc 63 | trimSuffix "-" }}
+      - {{ printf "%s-%s" (include "common.names.fullname" .) "forwarder" | trunc 63 | trimSuffix "-" }}
     verbs:
       - "use"
   {{- end }}


### PR DESCRIPTION
Fixing the `resourceNames` attribute to use the correct name of PSP without `namespace`. Currently the value assigned to `resourceNames` uses the PSP name with `namespace` which is wrong.

### Description of the change

PSP resource name [created here](https://github.com/bitnami/charts/blob/main/bitnami/fluentd/templates/forwarder-psp.yaml#L6) is without namespace. So need to reference with same name in the ClusterRole under the attribute `resourceNames`

Below is the error while performing the upgrade of fluentd-forwader helm chart with PSP enabled due to the wrong reference of PSP name in ClusterRole

`Error creating: pods "<name>-fluentd-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.securityContext.fsGroup: Invalid value: []int64{0}: group 0 must be in the ranges: [{1 65535}] spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.runAsUser: Invalid value: 0: running with the root UID is forbidden]`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
