### PR TITLE
[bitnami/postgresql-ha] pgPool Load Balanced Write Bugfix

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: postgresql-ha
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 11.7.5
+version: 11.7.6

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -221,7 +221,7 @@ spec:
               value: {{ ternary "yes" "no" .Values.pgpool.useLoadBalancing | quote }}
             {{- if .Values.pgpool.useLoadBalancing }}
             - name: PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE
-              value: {{ .Values.pgpool.loadBalancingOnWrite }}
+              value: {{ .Values.pgpool.loadBalancingOnWrite | quote }}
             {{- end }}
             - name: PGPOOL_ENABLE_LOG_CONNECTIONS
               value: {{ ternary "yes" "no" .Values.pgpool.logConnections | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added missing quotes around PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE value. The missing `| quote` filter would render an invalid deployment manifest when `pgpool.loadBalancingOnWrite` was set to `off` because YAML interprets `off` as `false` when unquoted.

### Benefits

Allows users to correctly configure load balancing in pgPool for reads from the PostgreSQL servers without also load balancing writes to the pool, should they choose to do so.

### Possible drawbacks

N/A

### Applicable issues

I personally encountered this bug just recently, but I haven't filed an issue for it. Quite frankly, the fix took less time than creating the issue would, so here we are.

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
