### PR TITLE
[bitnami/kube-state-metrics] Added example section for "extraArgs" section to help use argument in correct way

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: kube-state-metrics
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
-version: 3.5.4
+version: 3.5.5

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -114,7 +114,9 @@ image:
   ##
   pullSecrets: []
 ## @param extraArgs Additional command line arguments to pass to kube-state-metrics
-##
+## Example:
+## extraArgs:
+##    metric-labels-allowlist: pods=[*]
 extraArgs: {}
 ## @param command Override default container command (useful when using custom images)
 ##


### PR DESCRIPTION

### Description of the change

Adding an example section for `extraArgs` in values.yaml

### Benefits

This section will help new people use this argument as people new to Helm may find this one difficult to use.

### Possible drawbacks

None, As this change is added as a comment only so no drawbacks

### Applicable issues

- fixes # N/A

### Additional information

N/A

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in the agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
