### PR TITLE
add extraHosts to certificate

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: keycloak
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 15.1.2
+version: 15.1.3

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -52,6 +52,9 @@ spec:
   {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.secrets .Values.ingress.selfSigned) }}
     - hosts:
         - {{ (tpl .Values.ingress.hostname .) | quote }}
+      {{- range .Values.ingress.extraHosts }}
+        - {{ (tpl .name $) | quote }}
+      {{- end }}
       secretName: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}


### PR DESCRIPTION
If i define multiple hosts, i want to add them to certificate

ex: variable.yaml
```
ingress:
  hostname: keycloak..<dc>.<any.domain>

  extraHosts:
    - name: keycloak.<any.domain>
      path: /

```

result:
```
spec:
  ingressClassName: nginx
  rules:
  - host: keycloak.<dc>.<any.domain>
    http:
      paths:
      - backend:
          service:
            name: keycloak
            port:
              name: http
        path: /
        pathType: ImplementationSpecific
  - host: keycloak.<any.domain>
    http:
      paths:
      - backend:
          service:
            name: keycloak
            port:
              name: http
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - keycloak.<dc>.<any.domain>
    - keycloak.<any.domain>
    secretName: keycloak.<dc>.<any.domain>-tls
```