### PR TITLE
[bitnami/postgresql-ha] Fix password reference for created secret

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: postgresql-ha
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 11.7.4
+version: 11.7.5

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -388,7 +388,7 @@ spec:
           secret:
             secretName: {{ include "postgresql-ha.postgresqlSecretName" . }}
             items:
-              - key: postgresql-password
+              - key: password
                 path: pgpool-password
               - key: repmgr-password
                 path: pgpool-sr-check-password

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -388,8 +388,13 @@ spec:
           secret:
             secretName: {{ include "postgresql-ha.postgresqlSecretName" . }}
             items:
+              {{- if eq (include "postgresql-ha.postgresqlUsername" .) "postgres" }}
               - key: password
                 path: pgpool-password
+              {{- else }}
+              - key: postgresql-password
+                path: pgpool-password
+              {{- end }}             
               - key: repmgr-password
                 path: pgpool-sr-check-password
         {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

when I set both of:
```
postgresql.usePasswordFile	
pgpool.usePasswordFile	
````

I’m getting this error
```
MountVolume.SetUp failed for volume "postgresql-password" : references non-existent secret key: postgresql-password
```

This is my values.yaml

```yaml
postgresql:
  usePasswordFile: "true"
  replicaCount: 1

pgpool:
  usePasswordFile: "true"
``` 

`password` is always included in the pgsql secret. However, `postgres-password` may or may not be included.

### Benefits

Deploying with usePasswordFile for both pgpool and postgresql now works.

### Possible drawbacks

None I can think of

### Applicable issues

NA

### Additional information

The key here: https://github.com/bitnami/charts/blob/main/bitnami/postgresql-ha/templates/pgpool/deployment.yaml#L391 would still not be correct if the secret https://github.com/bitnami/charts/blob/main/bitnami/postgresql-ha/templates/postgresql/secrets.yaml#LL1C1-L22C12 included the key `postgres-password` since the volume references the key `postgresql-password`. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
