### PR TITLE
[bitnami/minio] remove unnecessary password conditions in NOTES.txt

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: minio
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 12.6.3
+version: 12.6.4

--- a/bitnami/minio/templates/NOTES.txt
+++ b/bitnami/minio/templates/NOTES.txt
@@ -74,15 +74,3 @@ To access the MinIO&reg; web UI:
 {{- include "common.warnings.rollingTag" .Values.clientImage }}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- include "minio.validateValues" . }}
-
-{{- $requiredPasswords := list -}}
-{{- $secretName := include "minio.secretName" . -}}
-{{- $rootPassword := include "minio.secret.existingPassword" . -}}
-{{- if not $rootPassword }}
-  {{- $requiredRootUser := dict "valueKey" "auth.rootUser" "secret" $secretName "field" "root-user" -}}
-  {{- $requiredRootPassword := dict "valueKey" "auth.rootPassword" "secret" $secretName "field" "root-password" -}}
-  {{- $requiredPasswords = append $requiredPasswords $requiredRootUser -}}
-  {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
-{{- end -}}
-{{- $requiredMinioPasswordErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" $) -}}
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredMinioPasswordErrors) "context" $) -}}

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -70,18 +70,6 @@ Get the password to use to access MinIO&reg;
 {{- end -}}
 
 {{/*
-Get existing password to access MinIO&reg without generating a new password;
-*/}}
-{{- define "minio.secret.existingPassword" -}}
-{{- $obj := (lookup "v1" "Secret" .Release.Namespace (include "minio.secretName" .)).data -}}
-{{- if $obj }}
-{{- index $obj "root-password" | b64dec -}}
-{{- else -}}
-{{- "" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Get the credentials secret.
 */}}
 {{- define "minio.secretName" -}}


### PR DESCRIPTION
### Description of the change

**I removed the check for the root-password `NOTES.txt`.**

The problem with the current implementation is a [known](https://github.com/helm/helm-www/issues/635) and [documented](https://github.com/helm/helm-www/blob/main/content/en/docs/chart_template_guide/functions_and_pipelines.md#using-the-lookup-function) behaviour:

> Keep in mind that Helm is not supposed to contact the Kubernetes API Server during a `helm template` or a `helm install|upgrade|delete|rollback --dry-run`, so the lookup function will return an empty list (i.e. dict) in such a case.

This (currently) makes the condition in `NOTES.txt` fail in all cases when using one of the aforementioned `helm` commands. I took a step back and thought about a case were the password could be not set/empty, but I couldn't really find one.  

I considered the following situations:

- `auth.rootPassword=""`, `auth.existingSecret=""`: The root password will be generated automatically once and kept in the default secret. On upgrades, it is looked up by Helm.
- `auth.rootPassword="xyz"`, `auth.existingSecret=""`: Same as above, without the auto-generation.
- `auth.rootPassword=""`, `auth.existingSecret="xyz"`: The password (and username) for root will be looked up from the given secret, on both installing and upgrading the chart. 

As you can see, the password will be set in all constellations.

### Benefits

Chart would be usable with `helmfile`, `helm diff` and `helm upgrade --dry-run`. Also, the problem from #14069 would still be answered.

### Possible drawbacks

The password in the existing Secret (be it auto-generated or created manually) will not be looked up anymore, so there could be a empty string inside. But if you'd consider this a problem, you'd probably have a `lookup` in the other charts as well :wink:  

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #16571 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
