### PR TITLE
[bitnami/redis] Fix replica-announce-ip wrong number of arguments whe…

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.11.1
+version: 17.10.2

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.10.1
+version: 17.11.1

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -87,6 +87,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
 | `useHostnames`           | Use hostnames internally when announcing replication                                    | `true`          |
+| `useHostnamesThreshold`  | Failure threshold for internal hostnames collection                                     | `true`          |
+| `useHostnamesTimeout`    | Timeout seconds between probes for internal hostnames collection                        | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -87,8 +87,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
 | `useHostnames`           | Use hostnames internally when announcing replication                                    | `true`          |
-| `useHostnamesThreshold`  | Failure threshold for internal hostnames collection                                     | `true`          |
-| `useHostnamesTimeout`    | Timeout seconds between probes for internal hostnames collection                        | `true`          |
+| `useHostnamesThreshold`  | Failure threshold for internal hostnames collection                                     | `5`             |
+| `useHostnamesTimeout`    | Timeout seconds between probes for internal hostnames collection                        | `5`             |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -76,22 +76,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                     | Description                                                                             | Value           |
-| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
-| `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
-| `nameOverride`           | String to partially override common.names.fullname                                      | `""`            |
-| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
-| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`            |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
-| `secretAnnotations`      | Annotations to add to secret                                                            | `{}`            |
-| `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
-| `useHostnames`           | Use hostnames internally when announcing replication                                    | `true`          |
-| `useHostnamesThreshold`  | Failure threshold for internal hostnames collection                                     | `5`             |
-| `useHostnamesTimeout`    | Timeout seconds between probes for internal hostnames collection                        | `5`             |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |
+| Name                     | Description                                                                                                     | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                                                                                     | `""`            |
+| `nameOverride`           | String to partially override common.names.fullname                                                              | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname                                                                  | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                                           | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                                                      | `{}`            |
+| `secretAnnotations`      | Annotations to add to secret                                                                                    | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain name                                                                                  | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                                               | `[]`            |
+| `useHostnames`           | Use hostnames internally when announcing replication. If false, the hostname will be resolved to an IP address  | `true`          |
+| `nameResolutionThreshold`| Failure threshold for internal hostnames resolution                                                             | `5`             |
+| `nameResolutionTimeout`  | Timeout seconds between probes for internal hostnames resolution                                                | `5`             |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                         | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the deployment                                                            | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the deployment                                                               | `["infinity"]`  |
 
 ### Redis&reg; Image parameters
 

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -76,22 +76,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                     | Description                                                                                                     | Value           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------- |
-| `kubeVersion`            | Override Kubernetes version                                                                                     | `""`            |
-| `nameOverride`           | String to partially override common.names.fullname                                                              | `""`            |
-| `fullnameOverride`       | String to fully override common.names.fullname                                                                  | `""`            |
-| `commonLabels`           | Labels to add to all deployed objects                                                                           | `{}`            |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                                                      | `{}`            |
-| `secretAnnotations`      | Annotations to add to secret                                                                                    | `{}`            |
-| `clusterDomain`          | Kubernetes cluster domain name                                                                                  | `cluster.local` |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                                               | `[]`            |
-| `useHostnames`           | Use hostnames internally when announcing replication. If false, the hostname will be resolved to an IP address  | `true`          |
-| `nameResolutionThreshold`| Failure threshold for internal hostnames resolution                                                             | `5`             |
-| `nameResolutionTimeout`  | Timeout seconds between probes for internal hostnames resolution                                                | `5`             |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                         | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the deployment                                                            | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the deployment                                                               | `["infinity"]`  |
+| Name                      | Description                                                                                                    | Value           |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`             | Override Kubernetes version                                                                                    | `""`            |
+| `nameOverride`            | String to partially override common.names.fullname                                                             | `""`            |
+| `fullnameOverride`        | String to fully override common.names.fullname                                                                 | `""`            |
+| `commonLabels`            | Labels to add to all deployed objects                                                                          | `{}`            |
+| `commonAnnotations`       | Annotations to add to all deployed objects                                                                     | `{}`            |
+| `secretAnnotations`       | Annotations to add to secret                                                                                   | `{}`            |
+| `clusterDomain`           | Kubernetes cluster domain name                                                                                 | `cluster.local` |
+| `extraDeploy`             | Array of extra objects to deploy with the release                                                              | `[]`            |
+| `useHostnames`            | Use hostnames internally when announcing replication. If false, the hostname will be resolved to an IP address | `true`          |
+| `nameResolutionThreshold` | Failure threshold for internal hostnames resolution                                                            | `5`             |
+| `nameResolutionTimeout`   | Timeout seconds between probes for internal hostnames resolution                                               | `5`             |
+| `diagnosticMode.enabled`  | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                        | `false`         |
+| `diagnosticMode.command`  | Command to override all containers in the deployment                                                           | `["sleep"]`     |
+| `diagnosticMode.args`     | Args to override all containers in the deployment                                                              | `["infinity"]`  |
 
 ### Redis&reg; Image parameters
 

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -54,7 +54,16 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
+        retry_count=0
+        until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
+        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
+            sleep {{ .Values.useHostnamesTimeout }}
+        else
+            error "IP address for ${full_hostname} not found"
+            exit 1
+        fi
+        ((retry_count++))
+        done
         {{- end }}
     }
 
