### PR TITLE
[bitnami/PostgreSQL] Update statefulset to inlcude verbose PVC reference

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: postgresql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 12.5.7
+version: 12.5.8

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -620,7 +620,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.primary.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.primary.persistence.annotations "context" $) | nindent 10 }}


### PR DESCRIPTION
### Description of the change

This is a simple cosmetic change in order to make my life a bit easier while working with the `PostgreSQL` chart and `ArgoCD`. I use the code-snippet below to deploy PostgreSQL via [`kustomize`](https://kustomize.io/), which produces a manifest referencing the `PersistentVolumeClaim` in the short form, without the `apiVersion` and `kind` (see the right side of the image below the code-snippet). 

The issue, is that the verbose reference is added once I apply it to my Cluster (left side of the image). This results in `ArgoCD` thinking there is a diff, where in actuality, they are equal. Now this can be solved by me adding a patch which adds the verbose reference, but I don't want to have unnecessary complexity for something I think is kind of silly. 

**Config**
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: abc123
resources:
helmCharts:
  - name: postgresql
    repo: https://charts.bitnami.com/bitnami
    version: 12.5.7 # https://artifacthub.io/packages/helm/bitnami/postgresql
    releaseName: abc123
    namespace: abc123
    valuesFile: values-postgresql.yaml
```
**Image**
![image](https://github.com/bitnami/charts/assets/34520175/fdcfa4f7-1ea5-4aaa-9dba-8f4c2a034890)

### Benefits

Saves me an extra file everytime I need to deploy `PostgreSQL`

### Possible drawbacks

I don't think this would break anything, but I haven't used Helm enough to know

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
