### PR TITLE
[bitnami/keycloak] Fix keycloakConfigCli

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 15.0.0
+version: 15.0.1

--- a/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
+++ b/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
@@ -63,7 +63,7 @@ spec:
           command:
             - java
             - -jar
-            - {{ printf "/opt/bitnami/keycloak-config-cli/keycloak-config-cli-%s.jar" .Chart.AppVersion }}
+            - /opt/bitnami/keycloak-config-cli/keycloak-config-cli.jar
           {{- end }}
           {{- if .Values.keycloakConfigCli.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.keycloakConfigCli.args "context" $) | nindent 12 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -968,9 +968,8 @@ keycloakConfigCli:
   ##       "realm": "realm1",
   ##       "clients": []
   ##     }
-  ##   files/realm2.yaml:
-  ##   realm3.yaml: |
-  ##     realm: realm3
+  ##   realm2.yaml: |
+  ##     realm: realm2
   ##     clients: []
   ##
   configuration: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The user cannot set keycloakConfigCli parameters on `values.yaml` because `keycloak-config-cli` pod container is crashing:
```
$ kubectl get po -n keycloak -w
NAME                                 READY   STATUS    RESTARTS   AGE
keycloak-0                           0/1     Running   0          68s
keycloak-keycloak-config-cli-cnsrr   0/1     Error     0          17s
keycloak-keycloak-config-cli-lgm9j   0/1     Error     0          67s
keycloak-postgresql-0                1/1     Running   0          68s
                                                                                                   
$ kubectl logs -n keycloak keycloak-keycloak-config-cli-cnsrr
Error: Unable to access jarfile /opt/bitnami/keycloak-config-cli/keycloak-config-cli-21.1.1.jar
```
To skip the error, the chart should avoid trying to match the chart version in the jarfile name.
```
$ docker run -it --name keycloak-config-cli --rm --entrypoint "" bitnami/keycloak-config-cli bash
I have no name!@c4b7ef16085b:/opt/bitnami/keycloak-config-cli$ ls -l /opt/bitnami/keycloak-config-cli/keycloak-config-cli*
-rw-r--r-- 1 root root 19771025 Apr 10 15:26 /opt/bitnami/keycloak-config-cli/keycloak-config-cli-18.0.2.jar
-rw-r--r-- 1 root root 19773454 Apr 10 15:26 /opt/bitnami/keycloak-config-cli/keycloak-config-cli-19.0.3.jar
-rw-r--r-- 1 root root 19782883 Apr 10 15:26 /opt/bitnami/keycloak-config-cli/keycloak-config-cli-20.0.5.jar
-rw-r--r-- 1 root root 19794409 Apr 10 15:27 /opt/bitnami/keycloak-config-cli/keycloak-config-cli-21.0.1.jar
lrwxrwxrwx 1 root root       63 Apr 10 15:27 /opt/bitnami/keycloak-config-cli/keycloak-config-cli.jar -> /opt/bitnami/keycloak-config-cli/keycloak-config-cli-21.0.1.jar
```
After fixing that issue, the `keycloakConfigCli` parameters loads fine.

### Benefits

<!-- What benefits will be realized by the code change? -->
User can set keycloakConfigCli parameters in `values.yaml`.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
