### PR TITLE
[bitnami/charts] Fix issue moving cards from forks

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -1,19 +1,21 @@
 name: '[Support] Review based card movements'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - review_requested
       - synchronize
-permissions:
-  repository-projects: write
-  contents: read
-  issues: read
-  pull-requests: read
+# Remove all permissions by default
+permissions: {}
 concurrency:
   group: card-movement-${{ github.event.number }}
 jobs:
   handler:
     runs-on: ubuntu-latest
+    permissions:
+      repository-projects: write
+      contents: read
+      issues: read
+      pull-requests: read
     # This job will ignore:
     # * Events triggered by bitnami-bot (README commits for example).
     # * Events triggered over automated PRs (They are managed in comments.yml workflow).
@@ -24,10 +26,6 @@ jobs:
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3
-        with:
-          # Checkout from base to try to get latest information from the main branch.
-          ref: ${{ github.event.pull_request.base.ref }}
-          repository: ${{ github.event.pull_request.base.repo.full_name }}
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
         with:


### PR DESCRIPTION
### Description of the change

Change `pr-reviews.yaml` workflow to listen for `pull_request_target` events to avoid issues with pull requests created from forks.

### Benefits

Allow moving cards in PRs created from forked repositories.

### Possible drawbacks

None identified

### Applicable issues

- Related to: https://github.com/bitnami/charts/actions/runs/5141142920

### Additional information

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
