### PR TITLE
[bitnami/thanos]: conditionals for compactor cronjob

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.6.2
+version: 12.6.3

--- a/bitnami/thanos/templates/compactor/service.yaml
+++ b/bitnami/thanos/templates/compactor/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.compactor.enabled -}}
+{{- if and .Values.compactor.enabled (not .Values.compactor.cronJob.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/bitnami/thanos/templates/compactor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/compactor/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.compactor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.compactor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (not .Values.compactor.cronJob.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
### Description of the change

Don't create a `Service` or `ServiceMonitor` for the compactor when the compactor is configured to run as a cronjob

### Benefits

When enabling the compactor as a cronjob, there's no need to delete the Service & ServiceMonitor via a kustomize patch

### Possible drawbacks

N/A

### Applicable issues

#16742

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
