### PR TITLE
[bitnami/etcd] Add support for dynamic snapshot dir in snapshotter cronjob

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/etcd
   - https://coreos.com/etcd/
-version: 8.8.3
+version: 8.9.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -279,6 +279,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `disasterRecovery.cronjob.schedule`             | Schedule in Cron format to save snapshots                               | `*/30 * * * *` |
 | `disasterRecovery.cronjob.historyLimit`         | Number of successful finished jobs to retain                            | `1`            |
 | `disasterRecovery.cronjob.snapshotHistoryLimit` | Number of etcd snapshots to retain, tagged by date                      | `1`            |
+| `disasterRecovery.cronjob.snapshotsDir`         | Directory to store snapshots                                            | `/snapshots`   |
 | `disasterRecovery.cronjob.podAnnotations`       | Pod annotations for cronjob pods                                        | `{}`           |
 | `disasterRecovery.cronjob.resources.limits`     | Cronjob container resource limits                                       | `{}`           |
 | `disasterRecovery.cronjob.resources.requests`   | Cronjob container resource requests                                     | `{}`           |

--- a/bitnami/etcd/templates/cronjob.yaml
+++ b/bitnami/etcd/templates/cronjob.yaml
@@ -86,6 +86,8 @@ spec:
                   value: {{ printf "%s.%s.svc.%s" $etcdHeadlessServiceName $releaseNamespace $clusterDomain | quote }}
                 - name: ETCD_SNAPSHOT_HISTORY_LIMIT
                   value: {{ .Values.disasterRecovery.cronjob.snapshotHistoryLimit | quote }}
+                - name: ETCD_SNAPSHOTS_DIR
+                  value: {{ .Values.disasterRecovery.cronjob.snapshotsDir | quote }}
                 {{- if .Values.auth.client.secureTransport }}
                 - name: ETCD_CERT_FILE
                   value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certFilename }}"
@@ -123,7 +125,7 @@ spec:
             {{- if .Values.auth.client.secureTransport }}
             - name: certs
               secret:
-                secretName: {{ required "A secret containinig the client certificates is required" (tpl .Values.auth.client.existingSecret .) }}
+                secretName: {{ required "A secret containing the client certificates is required" (tpl .Values.auth.client.existingSecret .) }}
                 defaultMode: 256
             {{- end }}
             - name: snapshot-volume

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -816,6 +816,9 @@ disasterRecovery:
     ## @param disasterRecovery.cronjob.snapshotHistoryLimit Number of etcd snapshots to retain, tagged by date
     ##
     snapshotHistoryLimit: 1
+    ## @param disasterRecovery.cronjob.snapshotsDir Directory to store snapshots
+    ##
+    snapshotsDir: "/snapshots"
     ## @param disasterRecovery.cronjob.podAnnotations [object] Pod annotations for cronjob pods
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##


### PR DESCRIPTION
### Description of the change

bitnami/etcd: Add ability to dynamically specify snapshot directory.

### Benefits

This allows multiple clusters to leverage the same snapshotting PVC.

### Possible drawbacks

Can't think of any, the variable will default to the current value (/snapshots).

### Applicable issues

N/A

### Additional information

Testing:

```
pit:~/brad # kubectl logs -n services cray-bos-bitnami-etcd-snapshotter-28020465-q67ds
etcd 15:45:06.17 DEBUG ==> Using endpoint cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2379
cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2379 is healthy: successfully committed proposal: took = 50.561429ms
etcd 15:45:06.27 INFO  ==> Snapshotting the keyspace
{"level":"info","ts":"2023-04-11T15:45:06.303Z","caller":"snapshot/v3_snapshot.go:65","msg":"created temporary db file","path":"/snapshots/cray-bos-bitnami-etcd/db-2023-04-11_15-45.part"}
{"level":"info","ts":"2023-04-11T15:45:06.306Z","logger":"client","caller":"v3@v3.5.7/maintenance.go:212","msg":"opened snapshot stream; downloading"}
{"level":"info","ts":"2023-04-11T15:45:06.306Z","caller":"snapshot/v3_snapshot.go:73","msg":"fetching snapshot","endpoint":"cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2379"}
{"level":"info","ts":"2023-04-11T15:45:06.350Z","logger":"client","caller":"v3@v3.5.7/maintenance.go:220","msg":"completed snapshot read; closing"}
{"level":"info","ts":"2023-04-11T15:45:06.417Z","caller":"snapshot/v3_snapshot.go:88","msg":"fetched snapshot","endpoint":"cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2379","size":"25 kB","took":"now"}
{"level":"info","ts":"2023-04-11T15:45:06.418Z","caller":"snapshot/v3_snapshot.go:97","msg":"saved","path":"/snapshots/cray-bos-bitnami-etcd/db-2023-04-11_15-45"}
Snapshot saved at /snapshots/cray-bos-bitnami-etcd/db-2023-04-11_15-45
```

Thanks for considering the pull request!

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
