### PR TITLE
[bitnami/kube-prometheus] Allows using wildcard as hostname for prometheus ingress

### DIFF
--- a/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
@@ -21,8 +21,7 @@ spec:
   {{- end }}
   rules:
     {{- if .Values.prometheus.ingress.hostname }}
-    - host: {{ .Values.prometheus.ingress.hostname }}
-      http:
+    - http:
         paths:
           {{- if .Values.prometheus.ingress.extraPaths }}
           {{- toYaml .Values.prometheus.ingress.extraPaths | nindent 10 }}
@@ -32,6 +31,9 @@ spec:
             pathType: {{ .Values.prometheus.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.prometheus.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
+      {{- if ne .Values.prometheus.ingress.hostname "*" }}
+      host: {{ .Values.prometheus.ingress.hostname }}
+      {{- end}}
     {{- end }}
     {{- range .Values.prometheus.ingress.extraHosts }}
     - host: {{ .name | quote }}


### PR DESCRIPTION
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Skips host definition in Prometheus ingress if `.Values.prometheus.ingress.hostname` is equal to `*`.

### Benefits

<!-- What benefits will be realized by the code change? -->
This allows setting the value of Prometheus ingress hostname to `*`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
