### PR TITLE
[bitnami/grafana-tempo] Avoid compactor restart

### DIFF
--- a/bitnami/grafana-tempo/Chart.lock
+++ b/bitnami/grafana-tempo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.4.1
+  version: 6.4.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.2.5
-digest: sha256:4e653c7a8beb59ae2652916dcef48cf6ae80d3f0332bf2156f1d097d31af9624
-generated: "2023-05-08T18:15:18.322977249Z"
+digest: sha256:bb5e2beb79bf97618644c826bb97417168e09b9edfb1dd3b8263b0411316b322
+generated: "2023-05-12T13:27:16.723316922+02:00"

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: grafana-tempo
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 2.3.0
+version: 2.3.1

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -119,13 +119,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.args`                                  | Override default container args (useful when using custom images)                                   | `[]`            |
 | `compactor.replicaCount`                          | Number of Compactor replicas to deploy                                                              | `1`             |
 | `compactor.livenessProbe.enabled`                 | Enable livenessProbe on Compactor nodes                                                             | `true`          |
-| `compactor.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                             | `60`            |
+| `compactor.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                             | `80`            |
 | `compactor.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                    | `10`            |
 | `compactor.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                   | `1`             |
 | `compactor.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                 | `3`             |
 | `compactor.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                 | `1`             |
 | `compactor.readinessProbe.enabled`                | Enable readinessProbe on Compactor nodes                                                            | `true`          |
-| `compactor.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                            | `60`            |
+| `compactor.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                            | `80`            |
 | `compactor.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                   | `10`            |
 | `compactor.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                  | `1`             |
 | `compactor.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                | `3`             |

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -288,7 +288,7 @@ compactor:
   livenessProbe:
     enabled: true
     failureThreshold: 3
-    initialDelaySeconds: 60
+    initialDelaySeconds: 80
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
@@ -302,7 +302,7 @@ compactor:
   readinessProbe:
     enabled: true
     failureThreshold: 3
-    initialDelaySeconds: 60
+    initialDelaySeconds: 80
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

When the chart is installed the pods of the compactor were restarted, so I'm increasing a little this time to avoid this behavior.
```
$ kubectl get po -w
NAME                                              READY   STATUS    RESTARTS      AGE
grafana-tempo-compactor-6d498df67-bb82q           0/1     Running   1 (48s ago)   2m10s
grafana-tempo-compactor-6d498df67-xbpkd           0/1     Running   1 (37s ago)   2m10s
grafana-tempo-distributor-64bf7b5db-4s7l5         1/1     Running   0             2m10s
grafana-tempo-ingester-0                          1/1     Running   0             2m10s
grafana-tempo-memcached-7d58dc68f8-vzjhc          1/1     Running   0             2m10s
grafana-tempo-metrics-generator-c59bc59bb-zp9nt   1/1     Running   0             2m10s
grafana-tempo-querier-6d5747c694-j7zk6            1/1     Running   0             2m10s
grafana-tempo-query-frontend-748dc5ff6-ldb9t      2/2     Running   0             2m10s
grafana-tempo-vulture-5486d7c754-74z6z            1/1     Running   0             2m10s
grafana-tempo-compactor-6d498df67-bb82q           1/1     Running   1 (64s ago)   2m26s
grafana-tempo-compactor-6d498df67-xbpkd           1/1     Running   1 (69s ago)   2m42s 
```

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
