### PR TITLE
[bitnami/vault] Fix: fluxcd fails to install vault

### DIFF
--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: vault
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 0.2.1
+version: 0.2.2

--- a/bitnami/vault/templates/server/statefulset.yaml
+++ b/bitnami/vault/templates/server/statefulset.yaml
@@ -120,7 +120,6 @@ spec:
             {{- end }}
           {{- end }}
           env:
-          env:
             - name: HOST_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removing a duplicated `env:` key in `server/statefulset.yaml` template which causes vault installation to fail when using
fluxcd-2.0.0-rc.5:

```
vault     	        	False    	False	Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
          	        	         	     	  line 73: mapping key "env" already defined at line 72
```

### Benefits

bitnami/vault helm chart will be possible to install using fluxcd

### Possible drawbacks

Not aware of any.

### Applicable issues

N/A

### Additional information

I have tested this change by building a new helm chart and successfully been able to install it using fluxcd-2.0.0-rc.5 in a k3s cluster.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
