### PR TITLE
[bitnami/wavefront-prometheus-storage-adapter] Mark Wavefront Prometheus Adapter helm chart as deprecated

### DIFF
--- a/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
+++ b/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
@@ -25,6 +25,7 @@ keywords:
   - observability
   - wavefront
 maintainers: []
+name: wavefront-prometheus-storage-adapter
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/wavefront-prometheus-storage-adapter
 version: 2.3.3

--- a/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
+++ b/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
@@ -13,7 +13,8 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: Wavefront Storage Adapter is a Prometheus integration to transfer metrics from Prometheus to Wavefront. It lets you save Prometheus data in Wavefront without changing your existing Prometheus setup.
+deprecated: true
+description: DEPRECATED Wavefront Storage Adapter is a Prometheus integration to transfer metrics from Prometheus to Wavefront. It lets you save Prometheus data in Wavefront without changing your existing Prometheus setup.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/wavefront-prometheus-storage-adapter/img/wavefront-prometheus-storage-adapter-stack-220x234.png
 keywords:
@@ -23,10 +24,7 @@ keywords:
   - monitoring
   - observability
   - wavefront
-maintainers:
-  - name: VMware, Inc.
-    url: https://github.com/bitnami/charts
-name: wavefront-prometheus-storage-adapter
+maintainers: []
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/wavefront-prometheus-storage-adapter
-version: 2.3.2
+version: 2.3.3

--- a/bitnami/wavefront-prometheus-storage-adapter/README.md
+++ b/bitnami/wavefront-prometheus-storage-adapter/README.md
@@ -6,6 +6,10 @@ Wavefront Storage Adapter is a Prometheus integration to transfer metrics from P
 
 [Overview of Wavefront Prometheus Adapter](https://github.com/wavefrontHQ/prometheus-storage-adapter)
 
+## This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 ## TL;DR
 
 ```console

--- a/bitnami/wavefront-prometheus-storage-adapter/README.md
+++ b/bitnami/wavefront-prometheus-storage-adapter/README.md
@@ -8,7 +8,7 @@ Wavefront Storage Adapter is a Prometheus integration to transfer metrics from P
 
 ## This Helm chart is deprecated
 
-The upstream project has been discontinued and no new features.
+This Helm chart is deprecated on our side and will not receive new updates.
 
 ## TL;DR
 

--- a/bitnami/wavefront-prometheus-storage-adapter/templates/NOTES.txt
+++ b/bitnami/wavefront-prometheus-storage-adapter/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/wavefront-prometheus-storage-adapter/templates/NOTES.txt
+++ b/bitnami/wavefront-prometheus-storage-adapter/templates/NOTES.txt
@@ -1,6 +1,4 @@
-This Helm chart is deprecated
-
-The upstream project has been discontinued and no new features.
+This Helm chart is deprecated on our side and will not receive new updates
 
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}


### PR DESCRIPTION
### Description of the change

Wavefront Prometheus Adapter helm chart will be deprecated since the upstream project has been discontinued and no new features.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
