### PR TITLE
[bitnami/vault] fix: break when using vault csiProvider

### DIFF
--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: vault
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 0.2.3
+version: 0.2.4

--- a/bitnami/vault/values.yaml
+++ b/bitnami/vault/values.yaml
@@ -752,7 +752,7 @@ csiProvider:
   ##
   config: |
     vault {
-        "address" = "http://{{ include "vault.server.fullname" }}:{{ .Values.server.service.general.ports.http }}
+        "address" = "http://{{ include "vault.server.fullname" . }}:{{ .Values.server.service.general.ports.http }}
     }
 
     cache {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix a bug in default value of `vault` charts, which cause error when vault csiProvider  enabled

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
