### PR TITLE
[bitnami/mongodb-sharded] allow mongodb to template existing secret

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: mongodb-sharded
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 6.5.0
+version: 6.5.1

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -18,7 +18,7 @@ Usage:
 
 {{- define "mongodb-sharded.secret" -}}
   {{- if .Values.auth.existingSecret -}}
-    {{- .Values.auth.existingSecret -}}
+    {{- printf "%s" (tpl .Values.auth.existingSecret $) -}}
   {{- else }}
     {{- include "common.names.fullname" . -}}
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`auth.existingSecret` may include Helm templating.

### Benefits

Allows users to use template functions when defining an existing/external secret.

### Possible drawbacks

No known drawbacks.

### Applicable issues

- fixes #16563 

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
