### PR TITLE
[bitnami/thanos] Add labels for Thanos Compactor PVC

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.6.3
+version: 12.7.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -610,6 +610,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `compactor.persistence.accessModes`                           | PVC Access Modes for data volume                                                                                                 | `["ReadWriteOnce"]`      |
 | `compactor.persistence.size`                                  | PVC Storage Request for data volume                                                                                              | `8Gi`                    |
 | `compactor.persistence.annotations`                           | Annotations for the PVC                                                                                                          | `{}`                     |
+| `compactor.persistence.labels`                                | Labels for the PVC                         | `{}`                     |
 | `compactor.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                   | `""`                     |
 
 ### Thanos Store Gateway parameters

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -609,7 +609,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `compactor.persistence.storageClass`                          | Specify the `storageClass` used to provision the volume                                                                          | `""`                     |
 | `compactor.persistence.accessModes`                           | PVC Access Modes for data volume                                                                                                 | `["ReadWriteOnce"]`      |
 | `compactor.persistence.size`                                  | PVC Storage Request for data volume                                                                                              | `8Gi`                    |
-| `compactor.persistence.labels`                                | Labels for the PVC                         | `{}`                     |
+| `compactor.persistence.labels`                                | Labels for the PVC                                                                                                               | `{}`                     |
 | `compactor.persistence.annotations`                           | Annotations for the PVC                                                                                                          | `{}`                     |
 | `compactor.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                   | `""`                     |
 

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -609,8 +609,8 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `compactor.persistence.storageClass`                          | Specify the `storageClass` used to provision the volume                                                                          | `""`                     |
 | `compactor.persistence.accessModes`                           | PVC Access Modes for data volume                                                                                                 | `["ReadWriteOnce"]`      |
 | `compactor.persistence.size`                                  | PVC Storage Request for data volume                                                                                              | `8Gi`                    |
-| `compactor.persistence.annotations`                           | Annotations for the PVC                                                                                                          | `{}`                     |
 | `compactor.persistence.labels`                                | Labels for the PVC                         | `{}`                     |
+| `compactor.persistence.annotations`                           | Annotations for the PVC                                                                                                          | `{}`                     |
 | `compactor.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                   | `""`                     |
 
 ### Thanos Store Gateway parameters

--- a/bitnami/thanos/templates/compactor/pvc.yaml
+++ b/bitnami/thanos/templates/compactor/pvc.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.compactor.persistence.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.compactor.persistence.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.compactor.persistence.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.compactor.persistence.annotations }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2109,6 +2109,9 @@ compactor:
     ## @param compactor.persistence.size PVC Storage Request for data volume
     ##
     size: 8Gi
+    ## @param compactor.persistence.labels Labels for the PVC
+    ##
+    labels: {}
     ## @param compactor.persistence.annotations Annotations for the PVC
     ##
     annotations: {}
@@ -3098,6 +3101,9 @@ ruler:
     ## @param ruler.persistence.size PVC Storage Request for data volume
     ##
     size: 8Gi
+    ## @param compactor.persistence.labels Labels for the PVC
+    ##
+    labels: {}
     ## @param ruler.persistence.annotations Annotations for the PVC
     ##
     annotations: {}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -3101,9 +3101,6 @@ ruler:
     ## @param ruler.persistence.size PVC Storage Request for data volume
     ##
     size: 8Gi
-    ## @param compactor.persistence.labels Labels for the PVC
-    ##
-    labels: {}
     ## @param ruler.persistence.annotations Annotations for the PVC
     ##
     annotations: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This change will add the possibility to add labels to the PVC of the Thanos Compactor
### Benefits
It is possible to add labels to the PVC. Before this only the common labels were added to the PVC. One use-case would be to add the `label_excluded_from_alerts=true` label to the PVC, which is used by kube-prometheus to ignore certain PVCs.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->
I cannot think of drawbacks.
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
