### PR TITLE
[bitnami/zookeeper] Bugfix: Use the correct variable for logging Zookeeper hostname

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 name: zookeeper
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 11.4.0
+version: 11.4.1

--- a/bitnami/zookeeper/templates/scripts-configmap.yaml
+++ b/bitnami/zookeeper/templates/scripts-configmap.yaml
@@ -95,7 +95,7 @@ data:
             ORD=${BASH_REMATCH[2]}
             export ZOO_SERVER_ID="$((ORD + {{ .Values.minServerId }} ))"
         else
-            echo "Failed to get index from hostname $HOST"
+            echo "Failed to get index from hostname $HOSTNAME"
             exit 1
         fi
     fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use the variable HOSTNAME instead of HOST when logging the Zookeeper hostname while trying to generate a server id

### Benefits

Properly log the Hostname when the bash script fails

### Possible drawbacks

None - bugfix

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
