### PR TITLE
[bitnami/nginx] Add resources for Add resources to Git-Sync. Otherwise hpa did not work

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nginx
   - https://www.nginx.org
-version: 14.0.0
+version: 14.1.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -126,6 +126,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraContainerPorts`                         | Array of additional container ports for the Nginx container                               | `[]`            |
 | `resources.limits`                            | The resources limits for the NGINX container                                              | `{}`            |
 | `resources.requests`                          | The requested resources for the NGINX container                                           | `{}`            |
+| `syncer.resources.limits`                     | The resources limits for the Syncer-container                                             | `{}`            |
+| `syncer.resources.requests`                   | The requested resources for the Syncer-container                                          | `{}`            |
 | `lifecycleHooks`                              | Optional lifecycleHooks for the NGINX container                                           | `{}`            |
 | `startupProbe.enabled`                        | Enable startupProbe                                                                       | `false`         |
 | `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                    | `30`            |

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -126,8 +126,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraContainerPorts`                         | Array of additional container ports for the Nginx container                               | `[]`            |
 | `resources.limits`                            | The resources limits for the NGINX container                                              | `{}`            |
 | `resources.requests`                          | The requested resources for the NGINX container                                           | `{}`            |
-| `syncer.resources.limits`                     | The resources limits for the Syncer-container                                             | `{}`            |
-| `syncer.resources.requests`                   | The requested resources for the Syncer-container                                          | `{}`            |
 | `lifecycleHooks`                              | Optional lifecycleHooks for the NGINX container                                           | `{}`            |
 | `startupProbe.enabled`                        | Enable startupProbe                                                                       | `false`         |
 | `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                    | `30`            |
@@ -170,28 +168,30 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Custom NGINX application parameters
 
