### PR TITLE
[bitnami/spring-cloud-dataflow] Upgrade MariaDB to version 10.11

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 11.13.0
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.5.7
+  version: 12.0.0
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.4.4
+  version: 21.4.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:3b960d8012c102bf01611593cb5c09908785e95e04b5ae904d8e3a752f582fdd
-generated: "2023-04-20T09:37:05.484988+02:00"
+digest: sha256:fe31e31465bb9f8cacf12813a88682666ee7873b5c06696a4c8c9d64ec2faa25
+generated: "2023-04-21T17:33:32.960597+02:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - dataflow-database
-    version: 11.x.x
+    version: 12.x.x
   - condition: kafka.enabled
     name: kafka
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 16.1.0
+version: 17.0.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -657,6 +657,10 @@ Find more information about how to deal with common errors related to Bitnami He
 
 If you enabled RabbitMQ chart to be used as the messaging solution for Skipper to manage streaming content, then it's necessary to set the `rabbitmq.auth.password` and `rabbitmq.auth.erlangCookie` parameters when upgrading for readiness/liveness probes to work properly. Inspect the RabbitMQ secret to obtain the password and the Erlang cookie, then you can upgrade your chart using the command below:
 
+### To 17.0.0
+
+This major release bumps the MariaDB version to 10.11. Follow the [upstream instructions](https://mariadb.com/kb/en/upgrading-from-mariadb-10-6-to-mariadb-10-11/) for upgrading from MariaDB 10.6 to 10.11. No major issues are expected during the upgrade.
+
 ### To 16.0.0
 
 This major updates the Kafka subchart to its newest major, 21.0.0. [Here](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2100) you can find more information about the changes introduced in that version.


### PR DESCRIPTION
### Description of the change

It bumps the MariaDB version to 10.11. 

### Benefits

Use latest LTS version for MariaDB

### Possible drawbacks

N/A

### Applicable issues

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
