### PR TITLE
[bitnami/thanos] Allow setting the index-cache configuration in a manually created config secret

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 12.5.1
+version: 12.6.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -114,8 +114,8 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `objstoreConfig`                              | The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)                                              | `""`                |
 | `indexCacheConfig`                            | The [index cache configuration](https://thanos.io/tip/components/store.md/)                                         | `""`                |
 | `bucketCacheConfig`                           | The [bucket cache configuration](https://thanos.io/tip/components/store.md/)                                        | `""`                |
-| `existingObjstoreSecret`                      | Secret with Objstore Configuration                                                                                  | `""`                |
-| `existingObjstoreSecretItems`                 | Optional item list for specifying a custom Secret key. If so, path should be objstore.yml                           | `[]`                |
+| `existingConfigSecret`                        | Secret with configuration files                                                                                     | `""`                |
+| `existingConfigSecretItems`                   | Optional item list for specifying a custom Secret key. If so, path should be objstore.yml                           | `[]`                |
 | `httpConfig`                                  | The [https and basic auth configuration](https://thanos.io/tip/operating/https.md/)                                 | `""`                |
 | `existingHttpConfigSecret`                    | Secret containing the HTTPS and Basic auth configuration                                                            | `""`                |
 | `https.enabled`                               | Set to true to enable HTTPS. Requires a secret containing the certificate and key.                                  | `false`             |
@@ -1250,7 +1250,7 @@ This helm chart supports using custom Objstore configuration.
 
 You can specify the Objstore configuration using the `objstoreConfig` parameter.
 
-In addition, you can also set an external Secret with the configuration file. This is done by setting the `existingObjstoreSecret` parameter. Note that this will override the previous option. If needed you can also provide a custom Secret Key with `existingObjstoreSecretItems`, please be aware that the Path of your Secret should be `objstore.yml`.
+In addition, you can also set an external Secret with the configuration file. This is done by setting the `existingConfigSecret` parameter. Note that this will override the previous option. If needed you can also provide a custom Secret Key with `existingConfigSecretItems`, please be aware that the Path of your Secret should be `objstore.yml`.
 
 ### Using custom Query Service Discovery configuration
 

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -41,8 +41,8 @@ Return the proper Docker Image Registry Secret Names
 Return the Thanos Objstore configuration secret.
 */}}
 {{- define "thanos.objstoreSecretName" -}}
-{{- if .Values.existingObjstoreSecret -}}
-    {{- printf "%s" (tpl .Values.existingObjstoreSecret $) -}}
+{{- if .Values.existingConfigSecret -}}
+    {{- printf "%s" (tpl .Values.existingConfigSecret $) -}}
 {{- else -}}
     {{- printf "%s-objstore-secret" (include "common.names.fullname" .) -}}
 {{- end -}}
@@ -52,7 +52,7 @@ Return the Thanos Objstore configuration secret.
 Return true if a secret object should be created
 */}}
 {{- define "thanos.createObjstoreSecret" -}}
-{{- if and .Values.objstoreConfig (not .Values.existingObjstoreSecret) }}
+{{- if and .Values.objstoreConfig (not .Values.existingConfigSecret) }}
     {{- true -}}
 {{- else -}}
 {{- end -}}
@@ -239,13 +239,13 @@ Compile all warnings into a single message, and call fail.
 
 {{/* Validate values of Thanos - Objstore configuration */}}
 {{- define "thanos.validateValues.objstore" -}}
-{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreSecret" .)) ( not .Values.existingObjstoreSecret) -}}
+{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreSecret" .)) ( not .Values.existingConfigSecret) -}}
 thanos: objstore configuration
     When enabling Bucket Web, Compactor, Ruler or Store component,
     you must provide a valid objstore configuration.
     There are three alternatives to provide it:
       1) Provide it using the 'objstoreConfig' parameter
-      2) Provide it using an existing Secret and using the 'existingObjstoreSecret' parameter
+      2) Provide it using an existing Secret and using the 'existingConfigSecret' parameter
       3) Put your objstore.yml under the 'files/conf/' directory
 {{- end -}}
 {{- end -}}

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -197,8 +197,8 @@ spec:
         - name: objstore-config
           secret:
             secretName: {{ include "thanos.objstoreSecretName" . }}
-            {{- if .Values.existingObjstoreSecretItems }}
-            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- if .Values.existingConfigSecretItems }}
+            items: {{- toYaml .Values.existingConfigSecretItems | nindent 14 }}
             {{- end }}
         {{- if (include "thanos.httpConfigEnabled" .) }}
         - name: http-config

--- a/bitnami/thanos/templates/compactor/_pod-template.tpl
+++ b/bitnami/thanos/templates/compactor/_pod-template.tpl
@@ -204,8 +204,8 @@ spec:
     - name: objstore-config
       secret:
         secretName: {{ include "thanos.objstoreSecretName" . }}
-        {{- if .Values.existingObjstoreSecretItems }}
-        items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 10 }}
+        {{- if .Values.existingConfigSecretItems }}
+        items: {{- toYaml .Values.existingConfigSecretItems | nindent 10 }}
         {{- end }}
     {{- if (include "thanos.httpConfigEnabled" .) }}
     - name: http-config

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -123,7 +123,7 @@ spec:
             - --grpc-address=0.0.0.0:10901
             - --http-address=0.0.0.0:10902
             - --remote-write.address=0.0.0.0:19291
