### PR TITLE
[bitnami/grafana-tempo] Add external client to generate traces

### DIFF
--- a/.vib/grafana-tempo/goss/goss.yaml
+++ b/.vib/grafana-tempo/goss/goss.yaml
@@ -33,6 +33,11 @@ command:
     exit-status: 0
     stdout:
       - "vulture"
+  xk6-client-registered-traces:
+    exec: tempo-cli query api search http://grafana-tempo-query-frontend:{{ .Vars.queryFrontend.service.ports.http }}
+    exit-status: 0
+    stdout:
+      - "article-to-cart"
   {{- $uid := .Vars.compactor.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.compactor.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/grafana-tempo/runtime-parameters.yaml
+++ b/.vib/grafana-tempo/runtime-parameters.yaml
@@ -1,8 +1,8 @@
 tempo:
   dataDir: /bitnami/grafana-tempo/data
   traces:
-    jaeger:
-      thriftHttp: true
+    otlp:
+      grpc: true
   search:
     enabled: true
   containerPorts:
@@ -43,3 +43,26 @@ queryFrontend:
       http: 80
 vulture:
   enabled: true
+extraDeploy:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: vib-xk6-client-tracing
+    name: vib-xk6-client-tracing
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: vib-xk6-client-tracing
+    template:
+      metadata:
+        labels:
+          app: vib-xk6-client-tracing
+      spec:
+        containers:
+        - image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
+          name: xk6-client-tracing
+          env:
+          - name: ENDPOINT
+            value: grafana-tempo-distributor:4317


### PR DESCRIPTION
### Description of the change

At testing time, add external client to the deployment to generate traces and verify that the ingestion of data is working properly. Based on https://grafana.com/docs/tempo/latest/getting-started/docker-example/ and https://github.com/grafana/tempo/blob/3e70bb9/example/docker-compose/distributed/docker-compose.yaml.

### Benefits

Improved test battery.

### Possible drawbacks

Additional points of unreliability in the tests.

### Checklist

- [ ] n/a ~Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.~
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
