### PR TITLE
[bitnami/sonarqube] Enable initContainers section in deployment.yaml for caCerts

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: sonarqube
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 3.2.0
+version: 3.2.1

--- a/bitnami/sonarqube/templates/deployment.yaml
+++ b/bitnami/sonarqube/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
-      {{- if or .Values.initContainers .Values.plugins.install .Values.sysctl.enabled (and .Values.volumePermissions.enabled .Values.persistence.enabled) }}
+      {{- if or .Values.initContainers .Values.caCerts.enabled .Values.plugins.install .Values.sysctl.enabled (and .Values.volumePermissions.enabled .Values.persistence.enabled) }}
       initContainers:
         {{- if .Values.plugins.install }}
         - name: {{ printf "%s-install-plugins-initcontainer" (include "common.names.fullname" .) }}


### PR DESCRIPTION
### Description of the change

Generate an `initContainers` section in `deployment.yaml` template even if caCerts is the only initContainer to be run.

### Benefits

Enable using custom ca certificates even if no other initContainer should be run.

### Possible drawbacks

None

### Applicable issues

- fixes #16619

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
