### PR TITLE
[bitnami/mysql] Enable extraVolumeMounts for metrics container

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: mysql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.10.0
+version: 9.11.0

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -333,6 +333,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.service.annotations`                   | Prometheus exporter service annotations                                                                                        | `{}`                      |
 | `metrics.extraArgs.primary`                     | Extra args to be passed to mysqld_exporter on Primary pods                                                                     | `[]`                      |
 | `metrics.extraArgs.secondary`                   | Extra args to be passed to mysqld_exporter on Secondary pods                                                                   | `[]`                      |
+| `metrics.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the MySQL metrics container(s)                                    | `[]`                      |
 | `metrics.resources.limits`                      | The resources limits for MySQL prometheus exporter containers                                                                  | `{}`                      |
 | `metrics.resources.requests`                    | The requested resources for MySQL prometheus exporter containers                                                               | `{}`                      |
 | `metrics.livenessProbe.enabled`                 | Enable livenessProbe                                                                                                           | `true`                    |

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -313,10 +313,15 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-          {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
+          {{- if or (and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles)) .Values.metrics.extraVolumeMounts }}
           volumeMounts:
+            {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mysql-credentials
               mountPath: /opt/bitnami/mysqld-exporter/secrets/
+            {{- end }}
+            {{- if .Values.metrics.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           {{- end }}
         {{- end }}
         {{- if .Values.primary.sidecars }}

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -297,10 +297,15 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-          {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
+          {{- if or (and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles)) .Values.metrics.extraVolumeMounts }}
           volumeMounts:
+            {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mysql-credentials
               mountPath: /opt/bitnami/mysqld-exporter/secrets/
+            {{- end }}
+            {{- if .Values.metrics.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           {{- end }}
         {{- end }}
         {{- if .Values.secondary.sidecars }}

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -1120,6 +1120,10 @@ metrics:
   extraArgs:
     primary: []
     secondary: []
+  ## @param metrics.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the MySQL metrics container(s)
+  ## The volumes referenced by these volume mounts must be defined in both the primary and secondary (if used) values.
+  ##
+  extraVolumeMounts: []
   ## Mysqld Prometheus exporter resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Description of the change

Enables extraVolumeMounts for metrics container.

### Benefits

Enables the use of customPasswordFiles for credentials within the metrics container.

### Possible drawbacks

Requires the operator to define extraVolumes in both primary and secondary if they are used by metrics.

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/16604

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
