### PR TITLE
[bitnami/etcd] Fix label selector for pdb

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: etcd
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 8.12.0
+version: 9.0.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -440,6 +440,29 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 9.0.0
+
+This version adds a new label `app.kubernetes.io/component=etcd` to the StatefulSet and pods. Due to this change, the StatefulSet will be replaced (as it's not possible to add additional `spec.selector.matchLabels` to an existing StatefulSet) and the pods will be recreated. To upgrade to this version from a previous version, you need to run the following steps:
+
+1. Add new label to your pods
+
+    ```console
+    kubectl label pod my-release-0 app.kubernetes.io/component=etcd
+    # Repeat for all etcd pods, based on configured .replicaCount (excluding the etcd snappshoter pod, if .disasterRecovery.enabled is set to true)
+    ````
+
+2. Remove the StatefulSet keeping the pods:
+
+    ```console
+    kubectl delete statefulset my-release --cascade=orphan
+    ```
+
+3. Upgrade your cluster:
+
+    ```console
+    helm upgrade my-release oci://registry-1.docker.io/bitnamicharts/etcd --set auth.rbac.rootPassword=$ETCD_ROOT_PASSWORD
+    ```
+
 ### To 8.0.0
 
 This version reverts the change in the previous major bump ([7.0.0](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-700)). Now the default `etcd` branch is `3.5` again once confirmed by the [etcd developers](https://github.com/etcd-io/etcd/tree/main/CHANGELOG#production-recommendation) that this version is production-ready once solved the data corruption issue.

--- a/bitnami/etcd/templates/pdb.yaml
+++ b/bitnami/etcd/templates/pdb.yaml
@@ -20,4 +20,5 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: etcd
 {{- end }}

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: etcd
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -14,12 +15,14 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: etcd
   serviceName: {{ printf "%s-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: etcd
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Hi,

We found an issue, that the `PodDisruptionBudget` is not working as desired, as it currently takes  `Jobs` created by the `Cronjob` (if `disasterRecovery.enabled=true`) into consideration:
```
$ k describe poddisruptionbudgets.policy -n sandbox-profile-0-n5c8h
Name:           sandbox-profile-0-n5c8h-etcd
Namespace:      sandbox-profile-0-n5c8h
Min available:  51%
Selector:       app.kubernetes.io/instance=sandbox-profile-0-n5c8h-etcd,app.kubernetes.io/name=etcd
Status:
    Allowed disruptions:  0
    Current:              3
    Desired:              2
    Total:                3
Events:
  Type     Reason                           Age              From               Message
  ----     ------                           ----             ----               -------
  Normal   NoPods                           18m              controllermanager  No matching pods found
  Warning  CalculateExpectedPodCountFailed  2s (x2 over 2s)  controllermanager  Failed to calculate the number of expected pods: jobs.batch does not implement the scale subresource
```


### Description of the change

Adding a label to `Statefulset` and `PodDisruptionBudget` to select the correct resources, similar what is done here: https://github.com/bitnami/charts/blob/487c893862a87992f2f75ff8192c84eb0cd17ad5/bitnami/redmine/templates/pdb.yaml

**Note:** If I would change `spec.selector.matchLabels` in the `StatefulSet` it would be a breaking change, as it's forbidden to update this field for already existing instances.

**Another option**: Define the selector of `PodDisruptionBudget` like this, by adding the `matchExpressions`
```
  selector:
    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
    {{- if .Values.disasterRecovery.enabled }}
    matchExpressions:
      - key: app.kubernetes.io/component
        operator: NotIn
        values:
          - snapshotter
    {{- end }}
```

### Benefits

We can drain nodes and `PodDisruptionBudget` is working if disaster recovery is enabled.

### Possible drawbacks

- Breaking change if we decide to update `spec.selector.matchLabels` as well

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
