### PR TITLE
redis chart: sort alphabetically hpa metrics, fixes #16198

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.10.0
+version: 17.10.1

--- a/bitnami/redis/templates/replicas/hpa.yaml
+++ b/bitnami/redis/templates/replicas/hpa.yaml
@@ -20,18 +20,6 @@ spec:
   minReplicas: {{ .Values.replica.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.replica.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.replica.autoscaling.targetMemory }}
-    - type: Resource
-      resource:
-        name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.targetMemory }}
-        {{- else }}
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.replica.autoscaling.targetMemory }}
-        {{- end }}
-    {{- end }}
     {{- if .Values.replica.autoscaling.targetCPU }}
     - type: Resource
       resource:
@@ -42,6 +30,18 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.replica.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.replica.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.replica.autoscaling.targetMemory }}
         {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION

### Description of the change

Change the order of the HPA metrics to avoid ArgoCD incorrectly reporting OutOfSync

### Benefits

Any tool that runs `diff` between the current HPA resource and the new version before deploying, will see no difference that hasn't been intentionally made.

### Possible drawbacks

In my current production deployment, I'm using `16.13.2`. Is it possible to backport this change to a `16.13.x` version of the chart?

### Applicable issues

- fixes #16198

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
