### PR TITLE
[bitnami/kubeapps] Switch Readiness check to grpc. Fix home URL

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
-home: https://bitnami.com
+home: https://kubeapps.dev
 icon: https://bitnami.com/assets/stacks/kubeapps/img/kubeapps-stack-220x234.png
 keywords:
   - helm
@@ -32,4 +32,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 12.4.0
+version: 12.4.1

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
-home: https://kubeapps.dev
+home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/kubeapps/img/kubeapps-stack-220x234.png
 keywords:
   - helm

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -183,7 +183,7 @@ spec:
           {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+              command: ["grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
             initialDelaySeconds: 10
           {{- end }}
           {{- if .Values.kubeappsapis.customReadinessProbe }}

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -191,7 +191,7 @@ spec:
           {{- else if .Values.kubeappsapis.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+              command: ["grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
             initialDelaySeconds: 5
           {{- end }}
           {{- if .Values.kubeappsapis.customStartupProbe }}

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -182,17 +182,17 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /core/plugins/v1alpha1/configured-plugins
-              port: grpc-http
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            initialDelaySeconds: 10
           {{- end }}
           {{- if .Values.kubeappsapis.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /core/plugins/v1alpha1/configured-plugins
-              port: grpc-http
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            initialDelaySeconds: 5
           {{- end }}
           {{- if .Values.kubeappsapis.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customStartupProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

Switches the readiness and liveness probes to use grpc_health_probe (until our minimum k8s version supports this natively) rather than the http get which depends on the gRPC-Gateway which we don't otherwise use.

Also fixes the Chart.home attribute which had been accidentally (I think?) switched to "https://bitnami.com" along with all the other charts (which don't have their own bitnami/vmware home pages) in #16546 .

### Benefits

Readiness and liveness checks are using the actual endpoint which is used by the app.
More useful homepage for chart.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [N/A] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