@@ -278,7 +287,16 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
+        retry_count=0
+        until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
+        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
+            sleep {{ .Values.useHostnamesTimeout }}
+        else
+            error "IP address for ${full_hostname} not found"
+            exit 1
+        fi
+        ((retry_count++))
+        done
         {{- end }}
     }
 
@@ -448,7 +466,16 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
+        retry_count=0
+        until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
+        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
+            sleep {{ .Values.useHostnamesTimeout }}
+        else
+            error "IP address for ${full_hostname} not found"
+            exit 1
+        fi
+        ((retry_count++))
+        done
         {{- end }}
     }
 
@@ -521,7 +548,16 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
+        retry_count=0
+        until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
+        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
+            sleep {{ .Values.useHostnamesTimeout }}
+        else
+            error "IP address for ${full_hostname} not found"
+            exit 1
+        fi
+        ((retry_count++))
+        done
         {{- end }}
     }
 
@@ -650,7 +686,16 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
+        retry_count=0
+        until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
+        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
+            sleep {{ .Values.useHostnamesTimeout }}
+        else
+            error "IP address for ${full_hostname} not found"
+            exit 1
+        fi
+        ((retry_count++))
+        done
         {{- end }}
     }
 

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -56,13 +56,13 @@ data:
         {{- else }}
         retry_count=0
         until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
-        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
-            sleep {{ .Values.useHostnamesTimeout }}
-        else
-            error "IP address for ${full_hostname} not found"
-            exit 1
-        fi
-        ((retry_count++))
+            if [[ $retry_count -lt {{ .Values.nameResolutionThreshold }} ]]; then
+                sleep {{ .Values.nameResolutionTimeout }}
+            else
+                error "IP address for ${full_hostname} not found"
+                exit 1
+            fi
+            ((retry_count++))
         done
         {{- end }}
     }
@@ -289,13 +289,13 @@ data:
         {{- else }}
         retry_count=0
         until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
-        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
-            sleep {{ .Values.useHostnamesTimeout }}
-        else
-            error "IP address for ${full_hostname} not found"
-            exit 1
-        fi
-        ((retry_count++))
+            if [[ $retry_count -lt {{ .Values.nameResolutionThreshold }} ]]; then
+                sleep {{ .Values.nameResolutionTimeout }}
+            else
+                error "IP address for ${full_hostname} not found"
+                exit 1
+            fi
+            ((retry_count++))
         done
         {{- end }}
     }
@@ -468,13 +468,13 @@ data:
         {{- else }}
         retry_count=0
         until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
-        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
-            sleep {{ .Values.useHostnamesTimeout }}
-        else
-            error "IP address for ${full_hostname} not found"
-            exit 1
-        fi
-        ((retry_count++))
+            if [[ $retry_count -lt {{ .Values.nameResolutionThreshold }} ]]; then
+                sleep {{ .Values.nameResolutionTimeout }}
+            else
+                error "IP address for ${full_hostname} not found"
+                exit 1
+            fi
+            ((retry_count++))
         done
         {{- end }}
     }
@@ -550,13 +550,13 @@ data:
         {{- else }}
         retry_count=0
         until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
-        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
-            sleep {{ .Values.useHostnamesTimeout }}
-        else
-            error "IP address for ${full_hostname} not found"
-            exit 1
-        fi
-        ((retry_count++))
+            if [[ $retry_count -lt {{ .Values.nameResolutionThreshold }} ]]; then
+                sleep {{ .Values.nameResolutionTimeout }}
+            else
+                error "IP address for ${full_hostname} not found"
+                exit 1
+            fi
+            ((retry_count++))
         done
         {{- end }}
     }
