### PR TITLE
[bitnami/mariadb] Fix mariadb upgrade

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 12.1.3
+version: 12.1.4

--- a/bitnami/mariadb/templates/_helpers.tpl
+++ b/bitnami/mariadb/templates/_helpers.tpl
@@ -147,3 +147,13 @@ mariadb: architecture
     "replication". Please set a valid architecture (--set architecture="xxxx")
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get existing password to access MariaDB
+*/}}
+{{- define "mariadb.secret.existPassword" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "mariadb.secretName" .)).data -}}
+{{- if hasKey $secret "mariadb-password" }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/mariadb/templates/secrets.yaml
+++ b/bitnami/mariadb/templates/secrets.yaml
@@ -2,7 +2,7 @@
 {{- $port := print .Values.primary.service.ports.mysql }}
 {{- $rootPassword := include "common.secrets.passwords.manage" (dict "secret" (include "mariadb.secretName" .) "key" "mariadb-root-password" "providedValues" (list "auth.rootPassword") "context" $) | trimAll "\"" | b64dec }}
 {{- $password := .Values.auth.password }}
-{{- if (not (empty .Values.auth.username)) }}
+{{- if eq (include "mariadb.secret.password" .) "true" }}
 {{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "mariadb.secretName" .) "key" "mariadb-password" "providedValues" (list "auth.password") "context" $) | trimAll "\"" | b64dec }}
 {{- end }}
 {{- if eq (include "mariadb.createSecret" .) "true" }}

--- a/bitnami/mariadb/templates/secrets.yaml
+++ b/bitnami/mariadb/templates/secrets.yaml
@@ -2,7 +2,7 @@
 {{- $port := print .Values.primary.service.ports.mysql }}
 {{- $rootPassword := include "common.secrets.passwords.manage" (dict "secret" (include "mariadb.secretName" .) "key" "mariadb-root-password" "providedValues" (list "auth.rootPassword") "context" $) | trimAll "\"" | b64dec }}
 {{- $password := .Values.auth.password }}
-{{- if eq (include "mariadb.secret.password" .) "true" }}
+{{- if eq (include "mariadb.secret.existPassword" .) "true" }}
 {{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "mariadb.secretName" .) "key" "mariadb-password" "providedValues" (list "auth.password") "context" $) | trimAll "\"" | b64dec }}
 {{- end }}
 {{- if eq (include "mariadb.createSecret" .) "true" }}
@@ -29,7 +29,7 @@ data:
   {{- if (not .Values.auth.forcePassword) }}
   mariadb-password: {{ print $password | b64enc | quote }}
   {{- else }}
-  mariadb-password: {{ required "A MariaDB Database Password is required!" .Values.auth.password | b64enc | quote }}
+  mariadb-password: {{ required "A MariaDB Database Password is required!" $password | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if eq .Values.architecture "replication" }}
@@ -90,7 +90,11 @@ data:
   {{- if $database }}
   database: {{ print $database | b64enc | quote }}
   {{- end }}
+  {{- if and (.Values.auth.forcePassword) (empty $password) }}
+  password: {{ required "A MariaDB Database Password is required!" $password | b64enc | quote }}
+  {{- else }}
   password: {{ print $password | b64enc | quote }}
+  {{- end }}
   uri: {{ printf "mysql://%s:%s@%s:%s/%s" .Values.auth.username $password $host $port $database | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/bitnami/mariadb/templates/secrets.yaml
+++ b/bitnami/mariadb/templates/secrets.yaml
@@ -1,7 +1,10 @@
 {{- $host := include "mariadb.primary.fullname" . }}
 {{- $port := print .Values.primary.service.ports.mysql }}
 {{- $rootPassword := include "common.secrets.passwords.manage" (dict "secret" (include "mariadb.secretName" .) "key" "mariadb-root-password" "providedValues" (list "auth.rootPassword") "context" $) | trimAll "\"" | b64dec }}
+{{- $password := .Values.auth.password }}
+{{- if (not (empty .Values.auth.username)) }}
 {{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "mariadb.secretName" .) "key" "mariadb-password" "providedValues" (list "auth.password") "context" $) | trimAll "\"" | b64dec }}
+{{- end }}
 {{- if eq (include "mariadb.createSecret" .) "true" }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Currently, when the user does execute `helm upgrade` helm always tries to find a `mariadb-password` secret key even if it does not exist and prints the error:
```
PASSWORDS ERROR: The secret "mariadb" does not contain the key "mariadb-password"
```
This change aims to avoid that error.

Also, when the `serviceBindings.enabled=true` now it will check if `auth.forcePassword=true` in case the user is forced to provide a password.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users can `helm upgrade` without having to set up a password.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

N/A

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #15093 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
