### PR TITLE
[bitnami/minio] fix error when not using persistence

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: minio
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 12.5.0
+version: 12.5.1

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -215,8 +215,10 @@ spec:
             - name: minio-credentials
               mountPath: /opt/bitnami/minio/secrets/
             {{- end }}
+            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: minio-certs
               mountPath: {{ default "/certs" .Values.tls.mountPath }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Small fix for an error when having defined `persistence: false` in the values.

### Benefits

This error will be fixed:
```
Error: INSTALLATION FAILED: template: minio/templates/standalone/deployment.yaml:219:35: executing "minio/templates/standalone/deployment.yaml" at <.Values.persistence.mountPath>: can't evaluate field mountPath in type interface {}
```

### Possible drawbacks

-

### Applicable issues

-

### Additional information

-

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
