### PR TITLE
[bitnami/etcd] Fix `service.clusterIP` only works when `service.type` is `ClusterIP`

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: etcd
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 8.11.2
+version: 8.11.3

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}


### PR DESCRIPTION
### Description of the change

Fix the issue [[bitnami/etcd] `service.clusterIP` only works when `service.type` is `ClusterIP`](https://github.com/bitnami/charts/issues/16325).

### Benefits

Assuming that service-cidr is `10.16.0.0/16`, now we can specify `clusterIP` when `service.type` is not `ClusterIP`.

```shell
cd bitnami/etcd
helm dependency build
helm install etcd . \
  --namespace test \
  --create-namespace \
  --set auth.rbac.create=false \
  --set service.type=NodePort \
  --set service.clusterIP=10.16.23.79
```

### Possible drawbacks

### Applicable issues

- fixes #16325

### Additional information

Only charts [bitnami/etcd], [bitnami/redis], [bitnami/redis-cluster] have changed.

### Checklist
