### PR TITLE
[bitnami/rabbitmq] removed empty line added between password and cookie secret

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: rabbitmq
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 12.0.1
+version: 12.0.2

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -20,10 +20,10 @@ type: Opaque
 data:
   {{- if (not .Values.auth.existingPasswordSecret ) }}
   rabbitmq-password: {{ print $password | b64enc | quote }}
-  {{ end }}
+  {{- end }}
   {{- if (not .Values.auth.existingErlangSecret ) }}
   rabbitmq-erlang-cookie: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "rabbitmq-erlang-cookie" "length" 32 "providedValues" (list "auth.erlangCookie") "context" $) }}
-  {{ end }}
+  {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.extraSecrets }}
 ---


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
I am using rabbitmq as dependency.
Upon debugging my chart template using the `helm template [CHART] --debug` command, I noticed that the secrets YAML file generated an empty line between rabbitmq-password and rabbitmq-erlang-cookie.
![image](https://github.com/bitnami/charts/assets/26142591/a78ce781-9631-4686-b790-9bb0a340e085)

This change removes any trailing whitespace between rabbitmq-password and rabbitmq-erlang-cookie.

### Benefits

<!-- What benefits will be realized by the code change? -->
By removing the empty line, the generated secrets YAML file will have a cleaner and more consistent structure.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
