### PR TITLE
[bitnami/keycloak] Use `httpRelativePath` for ingress path and service monitor endpoints

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 14.3.0
+version: 14.4.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -205,7 +205,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
 | `ingress.hostname`                 | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
-| `ingress.path`                     | Default path for the ingress record                                                                                              | `/`                      |
+| `ingress.path`                     | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`              | Backend service port to use                                                                                                      | `http`                   |
 | `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
 | `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -59,6 +59,16 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Return the path Keycloak is hosted on. This looks at httpRelativePath and returns it with a trailing slash. For example:
+    / -> / (the default httpRelativePath)
+    /auth -> /auth/ (trailing slash added)
+    /custom/ -> /custom/ (unchanged)
+*/}}
+{{- define "keycloak.httpPath" -}}
+{{ ternary .Values.httpRelativePath (printf "%s%s" .Values.httpRelativePath "/") (hasSuffix "/" .Values.httpRelativePath) }}
+{{- end -}}
+
+{{/*
 Return the Keycloak configuration configmap
 */}}
 {{- define "keycloak.configmapName" -}}

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
           {{- if .Values.ingress.extraPaths }}
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
-          - path: {{ .Values.ingress.path }}
+          - path: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.path "context" $) }}
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -25,7 +25,7 @@ spec:
     {{- range $endpoints }}
     {{- $endpoint := merge . $defaultEndpoint }}
     - port: {{ $endpoint.port }}
-      path: {{ $endpoint.path }}
+      path: {{ include "common.tplvalues.render" ( dict "value" $endpoint.path "context" $) }}
       {{- if $endpoint.interval }}
       interval: {{ $endpoint.interval }}
       {{- end }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -544,9 +544,9 @@ ingress:
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
   ##
   hostname: keycloak.local
-  ## @param ingress.path Default path for the ingress record
+  ## @param ingress.path [string] Default path for the ingress record (evaluated as template)
   ##
-  path: /
+  path: "{{ .Values.httpRelativePath }}"
   ## @param ingress.servicePort Backend service port to use
   ## Default is http. Alternative is https.
   ##
@@ -756,8 +756,8 @@ metrics:
     ## @param metrics.serviceMonitor.endpoints [array] The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten.
     ##
     endpoints:
-      - path: /metrics
-      - path: /realms/master/metrics
+      - path: '{{ include "keycloak.httpPath" . }}metrics'
+      - path: '{{ include "keycloak.httpPath" . }}realms/master/metrics'
     ## @param metrics.serviceMonitor.path Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead
     ##
     path: ""


### PR DESCRIPTION
### Description of the change

When `httpRelativePath` is set, keycloak listens on that path. If a user sets `httpRelativePath` they (optionally) need to match the same in `ingress.path` and must (if they use metrics) match the same path on `metrics.serviceMonitor.endpoints[]`.

This change automates setting these manually when setting `httpRelativePath` and improves user experience.

### Benefits

Improves user experience. No need to remember to set 4 values (`httpRelativePath`, `ingress.path`, and 2 elements of `metrics.serviceMonitor.endpoints`) when you really only want to set 1 (`httpRelativePath`).

### Possible drawbacks

None.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
