### PR TITLE
[bitnami/thanos] Exclude headless services from serviceMonitor

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.6.3
+version: 12.6.4

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -449,3 +449,15 @@ Usage:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Labels to use on serviceMonitor.spec.selector and svc.metadata.labels
+*/}}
+{{- define "thanos.servicemonitor.matchLabels" -}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+prometheus-operator/monitor: 'true'
+{{- if .Values.metrics.serviceMonitor.selector -}}
+{{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $)}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/thanos/templates/bucketweb/service.yaml
+++ b/bitnami/thanos/templates/bucketweb/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: bucketweb
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}

--- a/bitnami/thanos/templates/compactor/service.yaml
+++ b/bitnami/thanos/templates/compactor/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/compactor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/compactor/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: compactor
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}

--- a/bitnami/thanos/templates/query-frontend/service.yaml
+++ b/bitnami/thanos/templates/query-frontend/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/thanos/templates/query-frontend/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: query-frontend
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}

--- a/bitnami/thanos/templates/query/service.yaml
+++ b/bitnami/thanos/templates/query/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/query/servicemonitor.yaml
+++ b/bitnami/thanos/templates/query/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: query
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/receive/servicemonitor.yaml
+++ b/bitnami/thanos/templates/receive/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: receive
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}

--- a/bitnami/thanos/templates/ruler/service.yaml
+++ b/bitnami/thanos/templates/ruler/service.yaml
@@ -6,9 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
-    {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
-    prometheus-operator/monitor: 'true'
-    {{- end }}
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/ruler/servicemonitor.yaml
+++ b/bitnami/thanos/templates/ruler/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: ruler
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/service.yaml
+++ b/bitnami/thanos/templates/storegateway/service.yaml
@@ -6,9 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
-    {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
-    prometheus-operator/monitor: 'true'
-    {{- end }}
+    {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/thanos/templates/storegateway/servicemonitor.yaml
+++ b/bitnami/thanos/templates/storegateway/servicemonitor.yaml
@@ -45,7 +45,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: storegateway
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+      {{- include "thanos.servicemonitor.matchLabels" . | nindent 6 -}}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Exclude headless services from serviceMonitor.
### Benefits

Avoid monitoring twice the same endpoints.

### Possible drawbacks

None identified.

### Applicable issues

- fixes #16967

### Additional information

Other PRs related:
* https://github.com/bitnami/charts/pull/2263
* https://github.com/bitnami/charts/pull/3160
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
