### PR TITLE
[bitnami/matomo] Fix probe paths

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -30,4 +30,4 @@ name: matomo
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/matomo
   - https://www.matomo.org/
-version: 0.2.30
+version: 0.2.31

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -143,21 +143,21 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerSecurityContext.runAsUser`    | Matomo containers' Security Context                                                                                   | `1001`                |
 | `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                              | `true`                |
 | `startupProbe.enabled`                  | Enable startupProbe                                                                                                   | `false`               |
-| `startupProbe.path`                     | Request path for startupProbe                                                                                         | `/`                   |
+| `startupProbe.path`                     | Request path for startupProbe                                                                                         | `/matomo.php`         |
 | `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                | `600`                 |
 | `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                       | `10`                  |
 | `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                      | `5`                   |
 | `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                    | `5`                   |
 | `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                    | `1`                   |
 | `livenessProbe.enabled`                 | Enable livenessProbe                                                                                                  | `true`                |
-| `livenessProbe.path`                    | Request path for livenessProbe                                                                                        | `/`                   |
+| `livenessProbe.path`                    | Request path for livenessProbe                                                                                        | `/matomo.php`         |
 | `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                               | `600`                 |
 | `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                      | `10`                  |
 | `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                     | `5`                   |
 | `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                   | `5`                   |
 | `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                   | `1`                   |
 | `readinessProbe.enabled`                | Enable readinessProbe                                                                                                 | `true`                |
-| `readinessProbe.path`                   | Request path for readinessProbe                                                                                       | `/`                   |
+| `readinessProbe.path`                   | Request path for readinessProbe                                                                                       | `/matomo.php`         |
 | `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                              | `30`                  |
 | `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                     | `5`                   |
 | `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                    | `1`                   |

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -354,7 +354,7 @@ containerSecurityContext:
 ##
 startupProbe:
   enabled: false
-  path: /
+  path: /matomo.php
   initialDelaySeconds: 600
   periodSeconds: 10
   timeoutSeconds: 5
@@ -376,7 +376,7 @@ startupProbe:
 ##
 livenessProbe:
   enabled: true
-  path: /
+  path: /matomo.php
   initialDelaySeconds: 600
   periodSeconds: 10
   timeoutSeconds: 5
@@ -398,7 +398,7 @@ livenessProbe:
 ##
 readinessProbe:
   enabled: true
-  path: /
+  path: /matomo.php
   initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 1


### PR DESCRIPTION
### Description of the change

The proviced readiness and liveness probes don't work because matomo responses with redirects to https and port 443 on its base path. As documented [in the matomo faq](https://matomo.org/faq/how-to/faq_20278/) health checks can point to `/matomo.php`. 
This has been discussed in this [issue](https://github.com/bitnami/charts/issues/15793).

### Benefits

Out of the box, the probes won't work right now with the bitnami chart. With this change, the probes will work again.

### Possible drawbacks

Can't think of any.

### Applicable issues

- fixes #15793

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
