### PR TITLE
[bitnami/jupyterhub] Remove UID and GID user verification test for jupyterhub

### DIFF
--- a/.vib/jupyterhub/goss/goss.yaml
+++ b/.vib/jupyterhub/goss/goss.yaml
@@ -23,8 +23,6 @@ file:
     owner: root
     contains:
     - postgresql://{{ .Vars.postgresql.auth.username }}@jupyterhub-postgresql:{{ .Vars.postgresql.service.ports.postgresql }}/{{ .Vars.postgresql.auth.database }}
-    - /uid.*{{ .Vars.singleuser.containerSecurityContext.runAsUser }}/
-    - /fsGid.*{{ .Vars.singleuser.podSecurityContext.fsGroup }}/
     - /type.*dynamic/
 command:
   {{- $uid := .Vars.hub.containerSecurityContext.runAsUser }}

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 3.0.13
+version: 3.0.14


### PR DESCRIPTION
### Description of the change

It has been decided to remove the uid and gid verification because it is failing on other platforms such as openShift.

### Checklist
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