-| Name                                       | Description                                                                                         | Value                  |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------- | ---------------------- |
-| `cloneStaticSiteFromGit.enabled`           | Get the server static content from a Git repository                                                 | `false`                |
-| `cloneStaticSiteFromGit.image.registry`    | Git image registry                                                                                  | `docker.io`            |
-| `cloneStaticSiteFromGit.image.repository`  | Git image repository                                                                                | `bitnami/git`          |
-| `cloneStaticSiteFromGit.image.tag`         | Git image tag (immutable tags are recommended)                                                      | `2.40.0-debian-11-r12` |
-| `cloneStaticSiteFromGit.image.digest`      | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
-| `cloneStaticSiteFromGit.image.pullPolicy`  | Git image pull policy                                                                               | `IfNotPresent`         |
-| `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array                                                    | `[]`                   |
-| `cloneStaticSiteFromGit.repository`        | Git Repository to clone static content from                                                         | `""`                   |
-| `cloneStaticSiteFromGit.branch`            | Git branch to checkout                                                                              | `""`                   |
-| `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the Git repository                                         | `60`                   |
-| `cloneStaticSiteFromGit.gitClone.command`  | Override default container command for git-clone-repository                                         | `[]`                   |
-| `cloneStaticSiteFromGit.gitClone.args`     | Override default container args for git-clone-repository                                            | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.command`   | Override default container command for git-repo-syncer                                              | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.args`      | Override default container args for git-repo-syncer                                                 | `[]`                   |
-| `cloneStaticSiteFromGit.extraEnvVars`      | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
-| `cloneStaticSiteFromGit.extraVolumeMounts` | Add extra volume mounts for the Git containers                                                      | `[]`                   |
-| `serverBlock`                              | Custom server block to be added to NGINX configuration                                              | `""`                   |
-| `existingServerBlockConfigmap`             | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |
-| `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static site content                                      | `""`                   |
-| `staticSitePVC`                            | Name of existing PVC with the server static site content                                            | `""`                   |
+| Name                                                | Description                                                                                         | Value                  |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
+| `cloneStaticSiteFromGit.enabled`                    | Get the server static content from a Git repository                                                 | `false`                |
+| `cloneStaticSiteFromGit.image.registry`             | Git image registry                                                                                  | `docker.io`            |
+| `cloneStaticSiteFromGit.image.repository`           | Git image repository                                                                                | `bitnami/git`          |
+| `cloneStaticSiteFromGit.image.tag`                  | Git image tag (immutable tags are recommended)                                                      | `2.40.0-debian-11-r12` |
+| `cloneStaticSiteFromGit.image.digest`               | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
+| `cloneStaticSiteFromGit.image.pullPolicy`           | Git image pull policy                                                                               | `IfNotPresent`         |
+| `cloneStaticSiteFromGit.image.pullSecrets`          | Specify docker-registry secret names as an array                                                    | `[]`                   |
+| `cloneStaticSiteFromGit.repository`                 | Git Repository to clone static content from                                                         | `""`                   |
+| `cloneStaticSiteFromGit.branch`                     | Git branch to checkout                                                                              | `""`                   |
+| `cloneStaticSiteFromGit.interval`                   | Interval for sidecar container pull from the Git repository                                         | `60`                   |
+| `cloneStaticSiteFromGit.gitClone.command`           | Override default container command for git-clone-repository                                         | `[]`                   |
+| `cloneStaticSiteFromGit.gitClone.args`              | Override default container args for git-clone-repository                                            | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.command`            | Override default container command for git-repo-syncer                                              | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.args`               | Override default container args for git-repo-syncer                                                 | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.resources.limits`   | The resources limits for the git-repo-syncer container                                              | `{}`                   |
+| `cloneStaticSiteFromGit.gitSync.resources.requests` | The requested resources for the git-repo-syncer container                                           | `{}`                   |
+| `cloneStaticSiteFromGit.extraEnvVars`               | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
+| `cloneStaticSiteFromGit.extraVolumeMounts`          | Add extra volume mounts for the Git containers                                                      | `[]`                   |
+| `serverBlock`                                       | Custom server block to be added to NGINX configuration                                              | `""`                   |
+| `existingServerBlockConfigmap`                      | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |
+| `staticSiteConfigmap`                               | Name of existing ConfigMap with the server static site content                                      | `""`                   |
+| `staticSitePVC`                                     | Name of existing PVC with the server static site content                                            | `""`                   |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -133,8 +133,8 @@ spec:
           {{- if .Values.cloneStaticSiteFromGit.gitSync.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitSync.args "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.syncer.resources }}
-          resources: {{- toYaml .Values.syncer.resources | nindent 12 }}
+          {{- if .Values.cloneStaticSiteFromGit.gitSync.resources }}
+          resources: {{- toYaml .Values.cloneStaticSiteFromGit.gitSync.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: staticsite

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -133,6 +133,9 @@ spec:
           {{- if .Values.cloneStaticSiteFromGit.gitSync.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitSync.args "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.syncer.resources }}
+          resources: {{- toYaml .Values.syncer.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: staticsite
               mountPath: /app

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -256,6 +256,30 @@ resources:
   ##    memory: 128Mi
   requests: {}
 
+## syncer containers' resource requests and limits
+## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param syncer.resources.limits The resources limits for the Syncer-container
+## @param syncer.resources.requests The requested resources for the Syncer-container
+##  
+syncer:
+  resources:
+  ## Example:
+  ## limits:
+  ##    cpu: 100m
+  ##    memory: 128Mi
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    requests: {}
+
+
+
 ## NGINX containers' lifecycleHooks
 ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -256,26 +256,13 @@ resources:
   ##    memory: 128Mi
   requests: {}
 
-## syncer containers' resource requests and limits
-## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-## We usually recommend not to specify default resources and to leave this as a conscious
-## choice for the user. This also increases chances charts run on environments with little
-## resources, such as Minikube. If you do want to specify resources, uncomment the following
-## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-## @param syncer.resources.limits The resources limits for the Syncer-container
-## @param syncer.resources.requests The requested resources for the Syncer-container
-##  
-syncer:
+  ## git-repo-syncer resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param cloneStaticSiteFromGit.gitSync.resources.limits The resources limits for the git-repo-syncer container
+  ## @param cloneStaticSiteFromGit.gitSync.resources.requests The requested resources for the git-repo-syncer container
+  ##
   resources:
-  ## Example:
-  ## limits:
-  ##    cpu: 100m
-  ##    memory: 128Mi
     limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
     requests: {}
 
 

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -264,9 +264,6 @@ resources:
   resources:
     limits: {}
     requests: {}
-
-
-
 ## NGINX containers' lifecycleHooks
 ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -255,15 +255,6 @@ resources:
   ##    cpu: 100m
   ##    memory: 128Mi
   requests: {}
-
-  ## git-repo-syncer resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param cloneStaticSiteFromGit.gitSync.resources.limits The resources limits for the git-repo-syncer container
-  ## @param cloneStaticSiteFromGit.gitSync.resources.requests The requested resources for the git-repo-syncer container
-  ##
-  resources:
-    limits: {}
-    requests: {}
 ## NGINX containers' lifecycleHooks
 ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
@@ -473,6 +464,14 @@ cloneStaticSiteFromGit:
     ## @param cloneStaticSiteFromGit.gitSync.args Override default container args for git-repo-syncer
     ##
     args: []
+    ## git-repo-syncer resource requests and limits
+    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ## @param cloneStaticSiteFromGit.gitSync.resources.limits The resources limits for the git-repo-syncer container
+    ## @param cloneStaticSiteFromGit.gitSync.resources.requests The requested resources for the git-repo-syncer container
+    ##
+    resources:
+      limits: {}
+      requests: {}
   ## @param cloneStaticSiteFromGit.extraEnvVars Additional environment variables to set for the in the containers that clone static site from git
   ## E.g:
   ## extraEnvVars:


### PR DESCRIPTION
I had problems that hpa did not work together with GitClone

Added resources to Sync-Container in deployment.
In my Test-Environment i was able to use hpa and GitClone together

Replaces #16185 