### PR TITLE
[bitnami/wavefront] Mark wavefront helm chart as deprecated

### DIFF
--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -13,7 +13,8 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: Wavefront is a high-performance streaming analytics platform for monitoring and optimizing your environment and applications.
+deprecated: true
+description: DEPRECATED Wavefront is a high-performance streaming analytics platform for monitoring and optimizing your environment and applications.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/wavefront/img/wavefront-stack-220x234.png
 keywords:
@@ -21,10 +22,8 @@ keywords:
   - monitoring
   - observability
   - alerting
-maintainers:
-  - name: VMware, Inc.
-    url: https://github.com/bitnami/charts
+maintainers: []
 name: wavefront
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/wavefront
-version: 4.4.2
+version: 4.4.3

--- a/bitnami/wavefront/README.md
+++ b/bitnami/wavefront/README.md
@@ -6,6 +6,10 @@ Wavefront is a high-performance streaming analytics platform for monitoring and 
 
 [Overview of Wavefront](https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes)
 
+## This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 ## TL;DR
 
 ```console

--- a/bitnami/wavefront/templates/NOTES.txt
+++ b/bitnami/wavefront/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
### Description of the change

Wavefront helm chart will be deprecated since the upstream project has been discontinued and no new features.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
