### PR TITLE
[bitnami/postgresql-ha] Don't render empty keys from templates

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: postgresql-ha
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 11.6.0
+version: 11.6.1

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -72,7 +72,9 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "postgresql-ha.serviceAccountName" . }}
       {{- end }}
+      {{- if or .Values.pgpool.tls.enabled .Values.pgpool.initContainers -}}
       initContainers:
+      {{- end }}
       {{- if .Values.pgpool.tls.enabled }}
         - name: init-chmod-data
           image: {{ template "postgresql-ha.volumePermissions.image" . }}
@@ -98,9 +100,9 @@ spec:
               mountPath: /tmp/certs
             - name: pgpool-certificates
               mountPath: /opt/bitnami/pgpool/certs
-      {{- end }}
       {{- if .Values.pgpool.initContainers }}
       {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       {{- end }}
       # Auxiliary vars to populate environment variables
       {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
@@ -331,7 +333,9 @@ spec:
           {{- if .Values.pgpool.resources }}
           resources: {{- toYaml .Values.pgpool.resources | nindent 12 }}
           {{- end }}
+          {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM .Values.pgpool.initdbScriptsSecret .Values.postgresql.usePasswordFile .Values.pgpool.usePasswordFile .Values.pgpool.tls.enabled .Values.pgpool.extraVolumeMounts }}
           volumeMounts:
+          {{- end }}
             {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM }}
             - name: pgpool-config
               mountPath: /opt/bitnami/pgpool/user_config/
@@ -367,6 +371,7 @@ spec:
         {{- if .Values.pgpool.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.sidecars "context" $) | nindent 8 }}
         {{- end }}
+      {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM .Values.pgpool.initdbScriptsSecret .Values.postgresql.usePasswordFile .Values.pgpool.tls.enabled .Values.pgpool.extraVolumes }}
       volumes:
         {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM }}
         - name: pgpool-config
@@ -410,4 +415,5 @@ spec:
         {{- end }}
       {{- if .Values.pgpool.extraVolumes }}
       {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -80,7 +80,13 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.postgresql.hostNetwork }}
       hostIPC: {{ .Values.postgresql.hostIPC }}
+      {{- if .Values.postgresql.tls.enabled }}
       initContainers:
+      {{- else if and .Values.volumePermissions.enabled (or (or (not (empty .Values.postgresql.extendedConf)) (not (empty .Values.postgresql.extendedConfCM))) .Values.persistence.enabled) }}
+      initContainers:
+      {{- else if or .Values.postgresql.initContainers .Values.postgresql.extraInitContainers }}
+      initContainers:
+      {{- end }}
       {{- if .Values.postgresql.tls.enabled }}
         - name: init-chmod-tls
           image: {{ template "postgresql-ha.volumePermissions.image" . }}


### PR DESCRIPTION
Signed-off-by: Trey Hoffman treyhoffman@outlook.com

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change prevents rendered manifests from containing empty keys for `volumes` and `initContainers`. If there are no volumes or initContainers, then the rendered manifests should exclude their keys.

### Benefits

Datree tests would fire false positives if these empty keys are found in the manifests. Plus, it does not make sense to include a key for initContainers if there are no initContainers that actually need to run.

### Possible drawbacks

Creates somewhat more complex templating code.

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
