### PR TITLE
[bitnami/several] Revert changes done by mistake in Chart.yaml repo

### DIFF
--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-20T13:01:53.882500975Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:35:02.181833+02:00"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.4.57
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/apache
   - https://httpd.apache.org
-version: 9.4.1
+version: 9.5.0

--- a/bitnami/clickhouse/Chart.lock
+++ b/bitnami/clickhouse/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.2.1
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:a5ecc1fdd4d042aee16cea33c1188223b79985df62f05a1be19005e64dfad621
-generated: "2023-04-22T19:22:11.997404879Z"
+digest: sha256:6096760893ee2efeb54e10f7ecc20450eeb1265ee0ce451c07db11f4b025a9b5
+generated: "2023-04-25T10:35:08.312623+02:00"

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 11.x.x
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -26,4 +26,4 @@ name: clickhouse
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse
   - https://github.com/ClickHouse/ClickHouse
-version: 3.2.1
+version: 3.3.0

--- a/bitnami/grafana-mimir/Chart.lock
+++ b/bitnami/grafana-mimir/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.2.6
+  version: 12.3.1
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 6.3.14
@@ -15,7 +15,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 6.3.14
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:1244a65aa9a8ee3f81b4fc1441a8a4f680cdc3172bc8c8a68c0a4633d9f74e21
-generated: "2023-04-20T19:26:49.271341126Z"
+digest: sha256:36705d7bbaf0082d460c8c2d6613f1b70131bdb34b3296a0ce9cadd306d6b52a
+generated: "2023-04-25T10:35:15.196541+02:00"

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 6.x.x
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -48,4 +48,4 @@ name: grafana-mimir
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-mimir
   - https://github.com/grafana/mimir
-version: 0.3.1
+version: 0.4.0

--- a/bitnami/mariadb-galera/Chart.lock
+++ b/bitnami/mariadb-galera/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-21T12:41:14.109333664Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:36:48.543937+02:00"

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 10.11.2
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 8.0.1
+version: 8.1.0

--- a/bitnami/mariadb/Chart.lock
+++ b/bitnami/mariadb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-21T12:42:37.885250564Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:36:52.350329+02:00"

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 10.11.2
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 12.0.0
+version: 12.1.0

--- a/bitnami/minio/Chart.lock
+++ b/bitnami/minio/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-21T11:58:26.384080945Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:36:55.985643+02:00"

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2023.4.20
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
-version: 12.3.1
+version: 12.4.0

--- a/bitnami/postgresql-ha/Chart.lock
+++ b/bitnami/postgresql-ha/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-21T20:16:02.203179341Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:36:59.57912+02:00"

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 15.2.0
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -29,4 +29,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 11.4.1
+version: 11.5.0

--- a/bitnami/postgresql/Chart.lock
+++ b/bitnami/postgresql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-21T21:43:08.326299866Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:37:03.061527+02:00"

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 15.2.0
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 12.3.2
+version: 12.4.0

--- a/bitnami/tomcat/Chart.lock
+++ b/bitnami/tomcat/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-20T13:24:56.61515144Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:37:06.69384+02:00"

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 10.1.8
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/tomcat
   - http://tomcat.apache.org
-version: 10.7.1
+version: 10.8.0

--- a/bitnami/zookeeper/Chart.lock
+++ b/bitnami/zookeeper/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.4
-digest: sha256:634d19e9b7f6e4c07d7c04a0161ab96b3f83335ebdd70b35b952319ef0a2586b
-generated: "2023-04-20T13:54:08.945266062Z"
+digest: sha256:829fc25cbbb396161e735c83d152d74a8b3a82d07f08866b885b812d30b920df
+generated: "2023-04-25T10:37:10.358793+02:00"

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 3.8.1
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/zookeeper
   - https://zookeeper.apache.org/
-version: 11.2.1
+version: 11.3.0


### PR DESCRIPTION
Once applied changes from https://github.com/bitnami/charts/pull/15998, in some cases, our internal test & release pipeline reverts them by mistake (i.e https://github.com/bitnami/charts/pull/16150). The aim of this PR is to undo that undesired revert.

Changes were done by running
```bash
for chart in apache clickhouse grafana-mimir mariadb-galera mariadb minio postgresql-ha postgresql tomcat zookeeper; do
  cd $chart || exit
  sed -i '' -e 's@https://charts.bitnami.com/bitnami@oci://registry-1.docker.io/bitnamicharts@g' Chart.yaml
  rm -rf charts Chart.lock
  helm dep update --debug && cd ..
done
```
where the list of charts was previously obtained with
```bash
ag 'charts.bitnami.com' -l | grep 'Chart.*'
```