### PR TITLE
[bitnami/prometheus] Use FQDN for cluster.peers in alertmanager

### DIFF
--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -23,4 +23,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/prometheus/prometheus
   - https://github.com/prometheus-community/helm-charts
-version: 0.1.1
+version: 0.1.2

--- a/bitnami/prometheus/templates/alertmanager/statefulset.yaml
+++ b/bitnami/prometheus/templates/alertmanager/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
             - "--cluster.listen-address=0.0.0.0:{{ $clusterPort }}"
             {{- $fullName := include "prometheus.alertmanager.fullname" . }}
             {{- range $i := until (int .Values.alertmanager.replicaCount) }}
-            - "--cluster.peer={{ $fullName }}-{{ $i }}.{{ $fullName }}-headless:{{ $clusterPort }}"
+            - "--cluster.peer={{ $fullName }}-{{ $i }}.{{ $fullName }}-headless.{{ include "common.names.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $clusterPort }}"
             {{- end }}
             {{- end }}
             {{- if .Values.alertmanager.extraArgs }}

--- a/bitnami/prometheus/values.yaml
+++ b/bitnami/prometheus/values.yaml
@@ -633,7 +633,7 @@ server:
         {{- end }}
         - scheme: HTTP
           static_configs:
-            - targets: [ {{ printf "%s:%d" (include "prometheus.alertmanager.fullname" .) (int .Values.alertmanager.service.ports.http) }}]
+            - targets: [ "{{ printf "%s.%s.svc.%s:%d" (include "prometheus.alertmanager.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain (int .Values.alertmanager.service.ports.http) }}" ]
     rule_files:
       - rules.yaml
     {{- end }}


### PR DESCRIPTION
### Description of the change

Use FQDN for `cluster.peer` configuration in alertmanager.

### Benefits

Fix name resolution issues in some environments.

### Possible drawbacks

None identified.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
