### PR TITLE
[bitnami/oauth2-proxy] Allow name override of redis subchart

### DIFF
--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 3.6.1
+version: 3.6.2

--- a/bitnami/oauth2-proxy/templates/_helpers.tpl
+++ b/bitnami/oauth2-proxy/templates/_helpers.tpl
@@ -24,7 +24,7 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "oauth2-proxy.redis.fullname" -}}
-{{- printf "%s-redis" .Release.Name -}}
+{{- printf "%s-redis" (default .Release.Name .Values.redis.nameOverride) -}}
 {{- end -}}
 
 {{- define "oauth2-proxy.configmapName" -}}


### PR DESCRIPTION
### Description of the change

Update template helpers to resolve redis master node name in case one uses nameOverride for a subchart through values.yaml 

### Benefits

* Enables granular control over resource naming.
* Enables consuming more than one proxy as a subchart (through subcharts aliases) in case the app is governed by various IDPs. 

### Possible drawbacks

Not that I can think of.

### Applicable issues

Not that I'm aware of.

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
