### PR TITLE
[bitnami/clickhouse] allow to set custom configuration for users folder

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: clickhouse
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.4.4
+version: 3.5.0

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -156,6 +156,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraOverrides`                | Extra configuration overrides (evaluated as a template) apart from the default                                           | `""`                    |
 | `extraOverridesConfigmap`       | The name of an existing ConfigMap with extra configuration for ClickHouse                                                | `""`                    |
 | `extraOverridesSecret`          | The name of an existing ConfigMap with your custom configuration for ClickHouse                                          | `""`                    |
+| `usersExtraOverrides`           | Users extra configuration overrides (evaluated as a template) apart from the default                                     | `""`                    |
+| `usersExtraOverridesConfigmap`  | The name of an existing ConfigMap with users extra configuration for ClickHouse                                          | `""`                    |
+| `usersExtraOverridesSecret`     | The name of an existing ConfigMap with your custom users configuration for ClickHouse                                    | `""`                    |
 | `initdbScripts`                 | Dictionary of initdb scripts                                                                                             | `{}`                    |
 | `initdbScriptsSecret`           | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)                                                      | `""`                    |
 | `startdbScripts`                | Dictionary of startdb scripts                                                                                            | `{}`                    |

--- a/bitnami/clickhouse/templates/_helpers.tpl
+++ b/bitnami/clickhouse/templates/_helpers.tpl
@@ -99,6 +99,18 @@ Get the ClickHouse configuration configmap.
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Get the ClickHouse configuration users configmap.
+*/}}
+{{- define "clickhouse.usersExtraConfigmapName" -}}
+{{- if .Values.usersExtraOverridesConfigmap -}}
+    {{- .Values.usersExtraOverridesConfigmap -}}
+{{- else }}
+    {{- printf "%s-users-extra" (include "common.names.fullname" . ) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Get the Clickhouse password secret name
 */}}
@@ -195,7 +207,7 @@ Compile all warnings into a single message.
 {{- if or (and .Values.keeper.enabled .Values.zookeeper.enabled) (and .Values.keeper.enabled .Values.externalZookeeper.servers) (and .Values.zookeeper.enabled .Values.externalZookeeper.servers) -}}
 clickhouse: Multiple [Zoo]keeper
     You can only use one [zoo]keeper
-    Please choose use ClickHouse keeper or 
+    Please choose use ClickHouse keeper or
     installing a Zookeeper chart (--set zookeeper.enabled=true) or
     using an external instance (--set zookeeper.servers )
 {{- end -}}

--- a/bitnami/clickhouse/templates/configmap-users-extra.yaml
+++ b/bitnami/clickhouse/templates/configmap-users-extra.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.usersExtraOverrides (not .Values.usersExtraOverridesConfigmap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-users-extra" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  01_users_extra_overrides.xml: |
+    {{- include "common.tplvalues.render" (dict "value" .Values.usersExtraOverrides "context" $) | nindent 4 }}
+{{- end }}

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -33,6 +33,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
         checksum/config-extra: {{ include (print $.Template.BasePath "/configmap-extra.yaml") $ | sha256sum }}
+        checksum/config-users-extra: {{ include (print $.Template.BasePath "/configmap-users-extra.yaml") $ | sha256sum }}
         {{- if $.Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" $.Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -316,9 +317,17 @@ spec:
             - name: extra-config
               mountPath: /bitnami/clickhouse/etc/conf.d/extra-configmap
           {{- end }}
+          {{- if or $.Values.usersExtraOverridesConfigmap $.Values.usersExtraOverrides }}
+            - name: users-extra-config
+              mountPath: /bitnami/clickhouse/etc/users.d/users-extra-configmap
+          {{- end }}
           {{- if $.Values.extraOverridesSecret }}
             - name: extra-secret
               mountPath: /bitnami/clickhouse/etc/conf.d/extra-secret
+          {{- end }}
+          {{- if $.Values.usersExtraOverridesSecret }}
+            - name: users-extra-secret
+              mountPath: /bitnami/clickhouse/etc/users.d/users-extra-secret
           {{- end }}
           {{- if $.Values.tls.enabled }}
             - name: clickhouse-certificates
@@ -361,10 +370,20 @@ spec:
           configMap:
             name: {{ template "clickhouse.extraConfigmapName" $ }}
         {{- end }}
+        {{- if or $.Values.usersExtraOverridesConfigmap $.Values.usersExtraOverrides }}
+        - name: users-extra-config
+          configMap:
+            name: {{ template "clickhouse.usersExtraConfigmapName" $ }}
+        {{- end }}
         {{- if $.Values.extraOverridesSecret }}
         - name: extra-secret
           secret:
             secretName: {{ $.Values.extraOverridesSecret }}
+        {{- end }}
+        {{- if $.Values.usersExtraOverridesSecret }}
+        - name: users-extra-secret
+          secret:
+            secretName: {{ $.Values.usersExtraOverridesSecret }}
         {{- end }}
         {{- if not $.Values.persistence.enabled }}
         - name: data

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -395,6 +395,18 @@ extraOverridesConfigmap: ""
 ##
 extraOverridesSecret: ""
 
+## @param usersExtraOverrides Users extra configuration overrides (evaluated as a template) apart from the default
+##
+usersExtraOverrides: ""
+
+## @param usersExtraOverridesConfigmap The name of an existing ConfigMap with users extra configuration for ClickHouse
+##
+usersExtraOverridesConfigmap: ""
+
+## @param usersExtraOverridesSecret The name of an existing ConfigMap with your custom users configuration for ClickHouse
+##
+usersExtraOverridesSecret: ""
+
 ## @param initdbScripts Dictionary of initdb scripts
 ## Specify dictionary of scripts to be run at first boot
 ## Example:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

As shards need to set specific configuration over some user (default for example), there is no way to indicate that custom config from the chart. This PR takes the same approach the `extra` config map (or custom extra config) the chart uses today.

### Benefits

Shards and custom configs for users are now supported

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

- fixes #13541

### Additional information

This PR does not require changes on the bitnami clickhouse image, as the image already handles files written under the `users.d` folder. More info: [link to code](https://github.com/bitnami/containers/blob/cc3d2cdfe72ce58e788ba78fb627679632b1e088/bitnami/clickhouse/23/debian-11/rootfs/opt/bitnami/scripts/libclickhouse.sh#L89-L90C6)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
