### PR TITLE
[bitnami/discourse] Add feature discourse.plugins

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 10.1.0
+version: 10.2.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -131,6 +131,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                              | Description                                                                                  | Value           |
 | ------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------- |
 | `discourse.skipInstall`                           | Do not run the Discourse installation wizard                                                 | `false`         |
+| `discourse.plugins`                               | List of plugins to be installed before the container initialization                          | `[]`            |
 | `discourse.command`                               | Custom command to override image cmd                                                         | `[]`            |
 | `discourse.args`                                  | Custom args for the custom command                                                           | `[]`            |
 | `discourse.extraEnvVars`                          | Array with extra environment variables to add Discourse pods                                 | `[]`            |

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -99,11 +99,26 @@ spec:
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.discourse.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.command "context" $) | nindent 12 }}
+          {{- else }}
+          command:
+            - /bin/bash
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.discourse.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.args "context" $) | nindent 12 }}
+          {{- else }}
+          args:
+            - -c
+            - |
+              {{- if .Values.discourse.plugins }}
+              pushd "/opt/bitnami/discourse" >/dev/null || exit
+              {{- range $plugin := .Values.discourse.plugins }}
+              RAILS_ENV=production bundle exec rake plugin:install repo={{ $plugin }}
+              {{- end }}
+              popd >/dev/null || exit
+              {{- end }}
+              /opt/bitnami/scripts/discourse/entrypoint.sh /opt/bitnami/scripts/discourse/run.sh
           {{- end }}
           env:
             - name: BITNAMI_DEBUG

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -112,11 +112,11 @@ spec:
             - -c
             - |
               {{- if .Values.discourse.plugins }}
-              pushd "/opt/bitnami/discourse" >/dev/null || exit
+              pushd "/opt/bitnami/discourse" >/dev/null || exit 1
               {{- range $plugin := .Values.discourse.plugins }}
               RAILS_ENV=production bundle exec rake plugin:install repo={{ $plugin }}
               {{- end }}
-              popd >/dev/null || exit
+              popd >/dev/null || exit 1
               {{- end }}
               /opt/bitnami/scripts/discourse/entrypoint.sh /opt/bitnami/scripts/discourse/run.sh
           {{- end }}

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -256,6 +256,7 @@ discourse:
   skipInstall: false
   ## @param discourse.plugins List of plugins to be installed before the container initialization
   ## NOTE: This will be ignored if the values 'discourse.command' or 'discourse.args' are provided.
+  ## Additionally, consider increasing the value discourse.livenessProbe.initialDelaySeconds if the container restarts before the initialization finishes.
   ## e.g:
   ## plugins:
   ##   - https://github.com/discourse/discourse-oauth2-basic

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -254,6 +254,13 @@ discourse:
   ## Use only in case you are importing an existing database.
   ##
   skipInstall: false
+  ## @param discourse.plugins List of plugins to be installed before the container initialization
+  ## NOTE: This will be ignored if the values 'discourse.command' or 'discourse.args' are provided.
+  ## e.g:
+  ## plugins:
+  ##   - https://github.com/discourse/discourse-oauth2-basic
+  ##
+  plugins: []
   ## @param discourse.command Custom command to override image cmd
   ##
   command: []


### PR DESCRIPTION
### Description of the change

Adds a new feature 'discourse.plugins' to the bitnami/discourse chart.

This feature allows users to install plugins during the container initialization, by running `rake plugin:install --repo=...` before the discourse initialization begins.

### Applicable issues

- supersedes #16009

### Additional information

Tested locally using the following values:

```
discourse:
  plugins:
    - https://github.com/discourse/discourse-oauth2-basic
```

The Oauth plugin showing in the /admin/plugins page:

![image](https://user-images.githubusercontent.com/37381070/233976675-49ec2143-6462-4648-a8cb-6c9e3773a251.png)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
