### PR TITLE
[bitnami/postgresql] Fix execution when enablePostgresUser is false

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: postgresql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 12.5.6
+version: 12.5.7

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -154,7 +154,7 @@ Get the user-password key.
 Return true if a secret object should be created
 */}}
 {{- define "postgresql.createSecret" -}}
-{{- if not (or .Values.global.postgresql.auth.existingSecret .Values.auth.existingSecret) -}}
+{{- if and (not (or .Values.global.postgresql.auth.existingSecret .Values.auth.existingSecret)) (.Values.auth.enablePostgresUser) -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -207,6 +207,10 @@ spec:
               value: {{ .Values.containerPorts.postgresql | quote }}
             - name: POSTGRESQL_VOLUME_DIR
               value: {{ .Values.primary.persistence.mountPath | quote }}
+            {{- if not .Values.auth.enablePostgresUser }}
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "true"
+            {{- end }}
             {{- if .Values.primary.persistence.mountPath }}
             - name: PGDATA
               value: {{ .Values.postgresqlDataDir | quote }}
@@ -228,6 +232,7 @@ spec:
             {{- end }}
             {{- end }}
           {{- end }}
+            {{- if .Values.auth.enablePostgresUser }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: POSTGRES_PASSWORD_FILE
               value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include "postgresql.userPasswordKey" .) }}
@@ -237,6 +242,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
                   key: {{ include "postgresql.userPasswordKey" . }}
+            {{- end }}
             {{- end }}
             {{- if (include "postgresql.database" .) }}
             - name: POSTGRES_DB


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

It fixes the execution when ALLOW_EMPTY_PASSWORD. It avoids the creation of the secret and sets `ALLOW_EMPTY_PASSWORD` in that case.

### Benefits

Allow the execution without assigning a password to the "postgres" admin user.

### Possible drawbacks

N/A

### Applicable issues

- fixes #16865

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
