### PR TITLE
[bitnami/redis] Fix PVC labeling for bitnami/redis Helm chart

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 17.11.0
+version: 17.11.1

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -500,7 +500,7 @@ spec:
         labels: {{- include "common.labels.matchLabels" . | nindent 10 }}
           app.kubernetes.io/component: master
           {{- if .Values.master.persistence.labels }}
-          {{- toYaml .Values.master.persistence.labels | nindent 4 }}
+          {{- toYaml .Values.master.persistence.labels | nindent 10 }}
           {{- end }}
         {{- if .Values.master.persistence.annotations }}
         annotations: {{- toYaml .Values.master.persistence.annotations | nindent 10 }}

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -497,7 +497,7 @@ spec:
         labels: {{- include "common.labels.matchLabels" . | nindent 10 }}
           app.kubernetes.io/component: replica
           {{- if .Values.replica.persistence.labels }}
-          {{- toYaml .Values.replica.persistence.labels | nindent 4 }}
+        {{- toYaml .Values.replica.persistence.labels | nindent 10 }}
           {{- end }}
         {{- if .Values.replica.persistence.annotations }}
         annotations: {{- toYaml .Values.replica.persistence.annotations | nindent 10 }}


### PR DESCRIPTION
Use proper indentation level when adding additional labels to PVC for both Redis master and replicas.

### Description of the change

Fixes redis Helm template when used with labels.

### Benefits

Advertised functionality actually works

### Possible drawbacks

None known.

### Applicable issues

- fixes #16677 

### Additional information

Tested manually since there is no test automation that I could find.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
