### PR TITLE
[bitnami/mongodb] Handle mongodb-exporter arguments with chart values

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: mongodb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 13.11.0
+version: 13.12.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -498,73 +498,73 @@ Refer to the [chart documentation for more information on each of these architec
 
 ### Metrics parameters
 
-| Name                                         | Description                                                                                                           | Value                      |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `metrics.enabled`                            | Enable using a sidecar Prometheus exporter                                                                            | `false`                    |
-| `metrics.image.registry`                     | MongoDB(&reg;) Prometheus exporter image registry                                                                     | `docker.io`                |
-| `metrics.image.repository`                   | MongoDB(&reg;) Prometheus exporter image repository                                                                   | `bitnami/mongodb-exporter` |
-| `metrics.image.tag`                          | MongoDB(&reg;) Prometheus exporter image tag (immutable tags are recommended)                                         | `0.37.0-debian-11-r26`     |
-| `metrics.image.digest`                       | MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag        | `""`                       |
-| `metrics.image.pullPolicy`                   | MongoDB(&reg;) Prometheus exporter image pull policy                                                                  | `IfNotPresent`             |
-| `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                      | `[]`                       |
-| `metrics.username`                           | String with username for the metrics exporter                                                                         | `""`                       |
-| `metrics.password`                           | String with password for the metrics exporter                                                                         | `""`                       |
-| `metrics.compatibleMode`                     | Enables old style mongodb-exporter metrics                                                                            | `true`                     |
-| `metrics.collector.all` | Enable all collectors. Same as specifying enabling all individual metrics. Note: Enabling all metrics will cause significant CPU load on mongod | `false` |
-| `metrics.collector.diagnosticdata` | Enable collecting metrics from getDiagnosticData | `true` |
-| `metrics.collector.replicasetstatus` | Enable collecting metrics from replSetGetStatus | `true` |
-| `metrics.collector.dbstats` | Enable collecting metrics from dbStats | `false` |
-| `metrics.collector.topmetrics` | Enable collecting metrics from top admin command | `false` |
-| `metrics.collector.indexstats` | Enable collecting metrics from $indexStats | `false` |
-| `metrics.collector.collstats` | Enable collecting metrics from $collStats | `false` |
-| `metrics.collector.collstatsColls` | List of \<databases\>.\<collections\> to get $collStats | `[]` |
-| `metrics.collector.indexstatsColls` | List of \<databases\>.\<collections\> to get $indexStats | `[]` |
-| `metrics.collector.collstatsLimit` | Disable collstats, dbstats, topmetrics and indexstats collector if there are more than \<n\> collections. 0=No limit | `0` |
-| `metrics.extraFlags`                         | String with extra flags to the metrics exporter                                                                       | `""`                       |
-| `metrics.command`                            | Override default container command (useful when using custom images)                                                  | `[]`                       |
-| `metrics.args`                               | Override default container args (useful when using custom images)                                                     | `[]`                       |
-| `metrics.resources.limits`                   | The resources limits for Prometheus exporter containers                                                               | `{}`                       |
-| `metrics.resources.requests`                 | The requested resources for Prometheus exporter containers                                                            | `{}`                       |
-| `metrics.containerPort`                      | Port of the Prometheus metrics container                                                                              | `9216`                     |
-| `metrics.service.annotations`                | Annotations for Prometheus Exporter pods. Evaluated as a template.                                                    | `{}`                       |
-| `metrics.service.type`                       | Type of the Prometheus metrics service                                                                                | `ClusterIP`                |
-| `metrics.service.ports.metrics`              | Port of the Prometheus metrics service                                                                                | `9216`                     |
-| `metrics.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                                        | `[]`                       |
-| `metrics.livenessProbe.enabled`              | Enable livenessProbe                                                                                                  | `true`                     |
-| `metrics.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                               | `15`                       |
-| `metrics.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                      | `5`                        |
-| `metrics.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                     | `10`                       |
-| `metrics.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                   | `3`                        |
-| `metrics.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                   | `1`                        |
-| `metrics.readinessProbe.enabled`             | Enable readinessProbe                                                                                                 | `true`                     |
-| `metrics.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                              | `5`                        |
-| `metrics.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                     | `5`                        |
-| `metrics.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                    | `10`                       |
-| `metrics.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                  | `3`                        |
-| `metrics.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                  | `1`                        |
-| `metrics.startupProbe.enabled`               | Enable startupProbe                                                                                                   | `false`                    |
-| `metrics.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                | `5`                        |
-| `metrics.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                       | `10`                       |
-| `metrics.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                      | `5`                        |
-| `metrics.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                    | `30`                       |
-| `metrics.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                    | `1`                        |
-| `metrics.customLivenessProbe`                | Override default liveness probe for MongoDB(&reg;) containers                                                         | `{}`                       |
-| `metrics.customReadinessProbe`               | Override default readiness probe for MongoDB(&reg;) containers                                                        | `{}`                       |
-| `metrics.customStartupProbe`                 | Override default startup probe for MongoDB(&reg;) containers                                                          | `{}`                       |
-| `metrics.serviceMonitor.enabled`             | Create ServiceMonitor Resource for scraping metrics using Prometheus Operator                                         | `false`                    |
-| `metrics.serviceMonitor.namespace`           | Namespace which Prometheus is running in                                                                              | `""`                       |
-| `metrics.serviceMonitor.interval`            | Interval at which metrics should be scraped                                                                           | `30s`                      |
-| `metrics.serviceMonitor.scrapeTimeout`       | Specify the timeout after which the scrape is ended                                                                   | `""`                       |
-| `metrics.serviceMonitor.relabelings`         | RelabelConfigs to apply to samples before scraping.                                                                   | `[]`                       |
-| `metrics.serviceMonitor.metricRelabelings`   | MetricsRelabelConfigs to apply to samples before ingestion.                                                           | `[]`                       |
-| `metrics.serviceMonitor.labels`              | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with | `{}`                       |
-| `metrics.serviceMonitor.selector`            | Prometheus instance selector labels                                                                                   | `{}`                       |
-| `metrics.serviceMonitor.honorLabels`         | Specify honorLabels parameter to add the scrape endpoint                                                              | `false`                    |
-| `metrics.serviceMonitor.jobLabel`            | The name of the label on the target service to use as the job name in prometheus.                                     | `""`                       |
-| `metrics.prometheusRule.enabled`             | Set this to true to create prometheusRules for Prometheus operator                                                    | `false`                    |
-| `metrics.prometheusRule.additionalLabels`    | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                | `{}`                       |
-| `metrics.prometheusRule.namespace`           | Namespace where prometheusRules resource should be created                                                            | `""`                       |
-| `metrics.prometheusRule.rules`               | Rules to be created, check values for an example                                                                      | `[]`                       |
+| Name                                         | Description                                                                                                                   | Value                      |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `metrics.enabled`                            | Enable using a sidecar Prometheus exporter                                                                                    | `false`                    |
+| `metrics.image.registry`                     | MongoDB(&reg;) Prometheus exporter image registry                                                                             | `docker.io`                |
+| `metrics.image.repository`                   | MongoDB(&reg;) Prometheus exporter image repository                                                                           | `bitnami/mongodb-exporter` |
+| `metrics.image.tag`                          | MongoDB(&reg;) Prometheus exporter image tag (immutable tags are recommended)                                                 | `0.37.0-debian-11-r26`     |
+| `metrics.image.digest`                       | MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                | `""`                       |
+| `metrics.image.pullPolicy`                   | MongoDB(&reg;) Prometheus exporter image pull policy                                                                          | `IfNotPresent`             |
+| `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                              | `[]`                       |
+| `metrics.username`                           | String with username for the metrics exporter                                                                                 | `""`                       |
+| `metrics.password`                           | String with password for the metrics exporter                                                                                 | `""`                       |
+| `metrics.compatibleMode`                     | Enables old style mongodb-exporter metrics                                                                                    | `true`                     |
+| `metrics.collector.all`                      | Enable all collectors. Same as enabling all individual metrics                                                                | `false`                    |
+| `metrics.collector.diagnosticdata`           | Boolean Enable collecting metrics from getDiagnosticData                                                                      | `true`                     |
+| `metrics.collector.replicasetstatus`         | Boolean Enable collecting metrics from replSetGetStatus                                                                       | `true`                     |
+| `metrics.collector.dbstats`                  | Boolean Enable collecting metrics from dbStats                                                                                | `false`                    |
+| `metrics.collector.topmetrics`               | Boolean Enable collecting metrics from top admin command                                                                      | `false`                    |
+| `metrics.collector.indexstats`               | Boolean Enable collecting metrics from $indexStats                                                                            | `false`                    |
+| `metrics.collector.collstats`                | Boolean Enable collecting metrics from $collStats                                                                             | `false`                    |
+| `metrics.collector.collstatsColls`           | List of \<databases\>.\<collections\> to get $collStats                                                                       | `[]`                       |
+| `metrics.collector.indexstatsColls`          | List - List of \<databases\>.\<collections\> to get $indexStats                                                               | `[]`                       |
+| `metrics.collector.collstatsLimit`           | Number - Disable collstats, dbstats, topmetrics and indexstats collector if there are more than \<n\> collections. 0=No limit | `0`                        |
+| `metrics.extraFlags`                         | String with extra flags to the metrics exporter                                                                               | `""`                       |
+| `metrics.command`                            | Override default container command (useful when using custom images)                                                          | `[]`                       |
+| `metrics.args`                               | Override default container args (useful when using custom images)                                                             | `[]`                       |
+| `metrics.resources.limits`                   | The resources limits for Prometheus exporter containers                                                                       | `{}`                       |
+| `metrics.resources.requests`                 | The requested resources for Prometheus exporter containers                                                                    | `{}`                       |
+| `metrics.containerPort`                      | Port of the Prometheus metrics container                                                                                      | `9216`                     |
+| `metrics.service.annotations`                | Annotations for Prometheus Exporter pods. Evaluated as a template.                                                            | `{}`                       |
+| `metrics.service.type`                       | Type of the Prometheus metrics service                                                                                        | `ClusterIP`                |
+| `metrics.service.ports.metrics`              | Port of the Prometheus metrics service                                                                                        | `9216`                     |
+| `metrics.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                                                | `[]`                       |
+| `metrics.livenessProbe.enabled`              | Enable livenessProbe                                                                                                          | `true`                     |
+| `metrics.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                       | `15`                       |
+| `metrics.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                              | `5`                        |
+| `metrics.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                             | `10`                       |
+| `metrics.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                           | `3`                        |
+| `metrics.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                           | `1`                        |
+| `metrics.readinessProbe.enabled`             | Enable readinessProbe                                                                                                         | `true`                     |
+| `metrics.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                      | `5`                        |
+| `metrics.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                             | `5`                        |
+| `metrics.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                            | `10`                       |
+| `metrics.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                          | `3`                        |
+| `metrics.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                          | `1`                        |
+| `metrics.startupProbe.enabled`               | Enable startupProbe                                                                                                           | `false`                    |
+| `metrics.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                        | `5`                        |
+| `metrics.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                               | `10`                       |
+| `metrics.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                              | `5`                        |
+| `metrics.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                            | `30`                       |
+| `metrics.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                            | `1`                        |
+| `metrics.customLivenessProbe`                | Override default liveness probe for MongoDB(&reg;) containers                                                                 | `{}`                       |
+| `metrics.customReadinessProbe`               | Override default readiness probe for MongoDB(&reg;) containers                                                                | `{}`                       |
+| `metrics.customStartupProbe`                 | Override default startup probe for MongoDB(&reg;) containers                                                                  | `{}`                       |
+| `metrics.serviceMonitor.enabled`             | Create ServiceMonitor Resource for scraping metrics using Prometheus Operator                                                 | `false`                    |
+| `metrics.serviceMonitor.namespace`           | Namespace which Prometheus is running in                                                                                      | `""`                       |
+| `metrics.serviceMonitor.interval`            | Interval at which metrics should be scraped                                                                                   | `30s`                      |
+| `metrics.serviceMonitor.scrapeTimeout`       | Specify the timeout after which the scrape is ended                                                                           | `""`                       |
+| `metrics.serviceMonitor.relabelings`         | RelabelConfigs to apply to samples before scraping.                                                                           | `[]`                       |
+| `metrics.serviceMonitor.metricRelabelings`   | MetricsRelabelConfigs to apply to samples before ingestion.                                                                   | `[]`                       |
+| `metrics.serviceMonitor.labels`              | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with         | `{}`                       |
+| `metrics.serviceMonitor.selector`            | Prometheus instance selector labels                                                                                           | `{}`                       |
+| `metrics.serviceMonitor.honorLabels`         | Specify honorLabels parameter to add the scrape endpoint                                                                      | `false`                    |
+| `metrics.serviceMonitor.jobLabel`            | The name of the label on the target service to use as the job name in prometheus.                                             | `""`                       |
+| `metrics.prometheusRule.enabled`             | Set this to true to create prometheusRules for Prometheus operator                                                            | `false`                    |
+| `metrics.prometheusRule.additionalLabels`    | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                        | `{}`                       |
+| `metrics.prometheusRule.namespace`           | Namespace where prometheusRules resource should be created                                                                    | `""`                       |
+| `metrics.prometheusRule.rules`               | Rules to be created, check values for an example                                                                              | `[]`                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -509,6 +509,17 @@ Refer to the [chart documentation for more information on each of these architec
 | `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                      | `[]`                       |
 | `metrics.username`                           | String with username for the metrics exporter                                                                         | `""`                       |
 | `metrics.password`                           | String with password for the metrics exporter                                                                         | `""`                       |
+| `metrics.compatibleMode`                     | Enables old style mongodb-exporter metrics                                                                            | `true`                     |
+| `metrics.collector.all` | Enable all collectors. Same as specifying enabling all individual metrics. Note: Enabling all metrics will cause significant CPU load on mongod | `false` |
+| `metrics.collector.diagnosticdata` | Enable collecting metrics from getDiagnosticData | `true` |
+| `metrics.collector.replicasetstatus` | Enable collecting metrics from replSetGetStatus | `true` |
+| `metrics.collector.dbstats` | Enable collecting metrics from dbStats | `false` |
+| `metrics.collector.topmetrics` | Enable collecting metrics from top admin command | `false` |
+| `metrics.collector.indexstats` | Enable collecting metrics from $indexStats | `false` |
+| `metrics.collector.collstats` | Enable collecting metrics from $collStats | `false` |
+| `metrics.collector.collstatsColls` | List of \<databases\>.\<collections\> to get $collStats | `[]` |
+| `metrics.collector.indexstatsColls` | List of \<databases\>.\<collections\> to get $indexStats | `[]` |
+| `metrics.collector.collstatsLimit` | Disable collstats, dbstats, topmetrics and indexstats collector if there are more than \<n\> collections. 0=No limit | `0` |
 | `metrics.extraFlags`                         | String with extra flags to the metrics exporter                                                                       | `""`                       |
 | `metrics.command`                            | Override default container command (useful when using custom images)                                                  | `[]`                       |
 | `metrics.args`                               | Override default container args (useful when using custom images)                                                     | `[]`                       |
@@ -720,8 +731,8 @@ From this version, the way of setting the ingress rules has changed. Instead of 
 ```yaml
 ingress:
   hosts:
-  - name: mongodb.local
-    path: /
+    - name: mongodb.local
+      path: /
 ```
 
 ### To 6.0.0

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -474,3 +474,30 @@ Return true if certificates must be auto generated
     {{- true -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate argument list for mongodb-exporter
+reference: https://github.com/percona/mongodb_exporter/blob/main/REFERENCE.md
+*/}}
+{{- define "mongodb.exporterArgs" -}}
+{{- with .Values.metrics.collector -}}
+{{- ternary " --collect-all" "" .all -}}
+{{- ternary " --collector.diagnosticdata" "" .diagnosticdata -}}
+{{- ternary " --collector.replicasetstatus" "" .replicasetstatus -}}
+{{- ternary " --collector.dbstats" "" .dbstats -}}
+{{- ternary " --collector.topmetrics" "" .topmetrics -}}
+{{- ternary " --collector.indexstats" "" .indexstats -}}
+{{- ternary " --collector.collstats" "" .collstats -}}
+{{- if .collstatsColls -}}
+{{- " --mongodb.collstats-colls=" -}}
+{{- join "," .collstatsColls -}}
+{{- end -}}
+{{- if .indexstatsColls -}}
+{{- " --mongodb.indexstats-colls=" -}}
+{{- join "," .indexstatsColls -}}
+{{- end -}}
+{{- $limitArg := print " --collector.collstats-limit=" .collstatsLimit -}}
+{{- ne (print .collstatsLimit) "0" | ternary $limitArg "" -}}
+{{- end -}}
+{{- ternary " --compatible-mode" "" .Values.metrics.compatibleMode -}}
+{{- end -}}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -407,7 +407,7 @@ spec:
           {{- else }}
           args:
             - |
-              /bin/mongodb_exporter --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+              /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           {{- end }}
           env:
             {{- if .Values.auth.enabled }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -414,7 +414,7 @@ spec:
           {{- else }}
           args:
             - |
-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+              /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           {{- end }}
           env:
             {{- if .Values.auth.enabled }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -346,7 +346,7 @@ spec:
           {{- else }}
           args:
             - |
-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+              /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           {{- end }}
           env:
             {{- if .Values.auth.enabled }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -1934,31 +1934,30 @@ metrics:
   ## If undefined but metrics.username is defined, a random password will be generated
   ##
   password: ""
-  ## @param metrics.compatibleMode Boolean
-  ## Enables old style mongodb-exporter metrics
+  ## @param metrics.compatibleMode Enables old style mongodb-exporter metrics
   compatibleMode: true
 
   collector:
-    ## @param metrics.collector.all - Enable all collectors. Same as specifying enabling all individual metrics
+    ## @param metrics.collector.all Enable all collectors. Same as enabling all individual metrics
     ## Enabling all metrics will cause significant CPU load on mongod
     all: false
-    ## @param metrics.collector.diagnosticdata Boolean - Enable collecting metrics from getDiagnosticData
+    ## @param metrics.collector.diagnosticdata Boolean Enable collecting metrics from getDiagnosticData
     diagnosticdata: true
-    ## @param metrics.collector.replicasetstatus Boolean - Enable collecting metrics from replSetGetStatus
+    ## @param metrics.collector.replicasetstatus Boolean Enable collecting metrics from replSetGetStatus
     replicasetstatus: true
-    ## @param metrics.collector.dbstats Boolean - Enable collecting metrics from dbStats
+    ## @param metrics.collector.dbstats Boolean Enable collecting metrics from dbStats
     dbstats: false
-    ## @param metrics.collector.topmetrics Boolean - Enable collecting metrics from top admin command
+    ## @param metrics.collector.topmetrics Boolean Enable collecting metrics from top admin command
     topmetrics: false
-    ## @param metrics.collector.indexstats Boolean - Enable collecting metrics from $indexStats
+    ## @param metrics.collector.indexstats Boolean Enable collecting metrics from $indexStats
     indexstats: false
-    ## @param metrics.collector.collstats Boolean - Enable collecting metrics from $collStats
+    ## @param metrics.collector.collstats Boolean Enable collecting metrics from $collStats
     collstats: false
-    ## @param metrics.collector.collstatsColls List - List of <databases>.<collections> to get $collStats
+    ## @param metrics.collector.collstatsColls List of \<databases\>.\<collections\> to get $collStats
     collstatsColls: []
-    ## @param metrics.collector.indexstatsColls List - List of <databases>.<collections> to get $indexStats
+    ## @param metrics.collector.indexstatsColls List - List of \<databases\>.\<collections\> to get $indexStats
     indexstatsColls: []
-    ## @param metrics.collector.collstatsLimit Number - Disable collstats, dbstats, topmetrics and indexstats collector if there are more than <n> collections. 0=No limit
+    ## @param metrics.collector.collstatsLimit Number - Disable collstats, dbstats, topmetrics and indexstats collector if there are more than \<n\> collections. 0=No limit
     collstatsLimit: 0
 
   ## @param metrics.extraFlags String with extra flags to the metrics exporter

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -1934,6 +1934,33 @@ metrics:
   ## If undefined but metrics.username is defined, a random password will be generated
   ##
   password: ""
+  ## @param metrics.compatibleMode Boolean
+  ## Enables old style mongodb-exporter metrics
+  compatibleMode: true
+
+  collector:
+    ## @param metrics.collector.all - Enable all collectors. Same as specifying enabling all individual metrics
+    ## Enabling all metrics will cause significant CPU load on mongod
+    all: false
+    ## @param metrics.collector.diagnosticdata Boolean - Enable collecting metrics from getDiagnosticData
+    diagnosticdata: true
+    ## @param metrics.collector.replicasetstatus Boolean - Enable collecting metrics from replSetGetStatus
+    replicasetstatus: true
+    ## @param metrics.collector.dbstats Boolean - Enable collecting metrics from dbStats
+    dbstats: false
+    ## @param metrics.collector.topmetrics Boolean - Enable collecting metrics from top admin command
+    topmetrics: false
+    ## @param metrics.collector.indexstats Boolean - Enable collecting metrics from $indexStats
+    indexstats: false
+    ## @param metrics.collector.collstats Boolean - Enable collecting metrics from $collStats
+    collstats: false
+    ## @param metrics.collector.collstatsColls List - List of <databases>.<collections> to get $collStats
+    collstatsColls: []
+    ## @param metrics.collector.indexstatsColls List - List of <databases>.<collections> to get $indexStats
+    indexstatsColls: []
+    ## @param metrics.collector.collstatsLimit Number - Disable collstats, dbstats, topmetrics and indexstats collector if there are more than <n> collections. 0=No limit
+    collstatsLimit: 0
+
   ## @param metrics.extraFlags String with extra flags to the metrics exporter
   ## ref: https://github.com/percona/mongodb_exporter/blob/main/main.go
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR refers to https://github.com/bitnami/charts/issues/15982
It replaces the hardcoded "--collect-all" with configurable values. All collector options available from mongodb-exporter are now represented by values.

This change also affects the default behaviour of metrics. It no longer defaults to "--collect-all" - instead, by default only diagnosticData and replicasetStatus are enabled (and compatible mode). In my tests, this should be enough to allow the published grafana dashboards (on grafana.com) to work the same as they do with --collect all.

Reason for the change is outlined in the above issue: "--collect-all" is very CPU intensive and collects megabytes of metric data (bloating prometheus in the process) that go mostly unused.

### Benefits

- fine grained and easily accessible control over what metrics are collected
- defaults use less CPU (80% less in my specific use case)
- adding mongodb.direct-connect and global-conn-pool should decrease logspam in mongod as the exporter now doesn't reconnect for every scrape

### Possible drawbacks

- possibly higher maintenance, depending on how the arguments of mongodb-exporter evolve
- this could be considered a breaking change by anyone depending on "--collect-all" being the default (but it actually became a default only a short while ago as a workaround for the exporter's new behavious (not exporting anything be default))

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #15982

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
