### PR TITLE
[bitnami/grafana] Fix handling of admin.existingSecret in the ServiceAccount

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: grafana
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 8.4.4
+version: 8.4.5

--- a/bitnami/grafana/templates/serviceaccount.yaml
+++ b/bitnami/grafana/templates/serviceaccount.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
   {{- end }}
 secrets:
-  - name: {{ include "common.names.fullname" . }}-admin
+  - name: {{ include "grafana.adminSecretName" . }}
   {{- if .Values.datasources.secretName }}
   - name: {{ .Values.datasources.secretName }}
   {{- else if .Values.datasources.secretDefinition }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Corrects the handling of the `admin.existingSecret` value when generating the ServiceAccount. Previously, `{{ include "common.names.fullname" . }}-admin` would be used even when the secret had been overwritten.

### Benefits

The ServiceAccount references the correct secret even when `admin.existingSecret` has been set.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
