### PR TITLE
[bitnami/redis] Add automountServiceAccountToken in pod specs

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 17.11.5
+version: 17.11.6

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -65,6 +65,7 @@ spec:
       securityContext: {{- omit .Values.master.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "redis.masterServiceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.master.serviceAccount.automountServiceAccountToken }}
       {{- if .Values.master.priorityClassName }}
       priorityClassName: {{ .Values.master.priorityClassName | quote }}
       {{- end }}

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -64,6 +64,7 @@ spec:
       securityContext: {{- omit .Values.replica.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "redis.replicaServiceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.replica.serviceAccount.automountServiceAccountToken }}
       {{- if .Values.replica.priorityClassName }}
       priorityClassName: {{ .Values.replica.priorityClassName | quote }}
       {{- end }}

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -68,6 +68,7 @@ spec:
       {{- if .Values.replica.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.replica.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ template "redis.serviceAccountName" . }}
       {{- if .Values.replica.priorityClassName }}
       priorityClassName: {{ .Values.replica.priorityClassName | quote }}


### PR DESCRIPTION
### Description of the change

Add the `automountServiceAccountToken` to redis `master`, `replica` and `sentinel`.

### Benefits

Allow a user to influence the `automountServiceAccountToken` setting for `PodSpec`s.

### Possible drawbacks

A user having a custom `ServiceAccount` configured but explicitly having `automountServiceAccountToken` set to `false` might inadvertently rely on the current behavior of auto-mounting. I would argue, that the intent of `automountServiceAccountToken: false` is to not mount the token, making this a bug.

### Applicable issues

- fixes #17174 

### Additional information
-

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
