### PR TITLE
[bitnami/external-dns] add missing clusterrole permissions for gateway api

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: external-dns
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 6.20.2
+version: 6.20.3

--- a/bitnami/external-dns/templates/clusterrole.yaml
+++ b/bitnami/external-dns/templates/clusterrole.yaml
@@ -19,6 +19,7 @@ rules:
       - pods
       - nodes
       - endpoints
+      - namespaces
     verbs:
       - get
       - list
@@ -100,6 +101,7 @@ rules:
       - tlsroutes
       - tcproutes
       - udproutes
+      - grpcroutes
     verbs:
       - get
       - list


### PR DESCRIPTION
### Description of the change

This change adds missing permissions required for gateway api.

### Benefits

To be able to manage dns records for gateway api resources, external-dns will use these newly added required permissions.

### Possible drawbacks

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/16589

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
