### PR TITLE
[bitnami/supabase] Fix ingress to point to correct svc

### DIFF
--- a/bitnami/supabase/Chart.lock
+++ b/bitnami/supabase/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.4.3
+  version: 12.5.1
 - name: kong
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.2.2
+  version: 9.3.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.2.5
-digest: sha256:00bdcc8da2f3c7fbc64b5d388f0451cd683fe96464c07410869a97a3350ac262
-generated: "2023-05-11T01:00:46.277079139Z"
+  version: 2.3.0
+digest: sha256:77fee15fe39d2a3a5e25886b9044655261e747791fc60f7e82ab5a663062b1a7
+generated: "2023-05-15T11:46:52.030064+02:00"

--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: supabase
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/supabase/templates/studio/ingress.yaml
+++ b/bitnami/supabase/templates/studio/ingress.yaml
@@ -35,7 +35,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.studio.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "supabase.studio.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.studio.ingress.extraHosts }}
     - host: {{ .name | quote }}


### PR DESCRIPTION
### Description of the change

Fix Ingress to point to supabase-studio service.

### Benefits

Fix Ingress resource.

### Possible drawbacks

N/A

### Applicable issues

- fixes #16151

### Additional information


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
