### PR TITLE
[bitnami/moodle] Bugfix: container port different from http

### DIFF
--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 name: moodle
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 16.1.1
+version: 16.1.2

--- a/bitnami/moodle/templates/svc.yaml
+++ b/bitnami/moodle/templates/svc.yaml
@@ -42,6 +42,7 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.containerPorts.http }}
       {{- end }}
     - name: https
       port: {{ coalesce .Values.service.ports.https .Values.service.httpsPort }}
@@ -50,7 +51,6 @@ spec:
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-      targetPort: {{ .Values.containerPorts.http }}
       {{- end }}
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/moodle/templates/svc.yaml
+++ b/bitnami/moodle/templates/svc.yaml
@@ -50,6 +50,7 @@ spec:
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.containerPorts.http }}
       {{- end }}
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}

--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -45,6 +45,7 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.containerPorts.http }}
       {{- end }}
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}

--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -45,7 +45,6 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-      targetPort: {{ .Values.containerPorts.http }}
       {{- end }}
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

This change fixes the problem related to issue #16149 and any other when the service is ClusterIP type and the container listening port is not the standard HTTP port (e.g. moodle server running as a non-privileged user on 8080).

### Benefits

With this fix, the service target port gets configured with the value specified on `containerPorts.http` and the container service can be reached by the ingress.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
