### PR TITLE
[bitnami/prestashop] Upgrade MariaDB to version 10.11

### DIFF
--- a/bitnami/prestashop/Chart.lock
+++ b/bitnami/prestashop/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.5.7
+  version: 12.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:d1cd39becdc633408c58a5232dff5560569fa02b67810a916f6b6063aa5a0e96
-generated: "2023-04-20T09:36:06.466784+02:00"
+digest: sha256:dfb02da0eb35260bb01a0c9e07a464e5b0041fa042685e709e86710f688e7027
+generated: "2023-04-21T17:37:32.805819+02:00"

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 11.x.x
+    version: 12.x.x
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
@@ -29,4 +29,4 @@ name: prestashop
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prestashop
   - https://prestashop.com/
-version: 16.1.0
+version: 17.0.0

--- a/bitnami/prestashop/README.md
+++ b/bitnami/prestashop/README.md
@@ -419,6 +419,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 17.0.0
+
+This major release bumps the MariaDB version to 10.11. Follow the [upstream instructions](https://mariadb.com/kb/en/upgrading-from-mariadb-10-6-to-mariadb-10-11/) for upgrading from MariaDB 10.6 to 10.11. No major issues are expected during the upgrade.
+
 ### To 15.0.0
 
 This major release bumps the MariaDB version to 10.6. Follow the [upstream instructions](https://mariadb.com/kb/en/upgrading-from-mariadb-105-to-mariadb-106/) for upgrading from MariaDB 10.5 to 10.6. No major issues are expected during the upgrade.


### PR DESCRIPTION
### Description of the change

It bumps the MariaDB version to 10.11. 

### Benefits

Use latest LTS version for MariaDB

### Possible drawbacks

N/A

### Applicable issues

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
