### PR TITLE
[MongoDB] Respecting the MONGODB_ROOT_USER environment variable

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: mongodb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 13.15.1
+version: 13.15.2

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -120,7 +120,7 @@ data:
       {{- if .Values.externalAccess.externalMaster.enabled }}
         current_primary={{ printf "%s:%d" (.Values.externalAccess.externalMaster.host) ( int .Values.externalAccess.externalMaster.port) }}
       {{- else }}
-        current_primary=$(mongosh admin --host "{{ join "," $mongoList }}" {{- if .Values.auth.enabled }} --authenticationDatabase admin -u root -p $MONGODB_ROOT_PASSWORD{{- end }}{{- if .Values.tls.enabled}} --tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert{{- end }} --eval 'db.runCommand("ismaster")' | awk -F\' '/primary/ {print $2}')
+        current_primary=$(mongosh admin --host "{{ join "," $mongoList }}" {{- if .Values.auth.enabled }} --authenticationDatabase admin -u $MONGODB_ROOT_USER -p $MONGODB_ROOT_PASSWORD{{- end }}{{- if .Values.tls.enabled}} --tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert{{- end }} --eval 'db.runCommand("ismaster")' | awk -F\' '/primary/ {print $2}')
       {{- end }}
       if ! is_empty_value "$current_primary"; then
         info "Detected existing primary: ${current_primary}"

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -223,7 +223,7 @@ data:
     SLEEP_PERIOD=10
 
     {{- if and .Values.auth.enabled .Values.auth.rootPassword }}
-    usernameAndPassword="-u ${$MONGODB_ROOT_USER} -p ${MONGODB_ROOT_PASSWORD}"
+    usernameAndPassword="-u ${MONGODB_ROOT_USER} -p ${MONGODB_ROOT_PASSWORD}"
     {{- else }}
     usernameAndPassword=""
     {{- end }}


### PR DESCRIPTION
- Fixing reference to MONGODB_ROOT_USERNAME
- Use mongodb root user when getting current primary

### Description of the change

The MongoDB root username is customisable in the values.yaml file. This value was not used in all parts of the chart. 

This PR addresses a typo made when implementing that fix.

### Benefits

Correctly uses the MONGODB_ROOT_USER environment variable 

### Possible drawbacks

n/a

### Applicable issues

PR where `$` error was introduced
- https://github.com/bitnami/charts/pull/16849#pullrequestreview-1478956290
PR where `root` username was returned to current primary command: 
- https://github.com/bitnami/charts/pull/16853

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
