### PR TITLE
[bitnami/keycloak] Drop unnecessary secret mount in Keycloak container

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 14.1.0
+version: 14.2.0

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -161,10 +161,6 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
             {{- end }}
-            {{- if and .Values.externalDatabase.existingSecret (not .Values.postgresql.enabled) }}
-            - secretRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.externalDatabase.existingSecret "context" $) }}
-            {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

This PR removes the "explicit" mount of `externalDatabase.existingSecret` in the Keycloak container, due to the fact that it's already provided as `KEYCLOAK_DATABASE_PASSWORD`.
See https://github.com/bitnami/charts/blob/main/bitnami/keycloak/templates/statefulset.yaml#L118 and https://github.com/bitnami/charts/blob/main/bitnami/keycloak/templates/_helpers.tpl#L163 for the details on how `KEYCLOAK_DATABASE_PASSWORD` gets populated.

### Benefits

This code change avoids having *two* environment variables with a similar purpose being generated, as in:
```yaml
containers:
  - name: keycloak
    env:
      - name: KEYCLOAK_DATABASE_PASSWORD
        valueFrom:
          secretKeyRef:
            key: password
            name: database-credentials
    envFrom:
      - secretRef:
          name: database-credentials
```
With the following values:
```yaml
externalDatabase:
  ...
  existingSecret: database-credentials
  existingSecretPasswordKey: password
  ...
```
Producing in my case those 2 environment variables in the Keycloak container:
```
$ env
...
KEYCLOAK_DATABASE_PASSWORD=the-database-secret-password
password=the-database-secret-password
...
```

### Possible drawbacks

Backward compatibility with people directly using (the property declared in) `externalDatabase.existingSecret` in their deployment??

### Additional information

Back in 2021, https://github.com/bitnami/charts/pull/5844 added the ability to use `existingSecret` in combination with `externalDatabase`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
