### PR TITLE
[bitnami/spring-cloud-dataflow] Fix issue 17117 - Unable to mount volumes on Tasks

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 19.0.0
+version: 19.0.1

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -987,10 +987,10 @@ deployer:
   tolerations: []
   ## @param deployer.volumeMounts Streaming applications extra volume mounts
   ##
-  volumeMounts: {}
+  volumeMounts: []
   ## @param deployer.volumes Streaming applications extra volumes
   ##
-  volumes: {}
+  volumes: []
   ## @param deployer.environmentVariables Streaming applications environment variables
   ## RabbitMQ/Kafka envs.
   ## Example:


### PR DESCRIPTION
### Description of the change

This is a bug fix as outlines here in the issue:
https://github.com/bitnami/charts/issues/17117

`volumes` and `volumeMounts` properties are not being applied under `deployer` as they are originally defined as objects.

### Benefits

This will fix the issue where `deployer` is unable to mount volumes for `Tasks`.

### Possible drawbacks

I cannot see any.

### Applicable issues


### Additional information


### Checklist
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)