@@ -688,13 +688,13 @@ data:
         {{- else }}
         retry_count=0
         until getent hosts "${full_hostname}" | awk '{ print $1; exit }' | grep .; do 
-        if [[ $retry_count -lt {{ .Values.useHostnamesThreshold }} ]]; then
-            sleep {{ .Values.useHostnamesTimeout }}
-        else
-            error "IP address for ${full_hostname} not found"
-            exit 1
-        fi
-        ((retry_count++))
+            if [[ $retry_count -lt {{ .Values.nameResolutionThreshold }} ]]; then
+                sleep {{ .Values.nameResolutionTimeout }}
+            else
+                error "IP address for ${full_hostname} not found"
+                exit 1
+            fi
+            ((retry_count++))
         done
         {{- end }}
     }

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -54,7 +54,7 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        getent hosts "${full_hostname}" | awk '{ print $1 ; exit }'
+        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
         {{- end }}
     }
 
@@ -278,7 +278,7 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        getent hosts "${full_hostname}" | awk '{ print $1 ; exit }'
+        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
         {{- end }}
     }
 
@@ -448,7 +448,7 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        getent hosts "${full_hostname}" | awk '{ print $1 ; exit }'
+        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
         {{- end }}
     }
 
@@ -521,7 +521,7 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        getent hosts "${full_hostname}" | awk '{ print $1 ; exit }'
+        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
         {{- end }}
     }
 
@@ -650,7 +650,7 @@ data:
         {{- if .Values.useHostnames }}
         echo "${full_hostname}"
         {{- else }}
-        getent hosts "${full_hostname}" | awk '{ print $1 ; exit }'
+        until getent hosts "${full_hostname}"; do sleep 5; done | awk '{ print $1 ; exit }';
         {{- end }}
     }
 

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -50,6 +50,12 @@ extraDeploy: []
 ## @param useHostnames Use hostnames internally when announcing replication
 ###
 useHostnames: true
+## @param useHostnamesRetry Failure threshold for internal hostnames collection
+###
+useHostnamesThreshold: 5
+## @param useHostnamesDelay Timeout seconds between probes for internal hostnames collection
+###
+useHostnamesTimeout: 5
 
 ## Enable diagnostic mode in the deployment
 ##

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -50,10 +50,10 @@ extraDeploy: []
 ## @param useHostnames Use hostnames internally when announcing replication
 ###
 useHostnames: true
-## @param useHostnamesRetry Failure threshold for internal hostnames collection
+## @param useHostnamesThreshold Failure threshold for internal hostnames collection
 ###
 useHostnamesThreshold: 5
-## @param useHostnamesDelay Timeout seconds between probes for internal hostnames collection
+## @param useHostnamesTimeout Timeout seconds between probes for internal hostnames collection
 ###
 useHostnamesTimeout: 5
 

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -47,15 +47,15 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
-## @param useHostnames Use hostnames internally when announcing replication
-###
+## @param useHostnames Use hostnames internally when announcing replication. If false, the hostname will be resolved to an IP address
+##
 useHostnames: true
-## @param useHostnamesThreshold Failure threshold for internal hostnames collection
-###
-useHostnamesThreshold: 5
-## @param useHostnamesTimeout Timeout seconds between probes for internal hostnames collection
-###
-useHostnamesTimeout: 5
+## @param nameResolutionThreshold Failure threshold for internal hostnames resolution
+##
+nameResolutionThreshold: 5
+## @param nameResolutionTimeout Timeout seconds between probes for internal hostnames resolution
+##
+nameResolutionTimeout: 5
 
 ## Enable diagnostic mode in the deployment
 ##


### PR DESCRIPTION
Signed-off-by: Aleh Yarmalovich <yarmolmi@gmail.com>

### Description of the change

This change fix replica-announce-ip wrong number of arguments when useExternalDNS enabled.
When the useExternalDNS option is enabled and useHostnames is disabled, Redis containers fail because the external DNS doesn't have time to create an record, and the getent command gets empty output.

### Benefits

This solves the issue reported [here](https://github.com/bitnami/charts/issues/16177)

### Possible drawbacks

None from the tests I performed

- Launched a new deployment with the useHostnames parameter set to false and useExternalDNS set to true.
- Launched a new deployment with the useHostnames parameter set to true and useExternalDNS set to true.
- Launched a new deployment with the useHostnames parameter set to true and useExternalDNS set to false.
- Removed a secondary/master replicas and confirmed everything worked as expected.

### Applicable issues

- fixes #16177

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
