### PR TITLE
[bitnami/rabbitmq] Use built-in probes if management is not installed

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: rabbitmq
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 11.15.0
+version: 11.15.1

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -289,7 +289,7 @@ spec:
               command:
                 - sh
                 - -ec
-                {{- if .Values.loadDefinition.enabled }}
+                {{- if or (.Values.loadDefinition.enabled) (not (contains "rabbitmq_management" .Values.plugins )) }}
                 - rabbitmq-diagnostics -q ping
                 {{- else }}
                 - curl -f --user {{ .Values.auth.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.containerPorts.manager }}/api/health/checks/virtual-hosts
@@ -303,7 +303,7 @@ spec:
               command:
                 - sh
                 - -ec
-                {{- if .Values.loadDefinition.enabled }}
+                {{- if or (.Values.loadDefinition.enabled) (not (contains "rabbitmq_management" .Values.plugins )) }}
                 - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
                 {{- else }}
                 - curl -f --user {{ .Values.auth.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.containerPorts.manager }}/api/health/checks/local-alarms


### PR DESCRIPTION
### Description of the change

Use built-in probes if management is not installed

### Benefits

As reported in #16082, if `rabbitmq_management` plugin is omitted, there is no management interface to query.

Fallback to the built-in probes on this case.

### Possible drawbacks

It is much slower, but at least it will work :)

### Applicable issues

- complements #16082

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
