### PR TITLE
[bitnami/supabase] ClusterIP services pointing to the container exposed ports

### DIFF
--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: supabase
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 0.3.5
+version: 0.3.6

--- a/bitnami/supabase/templates/auth/service.yaml
+++ b/bitnami/supabase/templates/auth/service.yaml
@@ -47,6 +47,7 @@ spec:
       nodePort: {{ .Values.auth.service.nodePorts.http }}
       {{- else if eq .Values.auth.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.auth.containerPorts.http }}
       {{- end }}
     {{- if .Values.auth.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.auth.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/supabase/templates/meta/service.yaml
+++ b/bitnami/supabase/templates/meta/service.yaml
@@ -47,6 +47,7 @@ spec:
       nodePort: {{ .Values.meta.service.nodePorts.http }}
       {{- else if eq .Values.meta.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.meta.containerPorts.http }}
       {{- end }}
     {{- if .Values.meta.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.meta.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/supabase/templates/realtime/service.yaml
+++ b/bitnami/supabase/templates/realtime/service.yaml
@@ -47,6 +47,7 @@ spec:
       nodePort: {{ .Values.realtime.service.nodePorts.http }}
       {{- else if eq .Values.realtime.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.realtime.containerPorts.http }}
       {{- end }}
     {{- if .Values.realtime.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.realtime.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/supabase/templates/rest/service.yaml
+++ b/bitnami/supabase/templates/rest/service.yaml
@@ -47,6 +47,7 @@ spec:
       nodePort: {{ .Values.rest.service.nodePorts.http }}
       {{- else if eq .Values.rest.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.rest.containerPorts.http }}
       {{- end }}
     {{- if .Values.rest.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.rest.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/supabase/templates/storage/service.yaml
+++ b/bitnami/supabase/templates/storage/service.yaml
@@ -47,6 +47,7 @@ spec:
       nodePort: {{ .Values.storage.service.nodePorts.http }}
       {{- else if eq .Values.storage.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.storage.containerPorts.http }}
       {{- end }}
     {{- if .Values.storage.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.storage.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/supabase/templates/studio/service.yaml
+++ b/bitnami/supabase/templates/studio/service.yaml
@@ -47,6 +47,7 @@ spec:
       nodePort: {{ .Values.studio.service.nodePorts.http }}
       {{- else if eq .Values.studio.service.type "ClusterIP" }}
       nodePort: null
+      targetPort: {{ .Values.studio.containerPorts.http }}
       {{- end }}
     {{- if .Values.studio.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.studio.service.extraPorts "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

This change fixes the problem related to issue #16149 by setting the service _targetPort_ to the container port when the service is ClusterIP type, for each service template on the supabase chart.

### Benefits

The service is rightly exposed when using ClusterIP type for the services.

### Applicable issues

- fixes #16149

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
