### PR TITLE
[bitnami/argo-cd] Add helper for the redis image

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.6.0
+version: 4.6.1

--- a/bitnami/argo-cd/templates/NOTES.txt
+++ b/bitnami/argo-cd/templates/NOTES.txt
@@ -55,5 +55,6 @@ WARNING: config.createExtraKnownHosts is disabled, a secret called "argocd-ssh-k
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.dex.image }}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
+{{- include "common.warnings.rollingTag" .Values.redis.image }}
 
 {{- include "argocd.validateValues" . }}

--- a/bitnami/argo-cd/templates/_helpers.tpl
+++ b/bitnami/argo-cd/templates/_helpers.tpl
@@ -20,10 +20,17 @@ Return the proper image name (for the init container volume-permissions image)
 {{- end -}}
 
 {{/*
+Return the proper Redis image name
+*/}}
+{{- define "argocd.redis.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.redis.image "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "argocd.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.dex.image .Values.volumePermissions.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.dex.image .Values.volumePermissions.image .Values.redis.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/argo-cd/templates/application-controller/deployment.yaml
+++ b/bitnami/argo-cd/templates/application-controller/deployment.yaml
@@ -70,7 +70,7 @@ spec:
       initContainers:
         {{- if .Values.redisWait.enabled }}
         - name: wait-for-redis
-          image: {{ include "common.images.image" (dict "imageRoot" .Values.redis.image "global" .Values.global) }}
+          image: {{ include "argocd.redis.image" . }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
           {{- with .Values.redisWait.securityContext }}
           securityContext: {{ . | toYaml }}

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         {{- end }}
         {{- if .Values.redisWait.enabled }}
         - name: wait-for-redis
-          image: {{ include "common.images.image" (dict "imageRoot" .Values.redis.image "global" .Values.global) }}
+          image: {{ include "argocd.redis.image" . }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
           {{- with .Values.redisWait.securityContext }}
           securityContext: {{ . | toYaml }}

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         {{- end }}
         {{- if .Values.redisWait.enabled }}
         - name: wait-for-redis
-          image: {{ include "common.images.image" (dict "imageRoot" .Values.redis.image "global" .Values.global) }}
+          image: {{ include "argocd.redis.image" . }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
           {{- with .Values.redisWait.securityContext }}
           securityContext: {{ . | toYaml }}


### PR DESCRIPTION
### Description of the change

- Add helper for the redis image for compatibility with the rest of container image references.
- Include redis image in `argocd.imagePullSecrets`.
- Check redis image with `common.warnings.rollingTag`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
