### PR TITLE
[bitnami/kafka] kraft.clusterId format doc (again)

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -469,13 +469,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kraft chart parameters
 
-| Name                            | Description                                                                             | Value                    |
-| ------------------------------- | --------------------------------------------------------------------------------------- | ------------------------ |
-| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                    | `false`                  |
-| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them. | `broker,controller`      |
-| `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`             |
-| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `kafka_cluster_id_test1` |
-| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.         | `""`                     |
+| Name                            | Description                                                                                                                     | Value                    |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                                                            | `false`                  |
+| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them.                                         | `broker,controller`      |
+| `kraft.controllerListenerNames` | Controller listener names                                                                                                       | `CONTROLLER`             |
+| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node and it should match the regex `[a-zA-Z0-9_\-]{22}. | `kafka_cluster_id_test1` |
+| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.                                                 | `""`                     |
 
 ### ZooKeeper chart parameters
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1747,7 +1747,7 @@ kraft:
   ## @param kraft.controllerListenerNames Controller listener names
   ##
   controllerListenerNames: CONTROLLER
-  ## @param kraft.clusterId Kafka ClusterID. You must set it if your cluster contains more than one node.
+  ## @param kraft.clusterId Kafka ClusterID. You must set it if your cluster contains more than one node and it should match the regex `[a-zA-Z0-9_\-]{22}.
   ## Generate with `cat /proc/sys/kernel/random/uuid | tr -d '-' | base64 | cut -b 1-22`. Run `export LC_ALL=C` before if you generate it on MacOS.
   ## Example: k2yipv1sRue7z2_Y3o976A
   ##


### PR DESCRIPTION
Add a regex from https://cwiki.apache.org/confluence/display/KAFKA/KIP-78%3A+Cluster+Id with details of a valid format

This is a resubmission of commit 43b10fc0625010e34d06d3bebf66c8c120887087 (https://github.com/bitnami/charts/pull/15519), which was made directly to the `README.md`, and so was overwritten by the docs generator script.

### Description of the change

Docs/Readme clarification

### Benefits

Less wasted time on invalid configuration

### Possible drawbacks

None (docs addition)

### Applicable issues

#13624 (see comments)

### Additional information

The example/default turns out to be a valid ID but that is entirely not obvious from looking at it (without knowing the required format).

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
