### PR TITLE
[bitnami/external-dns] add namespace read access to cluster role

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: external-dns
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 6.20.2
+version: 6.20.3

--- a/bitnami/external-dns/templates/clusterrole.yaml
+++ b/bitnami/external-dns/templates/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - namespaces
       - services
       - pods
       - nodes


### PR DESCRIPTION
### Description of the change

This adds namespace read access to the external-dns cluster role.

### Benefits

This is required to support Gateway API.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