-            {{- if or .Values.objstoreConfig .Values.existingObjstoreSecret }}
+            {{- if or .Values.objstoreConfig .Values.existingConfigSecret }}
             - --objstore.config=$(OBJSTORE_CONFIG)
             {{- end }}
             {{- if (include "thanos.httpConfigEnabled" .) }}
@@ -160,7 +160,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if or .Values.objstoreConfig .Values.existingObjstoreSecret }}
+            {{- if or .Values.objstoreConfig .Values.existingConfigSecret }}
             - name: OBJSTORE_CONFIG
               valueFrom:
                 secretKeyRef:

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -250,8 +250,8 @@ spec:
         - name: objstore-config
           secret:
             secretName: {{ include "thanos.objstoreSecretName" . }}
-            {{- if .Values.existingObjstoreSecretItems }}
-            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- if .Values.existingConfigSecretItems }}
+            items: {{- toYaml .Values.existingConfigSecretItems | nindent 14 }}
             {{- end }}
         {{- if (include "thanos.httpConfigEnabled" .) }}
         - name: http-config

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -142,10 +142,10 @@ spec:
             {{- if (include "thanos.httpConfigEnabled" $) }}
             - --http.config=/conf/http/http-config.yml
             {{- end }}
-            {{- if $.Values.indexCacheConfig }}
+            {{- if or .Values.indexCacheConfig ( and .Values.existingConfigSecret ( index ( lookup "v1" "Secret" .Release.Namespace .Values.existingConfigSecret ).data "index-cache.yml" )) }}
             - --index-cache.config-file=/conf/index-cache.yml
             {{- end }}
-            {{- if $.Values.bucketCacheConfig }}
+            {{- if or .Values.bucketCacheConfig ( and .Values.existingConfigSecret ( index ( lookup "v1" "Secret" .Release.Namespace .Values.existingConfigSecret ).data "bucket-cache.yml" )) }}
             - --store.caching-bucket.config-file=/conf/bucket-cache.yml
             {{- end }}
             {{- if or $.Values.storegateway.config $.Values.storegateway.existingConfigmap }}
@@ -284,8 +284,8 @@ spec:
         - name: objstore-config
           secret:
             secretName: {{ include "thanos.objstoreSecretName" $ }}
-            {{- if $.Values.existingObjstoreSecretItems }}
-            items: {{- toYaml $.Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- if $.Values.existingConfigSecretItems }}
+            items: {{- toYaml $.Values.existingConfigSecretItems | nindent 14 }}
             {{- end }}
         {{- if (include "thanos.httpConfigEnabled" $) }}
         - name: http-config

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -127,10 +127,10 @@ spec:
             {{- if (include "thanos.httpConfigEnabled" .) }}
             - --http.config=/conf/http/http-config.yml
             {{- end }}
-            {{- if .Values.indexCacheConfig }}
+            {{- if or .Values.indexCacheConfig ( and .Values.existingConfigSecret ( index ( lookup "v1" "Secret" .Release.Namespace .Values.existingConfigSecret ).data "index-cache.yml" )) }}
             - --index-cache.config-file=/conf/index-cache.yml
             {{- end }}
-            {{- if .Values.bucketCacheConfig }}
+            {{- if or .Values.bucketCacheConfig ( and .Values.existingConfigSecret ( index ( lookup "v1" "Secret" .Release.Namespace .Values.existingConfigSecret ).data "bucket-cache.yml" )) }}
             - --store.caching-bucket.config-file=/conf/bucket-cache.yml
             {{- end }}
             {{- if or .Values.storegateway.config .Values.storegateway.existingConfigmap }}
@@ -242,8 +242,8 @@ spec:
         - name: objstore-config
           secret:
             secretName: {{ include "thanos.objstoreSecretName" . }}
-            {{- if .Values.existingObjstoreSecretItems }}
-            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
+            {{- if .Values.existingConfigSecretItems }}
+            items: {{- toYaml .Values.existingConfigSecretItems | nindent 14 }}
             {{- end }}
         {{- if .Values.storegateway.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -80,13 +80,13 @@ indexCacheConfig: ""
 ## Specify content for bucket-cache.yml
 ##
 bucketCacheConfig: ""
-## @param existingObjstoreSecret Secret with Objstore Configuration
-## Note: This will override objstoreConfig
+## @param existingConfigSecret Secret with configuration files
+## Note: This will override objstoreConfig, indexCacheConfig and bucketCacheConfig
 ##
-existingObjstoreSecret: ""
-## @param existingObjstoreSecretItems Optional item list for specifying a custom Secret key. If so, path should be objstore.yml
+existingConfigSecret: ""
+## @param existingConfigSecretItems Optional item list for specifying a custom Secret key. If so, path should be objstore.yml
 ##
-existingObjstoreSecretItems: []
+existingConfigSecretItems: []
 ## @param httpConfig The [https and basic auth configuration](https://thanos.io/tip/operating/https.md/)
 ## If provided, overrides settings under https.* and auth.*
 httpConfig: ""


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR allows configuring the index-cache.yml and bucket-cache.yml files in a existing secret (previously it only possible to configure the objstore.yml file). If you do not use the existingConfigSecret, a secret is generated with the content of the objstoreConfig, indexCacheConfig and bucketCacheConfig so we follow the same approach in both scenarios.

### Benefits

<!-- What benefits will be realized by the code change? -->

You can now create a secret with the content of the 3 files

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/16046

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
