### PR TITLE
[bitnami/schema-registry] Allow mounting the .Values.auth.tls.jksSecret secret in the certs folder

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/schema-registry
-version: 9.0.3
+version: 9.0.4

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -254,7 +254,7 @@ spec:
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
-      {{- if or .Values.configuration .Values.existingConfigmap  .Values.log4j .Values.existingLog4jConfigMap (contains "SSL" $kafkaProtocol) .Values.extraVolumes }}
+      {{- if or .Values.configuration .Values.existingConfigmap  .Values.log4j .Values.existingLog4jConfigMap (contains "SSL" $kafkaProtocol) .Values.auth.tls.enabled .Values.extraVolumes }}
       volumes:
         {{- if or .Values.configuration .Values.existingConfigmap }}
         - name: configuration
@@ -266,11 +266,19 @@ spec:
           configMap:
             name: {{ include "schema-registry.log4j.configmapName" . }}
         {{ end }}
-        {{- if contains "SSL" $kafkaProtocol }}
+        {{- if or (contains "SSL" $kafkaProtocol) .Values.auth.tls.enabled }}
         - name: certificates
-          secret:
-            secretName: {{ printf "%s" (tpl .Values.auth.kafka.jksSecret $) }}
-            defaultMode: 256
+          projected:
+            defaultMode: 0400
+            sources:
+            {{- if contains "SSL" $kafkaProtocol }}
+            - secret:
+                name: {{ printf "%s" (tpl .Values.auth.kafka.jksSecret $) }}
+            {{ end }}
+            {{- if .Values.auth.tls.enabled }}
+            - secret:
+                name: {{ printf "%s" (tpl .Values.auth.tls.jksSecret $) }}
+            {{ end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The .Values.auth.tls.jksSecret parameter was not used at all in the schema-registry chart when we have document it in the README and values files. 

### Benefits

<!-- What benefits will be realized by the code change? -->

Allow mounting the TLS certs when required

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None as this doesn't modify the default configuration

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/15771

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

I rendered the templates and the volume appeared in the statefulset.yaml file.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
