### PR TITLE
[bitnami/clickhouse] Fix volumePermissions's command syntax and security context

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -26,4 +26,4 @@ name: clickhouse
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse
   - https://github.com/ClickHouse/ClickHouse
-version: 3.3.1
+version: 3.3.2

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -123,7 +123,7 @@ spec:
               {{- end }}
               chmod 600 {{ include "clickhouse.tlsCertKey" $ }}
               {{- end }}
-          securityContext: {{ $.Values.volumePermissions.containerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "common.tplvalues.render" (dict "value" $.Values.volumePermissions.containerSecurityContext "context" $) | nindent 12 }}
           {{- if $.Values.volumePermissions.resources }}
           resources: {{- toYaml $.Values.volumePermissions.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -130,8 +130,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /bitnami/clickhouse
-            - name: config
-              mountPath: /bitnami/clickhouse/conf/default
             {{- if $.Values.tls.enabled }}
             - name: raw-certificates
               mountPath: /tmp/certs

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -82,8 +82,8 @@ spec:
           {{- if $.Values.resources }}
           resources: {{- toYaml $.Values.resources | nindent 12 }}
           {{- end }}
-          # We don't require a privileged container in this case
           {{- if $.Values.containerSecurityContext.enabled }}
+          # We don't require a privileged container in this case
           securityContext: {{- omit $.Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command:
@@ -123,9 +123,8 @@ spec:
               {{- end }}
               chmod 600 {{ include "clickhouse.tlsCertKey" $ }}
               {{- end }}
-          {{- if $.Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit $.Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
+          securityContext:
+            runAsUser: {{ $.Values.volumePermissions.containerSecurityContext.runAsUser }}
           {{- if $.Values.volumePermissions.resources }}
           resources: {{- toYaml $.Values.volumePermissions.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -123,8 +123,7 @@ spec:
               {{- end }}
               chmod 600 {{ include "clickhouse.tlsCertKey" $ }}
               {{- end }}
-          securityContext:
-            runAsUser: {{ $.Values.volumePermissions.containerSecurityContext.runAsUser }}
+          securityContext: {{ $.Values.volumePermissions.containerSecurityContext | toYaml | nindent 12 }}
           {{- if $.Values.volumePermissions.resources }}
           resources: {{- toYaml $.Values.volumePermissions.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -101,25 +101,28 @@ spec:
         - name: volume-permissions
           image: {{ include "clickhouse.volumePermissions.image" $ }}
           imagePullPolicy: {{ $.Values.volumePermissions.image.pullPolicy | quote }}
-          command: |
-            mkdir -p /bitnami/clickhouse/data
-            chmod 700 /bitnami/clickhouse/data
-            {{- if $.Values.keeper.enabled }}
-            mkdir -p /bitnami/clickhouse/keeper
-            chmod 700 /bitnami/clickhouse/keeper
-            {{- end }}
-            chown {{ $.Values.containerSecurityContext.runAsUser }}:{{ $.Values.podSecurityContext.fsGroup }} /bitnami/clickhouse
-            find /bitnami/clickhouse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
-            xargs -r chown -R {{ $.Values.containerSecurityContext.runAsUser }}:{{ $.Values.podSecurityContext.fsGroup }}
-            {{- if $.Values.tls.enabled }}
-            cp /tmp/certs/* /opt/bitnami/clickhouse/certs/
-            {{- if eq ( toString ( $.Values.volumePermissions.containerSecurityContext.runAsUser )) "auto" }}
-            chown -R `id -u`:`id -G | cut -d " " -f2` /opt/bitnami/clickhouse/certs/
-            {{- else }}
-            chown -R {{ $.Values.containerSecurityContext.runAsUser }}:{{ $.Values.podSecurityContext.fsGroup }} /opt/bitnami/clickhouse/certs/
-            {{- end }}
-            chmod 600 {{ include "clickhouse.tlsCertKey" $ }}
-            {{- end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              mkdir -p /bitnami/clickhouse/data
+              chmod 700 /bitnami/clickhouse/data
+              {{- if $.Values.keeper.enabled }}
+              mkdir -p /bitnami/clickhouse/keeper
+              chmod 700 /bitnami/clickhouse/keeper
+              {{- end }}
+              chown {{ $.Values.containerSecurityContext.runAsUser }}:{{ $.Values.podSecurityContext.fsGroup }} /bitnami/clickhouse
+              find /bitnami/clickhouse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+              xargs -r chown -R {{ $.Values.containerSecurityContext.runAsUser }}:{{ $.Values.podSecurityContext.fsGroup }}
+              {{- if $.Values.tls.enabled }}
+              cp /tmp/certs/* /opt/bitnami/clickhouse/certs/
+              {{- if eq ( toString ( $.Values.volumePermissions.containerSecurityContext.runAsUser )) "auto" }}
+              chown -R `id -u`:`id -G | cut -d " " -f2` /opt/bitnami/clickhouse/certs/
+              {{- else }}
+              chown -R {{ $.Values.containerSecurityContext.runAsUser }}:{{ $.Values.podSecurityContext.fsGroup }} /opt/bitnami/clickhouse/certs/
+              {{- end }}
+              chmod 600 {{ include "clickhouse.tlsCertKey" $ }}
+              {{- end }}
           {{- if $.Values.containerSecurityContext.enabled }}
           securityContext: {{- omit $.Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

The command used in `volumePermissions` init container was specified as string instead of a list of strings. This may have resulted in errors reported by Helm:
```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.initContainers[0].command): invalid type for io.k8s.api.core.v1.Container.command: got "string", expected "array"
```

Also, this chart appears to have an unused `.Values.volumePermissions.containerSecurityContext` knob and unconditionally uses the main container's securityContext for `volumePermissions` init container instead. This breaks the startup in some cases, e.g. when we require root privileges in order to set up file permissions properly. This PR makes `volumePermissions` honor the securityContext specified for it in `values.yaml`.

### Benefits

With this PR merged, both initContainers will use the same array-based command syntax.

### Possible drawbacks

(I'm not sure, please let me know if you know of any possible problems this may introduce 😅)

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
