### PR TITLE
[Bitname/Cassandra] Add PVC from existing Claim

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: cassandra
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 10.3.0
+version: 10.3.1

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -215,6 +215,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                             | Description                                                                                                                                          | Value                |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir                                                   | `true`               |
+| `persistence.existingClaim`      | Name of an existing PVC to use                                                                                                                       | `""`                 |
 | `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                                                                          | `""`                 |
 | `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                                                                    | `""`                 |
 | `persistence.annotations`        | Persistent Volume Claim annotations                                                                                                                  | `{}`                 |
@@ -338,7 +339,7 @@ Refer to the chart documentation for more [information on customizing an Apache 
 
 ### Initialize the database
 
-The [Bitnami Apache Cassandra image](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) image supports the use of custom scripts to initialize a fresh instance. This may be done by creating a Kubernetes ConfigMap that includes the necessary *sh* or *cql* scripts and passing this ConfigMap to the chart via the *initDBConfigMap* parameter.
+The [Bitnami Apache Cassandra image](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) image supports the use of custom scripts to initialize a fresh instance. This may be done by creating a Kubernetes ConfigMap that includes the necessary _sh_ or _cql_ scripts and passing this ConfigMap to the chart via the _initDBConfigMap_ parameter.
 
 Refer to the chart documentation for more [information on customizing an Apache Cassandra deployment](https://docs.bitnami.com/kubernetes/infrastructure/cassandra/configuration/customize-new-instance/).
 
@@ -380,7 +381,7 @@ It's necessary to set the `dbUser.password` parameter when upgrading for readine
 helm upgrade my-release oci://registry-1.docker.io/bitnamicharts/cassandra --set dbUser.password=[PASSWORD]
 ```
 
-| Note: you need to substitute the placeholder *[PASSWORD]* with the value obtained in the installation notes.
+| Note: you need to substitute the placeholder _[PASSWORD]_ with the value obtained in the installation notes.
 
 ### To 9.0.0
 

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -545,7 +545,11 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if not .Values.persistence.enabled }}
+  {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ tpl .Values.persistence.existingClaim $ }}
+  {{- else if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}
   {{- else }}
@@ -565,7 +569,7 @@ spec:
           {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}
+            storage: {{ .Values.persistence.size | quote }} 
     {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
     {{- if .Values.persistence.commitLogMountPath }}
     - metadata:

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -552,6 +552,9 @@ persistence:
   ## @param persistence.enabled Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir
   ##
   enabled: true
+  ## @param persistence.existingClaim Name of an existing PVC to use
+  ##
+  existingClaim: ""
   ## @param persistence.storageClass PVC Storage Class for Cassandra data volume
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -589,7 +592,6 @@ persistence:
   ##
   # commitLogMountPath: /bitnami/cassandra/commitlog
   commitLogMountPath: ""
-
 ## @section Volume Permissions parameters
 ##
 


### PR DESCRIPTION
### Description of the change

The Cassandra chart creates a new Persistence Volume and Persistence Volume Claim if you enable persistence but doesn't allow to use an existing PVC. This change allows to specify an existing PVC to use and not create a new one.

### Benefits

Use pre-created/existing PVC.

### Possible drawbacks


### Applicable issues

### Additional information

See: https://github.com/bitnami/charts/issues/16559

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
