### PR TITLE
[bitnami/mysql,mariadb] Use default slow-query log file

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: mariadb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 12.2.5
+version: 12.2.6

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -205,7 +205,6 @@ primary:
     character-set-server=UTF8
     collation-server=utf8_general_ci
     slow_query_log=0
-    slow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log
     long_query_time=10.0
 
     [client]
@@ -602,7 +601,6 @@ secondary:
     character-set-server=UTF8
     collation-server=utf8_general_ci
     slow_query_log=0
-    slow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log
     long_query_time=10.0
 
     [client]

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: mysql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.10.2
+version: 9.10.3

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -201,7 +201,6 @@ primary:
     character-set-server=UTF8
     collation-server=utf8_general_ci
     slow_query_log=0
-    slow_query_log_file=/opt/bitnami/mysql/logs/mysqld.log
     long_query_time=10.0
 
     [client]
@@ -580,7 +579,6 @@ secondary:
     character-set-server=UTF8
     collation-server=utf8_general_ci
     slow_query_log=0
-    slow_query_log_file=/opt/bitnami/mysql/logs/mysqld.log
     long_query_time=10.0
 
     [client]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use default slow query log path (inside data directory) for data to be easily checked using the `mysqldumpslow` binary.

### Benefits

if enabled, slow query information can be easily checked.

### Possible drawbacks

Not expected.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
