### PR TITLE
[bitnami/postgresql] Set auto-mount service account token in PodSpec

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: postgresql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 12.5.8
+version: 12.5.9

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -58,6 +58,7 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.primary.extraPodSpec "context" $) | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "postgresql.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- include "postgresql.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.primary.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.primary.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -56,6 +56,7 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.readReplicas.extraPodSpec "context" $) | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "postgresql.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- include "postgresql.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.readReplicas.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.readReplicas.hostAliases "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

Add the `automountServiceAccountToken` to postgresql `primary` and `read`.

### Benefits

Allow a user to influence the `automountServiceAccountToken` setting for `PodSpec`s.

### Possible drawbacks

A user having a custom `ServiceAccount` configured but explicitly having `automountServiceAccountToken` set to `false` might inadvertently rely on the current behavior of auto-mounting. I would argue, that the intent of `automountServiceAccountToken: false` is to not mount the token, making this a bug.

### Applicable issues

- fixes #17194 

### Additional information

This is the same issue / solution as in PR #17175 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
