### PR TITLE
[bitnami/redis] Try to seed redis with pss-restricted

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 17.13.2
+version: 17.14.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -123,296 +123,311 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Redis&reg; master configuration parameters
 
-| Name                                                 | Description                                                                                           | Value                    |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
-| `master.count`                                       | Number of Redis&reg; master instances to deploy (experimental, requires additional configuration)     | `1`                      |
-| `master.configuration`                               | Configuration for Redis&reg; master nodes                                                             | `""`                     |
-| `master.disableCommands`                             | Array with Redis&reg; commands to disable on master nodes                                             | `["FLUSHDB","FLUSHALL"]` |
-| `master.command`                                     | Override default container command (useful when using custom images)                                  | `[]`                     |
-| `master.args`                                        | Override default container args (useful when using custom images)                                     | `[]`                     |
-| `master.preExecCmds`                                 | Additional commands to run prior to starting Redis&reg; master                                        | `[]`                     |
-| `master.extraFlags`                                  | Array with additional command line flags for Redis&reg; master                                        | `[]`                     |
-| `master.extraEnvVars`                                | Array with extra environment variables to add to Redis&reg; master nodes                              | `[]`                     |
-| `master.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Redis&reg; master nodes                      | `""`                     |
-| `master.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Redis&reg; master nodes                         | `""`                     |
-| `master.containerPorts.redis`                        | Container port to open on Redis&reg; master nodes                                                     | `6379`                   |
-| `master.startupProbe.enabled`                        | Enable startupProbe on Redis&reg; master nodes                                                        | `false`                  |
-| `master.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                | `20`                     |
-| `master.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                       | `5`                      |
-| `master.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                      | `5`                      |
-| `master.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                    | `5`                      |
-| `master.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                    | `1`                      |
-| `master.livenessProbe.enabled`                       | Enable livenessProbe on Redis&reg; master nodes                                                       | `true`                   |
-| `master.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                               | `20`                     |
-| `master.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                      | `5`                      |
-| `master.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                     | `5`                      |
-| `master.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                   | `5`                      |
-| `master.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                   | `1`                      |
-| `master.readinessProbe.enabled`                      | Enable readinessProbe on Redis&reg; master nodes                                                      | `true`                   |
-| `master.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                              | `20`                     |
-| `master.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                     | `5`                      |
-| `master.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                    | `1`                      |
-| `master.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                  | `5`                      |
-| `master.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                  | `1`                      |
-| `master.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                    | `{}`                     |
-| `master.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                   | `{}`                     |
-| `master.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                  | `{}`                     |
-| `master.resources.limits`                            | The resources limits for the Redis&reg; master containers                                             | `{}`                     |
-| `master.resources.requests`                          | The requested resources for the Redis&reg; master containers                                          | `{}`                     |
-| `master.podSecurityContext.enabled`                  | Enabled Redis&reg; master pods' Security Context                                                      | `true`                   |
-| `master.podSecurityContext.fsGroup`                  | Set Redis&reg; master pod's Security Context fsGroup                                                  | `1001`                   |
-| `master.containerSecurityContext.enabled`            | Enabled Redis&reg; master containers' Security Context                                                | `true`                   |
-| `master.containerSecurityContext.runAsUser`          | Set Redis&reg; master containers' Security Context runAsUser                                          | `1001`                   |
-| `master.kind`                                        | Use either Deployment or StatefulSet (default)                                                        | `StatefulSet`            |
-| `master.schedulerName`                               | Alternate scheduler for Redis&reg; master pods                                                        | `""`                     |
-| `master.updateStrategy.type`                         | Redis&reg; master statefulset strategy type                                                           | `RollingUpdate`          |
-| `master.minReadySeconds`                             | How many seconds a pod needs to be ready before killing the next, during update                       | `0`                      |
-| `master.priorityClassName`                           | Redis&reg; master pods' priorityClassName                                                             | `""`                     |
-| `master.hostAliases`                                 | Redis&reg; master pods host aliases                                                                   | `[]`                     |
-| `master.podLabels`                                   | Extra labels for Redis&reg; master pods                                                               | `{}`                     |
-| `master.podAnnotations`                              | Annotations for Redis&reg; master pods                                                                | `{}`                     |
-| `master.shareProcessNamespace`                       | Share a single process namespace between all of the containers in Redis&reg; master pods              | `false`                  |
-| `master.podAffinityPreset`                           | Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`            | `""`                     |
-| `master.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`       | `soft`                   |
-| `master.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`      | `""`                     |
-| `master.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `master.affinity` is set                                          | `""`                     |
-| `master.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `master.affinity` is set                                       | `[]`                     |
-| `master.affinity`                                    | Affinity for Redis&reg; master pods assignment                                                        | `{}`                     |
-| `master.nodeSelector`                                | Node labels for Redis&reg; master pods assignment                                                     | `{}`                     |
-| `master.tolerations`                                 | Tolerations for Redis&reg; master pods assignment                                                     | `[]`                     |
-| `master.topologySpreadConstraints`                   | Spread Constraints for Redis&reg; master pod assignment                                               | `[]`                     |
-| `master.dnsPolicy`                                   | DNS Policy for Redis&reg; master pod                                                                  | `""`                     |
-| `master.dnsConfig`                                   | DNS Configuration for Redis&reg; master pod                                                           | `{}`                     |
-| `master.lifecycleHooks`                              | for the Redis&reg; master container(s) to automate configuration before or after startup              | `{}`                     |
-| `master.extraVolumes`                                | Optionally specify extra list of additional volumes for the Redis&reg; master pod(s)                  | `[]`                     |
-| `master.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Redis&reg; master container(s)       | `[]`                     |
-| `master.sidecars`                                    | Add additional sidecar containers to the Redis&reg; master pod(s)                                     | `[]`                     |
-| `master.initContainers`                              | Add additional init containers to the Redis&reg; master pod(s)                                        | `[]`                     |
-| `master.persistence.enabled`                         | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                          | `true`                   |
-| `master.persistence.medium`                          | Provide a medium for `emptyDir` volumes.                                                              | `""`                     |
-| `master.persistence.sizeLimit`                       | Set this to enable a size limit for `emptyDir` volumes.                                               | `""`                     |
-| `master.persistence.path`                            | The path the volume will be mounted at on Redis&reg; master containers                                | `/data`                  |
-| `master.persistence.subPath`                         | The subdirectory of the volume to mount on Redis&reg; master containers                               | `""`                     |
-| `master.persistence.subPathExpr`                     | Used to construct the subPath subdirectory of the volume to mount on Redis&reg; master containers     | `""`                     |
-| `master.persistence.storageClass`                    | Persistent Volume storage class                                                                       | `""`                     |
-| `master.persistence.accessModes`                     | Persistent Volume access modes                                                                        | `["ReadWriteOnce"]`      |
-| `master.persistence.size`                            | Persistent Volume size                                                                                | `8Gi`                    |
-| `master.persistence.annotations`                     | Additional custom annotations for the PVC                                                             | `{}`                     |
-| `master.persistence.labels`                          | Additional custom labels for the PVC                                                                  | `{}`                     |
-| `master.persistence.selector`                        | Additional labels to match for the PVC                                                                | `{}`                     |
-| `master.persistence.dataSource`                      | Custom PVC data source                                                                                | `{}`                     |
-| `master.persistence.existingClaim`                   | Use a existing PVC which must be created manually before bound                                        | `""`                     |
-| `master.service.type`                                | Redis&reg; master service type                                                                        | `ClusterIP`              |
-| `master.service.ports.redis`                         | Redis&reg; master service port                                                                        | `6379`                   |
-| `master.service.nodePorts.redis`                     | Node port for Redis&reg; master                                                                       | `""`                     |
-| `master.service.externalTrafficPolicy`               | Redis&reg; master service external traffic policy                                                     | `Cluster`                |
-| `master.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                        | `[]`                     |
-| `master.service.internalTrafficPolicy`               | Redis&reg; master service internal traffic policy (requires Kubernetes v1.22 or greater to be usable) | `Cluster`                |
-| `master.service.clusterIP`                           | Redis&reg; master service Cluster IP                                                                  | `""`                     |
-| `master.service.loadBalancerIP`                      | Redis&reg; master service Load Balancer IP                                                            | `""`                     |
-| `master.service.loadBalancerSourceRanges`            | Redis&reg; master service Load Balancer sources                                                       | `[]`                     |
-| `master.service.externalIPs`                         | Redis&reg; master service External IPs                                                                | `[]`                     |
-| `master.service.annotations`                         | Additional custom annotations for Redis&reg; master service                                           | `{}`                     |
-| `master.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                  | `None`                   |
-| `master.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                           | `{}`                     |
-| `master.terminationGracePeriodSeconds`               | Integer setting the termination grace period for the redis-master pods                                | `30`                     |
-| `master.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                  | `false`                  |
-| `master.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                | `""`                     |
-| `master.serviceAccount.automountServiceAccountToken` | Whether to auto mount the service account token                                                       | `true`                   |
-| `master.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                  | `{}`                     |
+| Name                                                       | Description                                                                                           | Value                    |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
+| `master.count`                                             | Number of Redis&reg; master instances to deploy (experimental, requires additional configuration)     | `1`                      |
+| `master.configuration`                                     | Configuration for Redis&reg; master nodes                                                             | `""`                     |
+| `master.disableCommands`                                   | Array with Redis&reg; commands to disable on master nodes                                             | `["FLUSHDB","FLUSHALL"]` |
+| `master.command`                                           | Override default container command (useful when using custom images)                                  | `[]`                     |
+| `master.args`                                              | Override default container args (useful when using custom images)                                     | `[]`                     |
+| `master.preExecCmds`                                       | Additional commands to run prior to starting Redis&reg; master                                        | `[]`                     |
+| `master.extraFlags`                                        | Array with additional command line flags for Redis&reg; master                                        | `[]`                     |
+| `master.extraEnvVars`                                      | Array with extra environment variables to add to Redis&reg; master nodes                              | `[]`                     |
+| `master.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Redis&reg; master nodes                      | `""`                     |
+| `master.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Redis&reg; master nodes                         | `""`                     |
+| `master.containerPorts.redis`                              | Container port to open on Redis&reg; master nodes                                                     | `6379`                   |
+| `master.startupProbe.enabled`                              | Enable startupProbe on Redis&reg; master nodes                                                        | `false`                  |
+| `master.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                | `20`                     |
+| `master.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                       | `5`                      |
+| `master.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                      | `5`                      |
+| `master.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                    | `5`                      |
+| `master.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                    | `1`                      |
+| `master.livenessProbe.enabled`                             | Enable livenessProbe on Redis&reg; master nodes                                                       | `true`                   |
+| `master.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                               | `20`                     |
+| `master.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                      | `5`                      |
+| `master.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                     | `5`                      |
+| `master.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                   | `5`                      |
+| `master.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                   | `1`                      |
+| `master.readinessProbe.enabled`                            | Enable readinessProbe on Redis&reg; master nodes                                                      | `true`                   |
+| `master.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                              | `20`                     |
+| `master.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                     | `5`                      |
+| `master.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                    | `1`                      |
+| `master.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                  | `5`                      |
+| `master.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                  | `1`                      |
+| `master.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                    | `{}`                     |
+| `master.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                   | `{}`                     |
+| `master.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                  | `{}`                     |
+| `master.resources.limits`                                  | The resources limits for the Redis&reg; master containers                                             | `{}`                     |
+| `master.resources.requests`                                | The requested resources for the Redis&reg; master containers                                          | `{}`                     |
+| `master.podSecurityContext.enabled`                        | Enabled Redis&reg; master pods' Security Context                                                      | `true`                   |
+| `master.podSecurityContext.fsGroup`                        | Set Redis&reg; master pod's Security Context fsGroup                                                  | `1001`                   |
+| `master.containerSecurityContext.enabled`                  | Enabled Redis&reg; master containers' Security Context                                                | `true`                   |
+| `master.containerSecurityContext.runAsUser`                | Set Redis&reg; master containers' Security Context runAsUser                                          | `1001`                   |
+| `master.containerSecurityContext.runAsGroup`               | Set Redis&reg; master containers' Security Context runAsGroup                                         | `0`                      |
+| `master.containerSecurityContext.runAsNonRoot`             | Set Redis&reg; master containers' Security Context runAsNonRoot                                       | `true`                   |
+| `master.containerSecurityContext.allowPrivilegeEscalation` | Is it possible to escalate Redis&reg; pod(s) privileges                                               | `false`                  |
+| `master.containerSecurityContext.seccompProfile.type`      | Set Redis&reg; master containers' Security Context seccompProfile                                     | `RuntimeDefault`         |
+| `master.containerSecurityContext.capabilities.drop`        | Set Redis&reg; master containers' Security Context capabilities to drop                               | `["ALL"]`                |
+| `master.kind`                                              | Use either Deployment or StatefulSet (default)                                                        | `StatefulSet`            |
+| `master.schedulerName`                                     | Alternate scheduler for Redis&reg; master pods                                                        | `""`                     |
+| `master.updateStrategy.type`                               | Redis&reg; master statefulset strategy type                                                           | `RollingUpdate`          |
+| `master.minReadySeconds`                                   | How many seconds a pod needs to be ready before killing the next, during update                       | `0`                      |
+| `master.priorityClassName`                                 | Redis&reg; master pods' priorityClassName                                                             | `""`                     |
+| `master.hostAliases`                                       | Redis&reg; master pods host aliases                                                                   | `[]`                     |
+| `master.podLabels`                                         | Extra labels for Redis&reg; master pods                                                               | `{}`                     |
+| `master.podAnnotations`                                    | Annotations for Redis&reg; master pods                                                                | `{}`                     |
+| `master.shareProcessNamespace`                             | Share a single process namespace between all of the containers in Redis&reg; master pods              | `false`                  |
+| `master.podAffinityPreset`                                 | Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`            | `""`                     |
+| `master.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`       | `soft`                   |
+| `master.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`      | `""`                     |
+| `master.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `master.affinity` is set                                          | `""`                     |
+| `master.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `master.affinity` is set                                       | `[]`                     |
+| `master.affinity`                                          | Affinity for Redis&reg; master pods assignment                                                        | `{}`                     |
+| `master.nodeSelector`                                      | Node labels for Redis&reg; master pods assignment                                                     | `{}`                     |
+| `master.tolerations`                                       | Tolerations for Redis&reg; master pods assignment                                                     | `[]`                     |
+| `master.topologySpreadConstraints`                         | Spread Constraints for Redis&reg; master pod assignment                                               | `[]`                     |
+| `master.dnsPolicy`                                         | DNS Policy for Redis&reg; master pod                                                                  | `""`                     |
+| `master.dnsConfig`                                         | DNS Configuration for Redis&reg; master pod                                                           | `{}`                     |
+| `master.lifecycleHooks`                                    | for the Redis&reg; master container(s) to automate configuration before or after startup              | `{}`                     |
+| `master.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Redis&reg; master pod(s)                  | `[]`                     |
+| `master.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Redis&reg; master container(s)       | `[]`                     |
+| `master.sidecars`                                          | Add additional sidecar containers to the Redis&reg; master pod(s)                                     | `[]`                     |
+| `master.initContainers`                                    | Add additional init containers to the Redis&reg; master pod(s)                                        | `[]`                     |
+| `master.persistence.enabled`                               | Enable persistence on Redis&reg; master nodes using Persistent Volume Claims                          | `true`                   |
+| `master.persistence.medium`                                | Provide a medium for `emptyDir` volumes.                                                              | `""`                     |
+| `master.persistence.sizeLimit`                             | Set this to enable a size limit for `emptyDir` volumes.                                               | `""`                     |
+| `master.persistence.path`                                  | The path the volume will be mounted at on Redis&reg; master containers                                | `/data`                  |
+| `master.persistence.subPath`                               | The subdirectory of the volume to mount on Redis&reg; master containers                               | `""`                     |
+| `master.persistence.subPathExpr`                           | Used to construct the subPath subdirectory of the volume to mount on Redis&reg; master containers     | `""`                     |
+| `master.persistence.storageClass`                          | Persistent Volume storage class                                                                       | `""`                     |
+| `master.persistence.accessModes`                           | Persistent Volume access modes                                                                        | `["ReadWriteOnce"]`      |
+| `master.persistence.size`                                  | Persistent Volume size                                                                                | `8Gi`                    |
+| `master.persistence.annotations`                           | Additional custom annotations for the PVC                                                             | `{}`                     |
+| `master.persistence.labels`                                | Additional custom labels for the PVC                                                                  | `{}`                     |
+| `master.persistence.selector`                              | Additional labels to match for the PVC                                                                | `{}`                     |
+| `master.persistence.dataSource`                            | Custom PVC data source                                                                                | `{}`                     |
+| `master.persistence.existingClaim`                         | Use a existing PVC which must be created manually before bound                                        | `""`                     |
+| `master.service.type`                                      | Redis&reg; master service type                                                                        | `ClusterIP`              |
+| `master.service.ports.redis`                               | Redis&reg; master service port                                                                        | `6379`                   |
+| `master.service.nodePorts.redis`                           | Node port for Redis&reg; master                                                                       | `""`                     |
+| `master.service.externalTrafficPolicy`                     | Redis&reg; master service external traffic policy                                                     | `Cluster`                |
+| `master.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                        | `[]`                     |
+| `master.service.internalTrafficPolicy`                     | Redis&reg; master service internal traffic policy (requires Kubernetes v1.22 or greater to be usable) | `Cluster`                |
+| `master.service.clusterIP`                                 | Redis&reg; master service Cluster IP                                                                  | `""`                     |
+| `master.service.loadBalancerIP`                            | Redis&reg; master service Load Balancer IP                                                            | `""`                     |
+| `master.service.loadBalancerSourceRanges`                  | Redis&reg; master service Load Balancer sources                                                       | `[]`                     |
+| `master.service.externalIPs`                               | Redis&reg; master service External IPs                                                                | `[]`                     |
+| `master.service.annotations`                               | Additional custom annotations for Redis&reg; master service                                           | `{}`                     |
+| `master.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                  | `None`                   |
+| `master.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                           | `{}`                     |
+| `master.terminationGracePeriodSeconds`                     | Integer setting the termination grace period for the redis-master pods                                | `30`                     |
+| `master.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                  | `false`                  |
+| `master.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                | `""`                     |
+| `master.serviceAccount.automountServiceAccountToken`       | Whether to auto mount the service account token                                                       | `true`                   |
+| `master.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                  | `{}`                     |
 
 ### Redis&reg; replicas configuration parameters
 
-| Name                                                  | Description                                                                                             | Value                    |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `replica.replicaCount`                                | Number of Redis&reg; replicas to deploy                                                                 | `3`                      |
-| `replica.configuration`                               | Configuration for Redis&reg; replicas nodes                                                             | `""`                     |
-| `replica.disableCommands`                             | Array with Redis&reg; commands to disable on replicas nodes                                             | `["FLUSHDB","FLUSHALL"]` |
-| `replica.command`                                     | Override default container command (useful when using custom images)                                    | `[]`                     |
-| `replica.args`                                        | Override default container args (useful when using custom images)                                       | `[]`                     |
-| `replica.preExecCmds`                                 | Additional commands to run prior to starting Redis&reg; replicas                                        | `[]`                     |
-| `replica.extraFlags`                                  | Array with additional command line flags for Redis&reg; replicas                                        | `[]`                     |
-| `replica.extraEnvVars`                                | Array with extra environment variables to add to Redis&reg; replicas nodes                              | `[]`                     |
-| `replica.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Redis&reg; replicas nodes                      | `""`                     |
-| `replica.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Redis&reg; replicas nodes                         | `""`                     |
-| `replica.externalMaster.enabled`                      | Use external master for bootstrapping                                                                   | `false`                  |
-| `replica.externalMaster.host`                         | External master host to bootstrap from                                                                  | `""`                     |
-| `replica.externalMaster.port`                         | Port for Redis service external master host                                                             | `6379`                   |
-| `replica.containerPorts.redis`                        | Container port to open on Redis&reg; replicas nodes                                                     | `6379`                   |
-| `replica.startupProbe.enabled`                        | Enable startupProbe on Redis&reg; replicas nodes                                                        | `true`                   |
-| `replica.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                  | `10`                     |
-| `replica.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                         | `10`                     |
-| `replica.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                        | `5`                      |
-| `replica.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                      | `22`                     |
-| `replica.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                      | `1`                      |
-| `replica.livenessProbe.enabled`                       | Enable livenessProbe on Redis&reg; replicas nodes                                                       | `true`                   |
-| `replica.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                 | `20`                     |
-| `replica.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                        | `5`                      |
-| `replica.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                       | `5`                      |
-| `replica.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                     | `5`                      |
-| `replica.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                     | `1`                      |
-| `replica.readinessProbe.enabled`                      | Enable readinessProbe on Redis&reg; replicas nodes                                                      | `true`                   |
-| `replica.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                | `20`                     |
-| `replica.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                       | `5`                      |
-| `replica.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                      | `1`                      |
-| `replica.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                    | `5`                      |
-| `replica.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                    | `1`                      |
-| `replica.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                      | `{}`                     |
-| `replica.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                     | `{}`                     |
-| `replica.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                    | `{}`                     |
-| `replica.resources.limits`                            | The resources limits for the Redis&reg; replicas containers                                             | `{}`                     |
-| `replica.resources.requests`                          | The requested resources for the Redis&reg; replicas containers                                          | `{}`                     |
-| `replica.podSecurityContext.enabled`                  | Enabled Redis&reg; replicas pods' Security Context                                                      | `true`                   |
-| `replica.podSecurityContext.fsGroup`                  | Set Redis&reg; replicas pod's Security Context fsGroup                                                  | `1001`                   |
-| `replica.containerSecurityContext.enabled`            | Enabled Redis&reg; replicas containers' Security Context                                                | `true`                   |
-| `replica.containerSecurityContext.runAsUser`          | Set Redis&reg; replicas containers' Security Context runAsUser                                          | `1001`                   |
-| `replica.schedulerName`                               | Alternate scheduler for Redis&reg; replicas pods                                                        | `""`                     |
-| `replica.updateStrategy.type`                         | Redis&reg; replicas statefulset strategy type                                                           | `RollingUpdate`          |
-| `replica.minReadySeconds`                             | How many seconds a pod needs to be ready before killing the next, during update                         | `0`                      |
-| `replica.priorityClassName`                           | Redis&reg; replicas pods' priorityClassName                                                             | `""`                     |
-| `replica.podManagementPolicy`                         | podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods                         | `""`                     |
-| `replica.hostAliases`                                 | Redis&reg; replicas pods host aliases                                                                   | `[]`                     |
-| `replica.podLabels`                                   | Extra labels for Redis&reg; replicas pods                                                               | `{}`                     |
-| `replica.podAnnotations`                              | Annotations for Redis&reg; replicas pods                                                                | `{}`                     |
-| `replica.shareProcessNamespace`                       | Share a single process namespace between all of the containers in Redis&reg; replicas pods              | `false`                  |
-| `replica.podAffinityPreset`                           | Pod affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`             | `""`                     |
-| `replica.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`        | `soft`                   |
-| `replica.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`       | `""`                     |
-| `replica.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `replica.affinity` is set                                           | `""`                     |
-| `replica.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `replica.affinity` is set                                        | `[]`                     |
-| `replica.affinity`                                    | Affinity for Redis&reg; replicas pods assignment                                                        | `{}`                     |
-| `replica.nodeSelector`                                | Node labels for Redis&reg; replicas pods assignment                                                     | `{}`                     |
-| `replica.tolerations`                                 | Tolerations for Redis&reg; replicas pods assignment                                                     | `[]`                     |
-| `replica.topologySpreadConstraints`                   | Spread Constraints for Redis&reg; replicas pod assignment                                               | `[]`                     |
-| `replica.dnsPolicy`                                   | DNS Policy for Redis&reg; replica pods                                                                  | `""`                     |
-| `replica.dnsConfig`                                   | DNS Configuration for Redis&reg; replica pods                                                           | `{}`                     |
-| `replica.lifecycleHooks`                              | for the Redis&reg; replica container(s) to automate configuration before or after startup               | `{}`                     |
-| `replica.extraVolumes`                                | Optionally specify extra list of additional volumes for the Redis&reg; replicas pod(s)                  | `[]`                     |
-| `replica.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Redis&reg; replicas container(s)       | `[]`                     |
-| `replica.sidecars`                                    | Add additional sidecar containers to the Redis&reg; replicas pod(s)                                     | `[]`                     |
-| `replica.initContainers`                              | Add additional init containers to the Redis&reg; replicas pod(s)                                        | `[]`                     |
-| `replica.persistence.enabled`                         | Enable persistence on Redis&reg; replicas nodes using Persistent Volume Claims                          | `true`                   |
-| `replica.persistence.medium`                          | Provide a medium for `emptyDir` volumes.                                                                | `""`                     |
-| `replica.persistence.sizeLimit`                       | Set this to enable a size limit for `emptyDir` volumes.                                                 | `""`                     |
-| `replica.persistence.path`                            | The path the volume will be mounted at on Redis&reg; replicas containers                                | `/data`                  |
-| `replica.persistence.subPath`                         | The subdirectory of the volume to mount on Redis&reg; replicas containers                               | `""`                     |
-| `replica.persistence.subPathExpr`                     | Used to construct the subPath subdirectory of the volume to mount on Redis&reg; replicas containers     | `""`                     |
-| `replica.persistence.storageClass`                    | Persistent Volume storage class                                                                         | `""`                     |
-| `replica.persistence.accessModes`                     | Persistent Volume access modes                                                                          | `["ReadWriteOnce"]`      |
-| `replica.persistence.size`                            | Persistent Volume size                                                                                  | `8Gi`                    |
-| `replica.persistence.annotations`                     | Additional custom annotations for the PVC                                                               | `{}`                     |
-| `replica.persistence.labels`                          | Additional custom labels for the PVC                                                                    | `{}`                     |
-| `replica.persistence.selector`                        | Additional labels to match for the PVC                                                                  | `{}`                     |
-| `replica.persistence.dataSource`                      | Custom PVC data source                                                                                  | `{}`                     |
-| `replica.persistence.existingClaim`                   | Use a existing PVC which must be created manually before bound                                          | `""`                     |
-| `replica.service.type`                                | Redis&reg; replicas service type                                                                        | `ClusterIP`              |
-| `replica.service.ports.redis`                         | Redis&reg; replicas service port                                                                        | `6379`                   |
-| `replica.service.nodePorts.redis`                     | Node port for Redis&reg; replicas                                                                       | `""`                     |
-| `replica.service.externalTrafficPolicy`               | Redis&reg; replicas service external traffic policy                                                     | `Cluster`                |
-| `replica.service.internalTrafficPolicy`               | Redis&reg; replicas service internal traffic policy (requires Kubernetes v1.22 or greater to be usable) | `Cluster`                |
-| `replica.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                          | `[]`                     |
-| `replica.service.clusterIP`                           | Redis&reg; replicas service Cluster IP                                                                  | `""`                     |
-| `replica.service.loadBalancerIP`                      | Redis&reg; replicas service Load Balancer IP                                                            | `""`                     |
-| `replica.service.loadBalancerSourceRanges`            | Redis&reg; replicas service Load Balancer sources                                                       | `[]`                     |
-| `replica.service.annotations`                         | Additional custom annotations for Redis&reg; replicas service                                           | `{}`                     |
-| `replica.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                    | `None`                   |
-| `replica.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                             | `{}`                     |
-| `replica.terminationGracePeriodSeconds`               | Integer setting the termination grace period for the redis-replicas pods                                | `30`                     |
-| `replica.autoscaling.enabled`                         | Enable replica autoscaling settings                                                                     | `false`                  |
-| `replica.autoscaling.minReplicas`                     | Minimum replicas for the pod autoscaling                                                                | `1`                      |
-| `replica.autoscaling.maxReplicas`                     | Maximum replicas for the pod autoscaling                                                                | `11`                     |
-| `replica.autoscaling.targetCPU`                       | Percentage of CPU to consider when autoscaling                                                          | `""`                     |
-| `replica.autoscaling.targetMemory`                    | Percentage of Memory to consider when autoscaling                                                       | `""`                     |
-| `replica.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                    | `false`                  |
-| `replica.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                  | `""`                     |
-| `replica.serviceAccount.automountServiceAccountToken` | Whether to auto mount the service account token                                                         | `true`                   |
-| `replica.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                    | `{}`                     |
+| Name                                                        | Description                                                                                             | Value                    |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `replica.replicaCount`                                      | Number of Redis&reg; replicas to deploy                                                                 | `3`                      |
+| `replica.configuration`                                     | Configuration for Redis&reg; replicas nodes                                                             | `""`                     |
+| `replica.disableCommands`                                   | Array with Redis&reg; commands to disable on replicas nodes                                             | `["FLUSHDB","FLUSHALL"]` |
+| `replica.command`                                           | Override default container command (useful when using custom images)                                    | `[]`                     |
+| `replica.args`                                              | Override default container args (useful when using custom images)                                       | `[]`                     |
+| `replica.preExecCmds`                                       | Additional commands to run prior to starting Redis&reg; replicas                                        | `[]`                     |
+| `replica.extraFlags`                                        | Array with additional command line flags for Redis&reg; replicas                                        | `[]`                     |
+| `replica.extraEnvVars`                                      | Array with extra environment variables to add to Redis&reg; replicas nodes                              | `[]`                     |
+| `replica.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Redis&reg; replicas nodes                      | `""`                     |
+| `replica.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Redis&reg; replicas nodes                         | `""`                     |
+| `replica.externalMaster.enabled`                            | Use external master for bootstrapping                                                                   | `false`                  |
+| `replica.externalMaster.host`                               | External master host to bootstrap from                                                                  | `""`                     |
+| `replica.externalMaster.port`                               | Port for Redis service external master host                                                             | `6379`                   |
+| `replica.containerPorts.redis`                              | Container port to open on Redis&reg; replicas nodes                                                     | `6379`                   |
+| `replica.startupProbe.enabled`                              | Enable startupProbe on Redis&reg; replicas nodes                                                        | `true`                   |
+| `replica.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                  | `10`                     |
+| `replica.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                         | `10`                     |
+| `replica.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                        | `5`                      |
+| `replica.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                      | `22`                     |
+| `replica.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                      | `1`                      |
+| `replica.livenessProbe.enabled`                             | Enable livenessProbe on Redis&reg; replicas nodes                                                       | `true`                   |
+| `replica.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                 | `20`                     |
+| `replica.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                        | `5`                      |
+| `replica.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                       | `5`                      |
+| `replica.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                     | `5`                      |
+| `replica.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                     | `1`                      |
+| `replica.readinessProbe.enabled`                            | Enable readinessProbe on Redis&reg; replicas nodes                                                      | `true`                   |
+| `replica.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                | `20`                     |
+| `replica.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                       | `5`                      |
+| `replica.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                      | `1`                      |
+| `replica.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                    | `5`                      |
+| `replica.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                    | `1`                      |
+| `replica.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                      | `{}`                     |
+| `replica.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                     | `{}`                     |
+| `replica.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                    | `{}`                     |
+| `replica.resources.limits`                                  | The resources limits for the Redis&reg; replicas containers                                             | `{}`                     |
+| `replica.resources.requests`                                | The requested resources for the Redis&reg; replicas containers                                          | `{}`                     |
+| `replica.podSecurityContext.enabled`                        | Enabled Redis&reg; replicas pods' Security Context                                                      | `true`                   |
+| `replica.podSecurityContext.fsGroup`                        | Set Redis&reg; replicas pod's Security Context fsGroup                                                  | `1001`                   |
+| `replica.containerSecurityContext.enabled`                  | Enabled Redis&reg; replicas containers' Security Context                                                | `true`                   |
+| `replica.containerSecurityContext.runAsUser`                | Set Redis&reg; replicas containers' Security Context runAsUser                                          | `1001`                   |
+| `replica.containerSecurityContext.runAsGroup`               | Set Redis&reg; replicas containers' Security Context runAsGroup                                         | `0`                      |
+| `replica.containerSecurityContext.runAsNonRoot`             | Set Redis&reg; replicas containers' Security Context runAsNonRoot                                       | `true`                   |
+| `replica.containerSecurityContext.allowPrivilegeEscalation` | Set Redis&reg; replicas pod's Security Context allowPrivilegeEscalation                                 | `false`                  |
+| `replica.containerSecurityContext.seccompProfile.type`      | Set Redis&reg; replicas containers' Security Context seccompProfile                                     | `RuntimeDefault`         |
+| `replica.containerSecurityContext.capabilities.drop`        | Set Redis&reg; replicas containers' Security Context capabilities to drop                               | `["ALL"]`                |
+| `replica.schedulerName`                                     | Alternate scheduler for Redis&reg; replicas pods                                                        | `""`                     |
+| `replica.updateStrategy.type`                               | Redis&reg; replicas statefulset strategy type                                                           | `RollingUpdate`          |
+| `replica.minReadySeconds`                                   | How many seconds a pod needs to be ready before killing the next, during update                         | `0`                      |
+| `replica.priorityClassName`                                 | Redis&reg; replicas pods' priorityClassName                                                             | `""`                     |
+| `replica.podManagementPolicy`                               | podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods                         | `""`                     |
+| `replica.hostAliases`                                       | Redis&reg; replicas pods host aliases                                                                   | `[]`                     |
+| `replica.podLabels`                                         | Extra labels for Redis&reg; replicas pods                                                               | `{}`                     |
+| `replica.podAnnotations`                                    | Annotations for Redis&reg; replicas pods                                                                | `{}`                     |
+| `replica.shareProcessNamespace`                             | Share a single process namespace between all of the containers in Redis&reg; replicas pods              | `false`                  |
+| `replica.podAffinityPreset`                                 | Pod affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`             | `""`                     |
+| `replica.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`        | `soft`                   |
+| `replica.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`       | `""`                     |
+| `replica.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `replica.affinity` is set                                           | `""`                     |
+| `replica.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `replica.affinity` is set                                        | `[]`                     |
+| `replica.affinity`                                          | Affinity for Redis&reg; replicas pods assignment                                                        | `{}`                     |
+| `replica.nodeSelector`                                      | Node labels for Redis&reg; replicas pods assignment                                                     | `{}`                     |
+| `replica.tolerations`                                       | Tolerations for Redis&reg; replicas pods assignment                                                     | `[]`                     |
+| `replica.topologySpreadConstraints`                         | Spread Constraints for Redis&reg; replicas pod assignment                                               | `[]`                     |
+| `replica.dnsPolicy`                                         | DNS Policy for Redis&reg; replica pods                                                                  | `""`                     |
+| `replica.dnsConfig`                                         | DNS Configuration for Redis&reg; replica pods                                                           | `{}`                     |
+| `replica.lifecycleHooks`                                    | for the Redis&reg; replica container(s) to automate configuration before or after startup               | `{}`                     |
+| `replica.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Redis&reg; replicas pod(s)                  | `[]`                     |
+| `replica.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Redis&reg; replicas container(s)       | `[]`                     |
+| `replica.sidecars`                                          | Add additional sidecar containers to the Redis&reg; replicas pod(s)                                     | `[]`                     |
+| `replica.initContainers`                                    | Add additional init containers to the Redis&reg; replicas pod(s)                                        | `[]`                     |
+| `replica.persistence.enabled`                               | Enable persistence on Redis&reg; replicas nodes using Persistent Volume Claims                          | `true`                   |
+| `replica.persistence.medium`                                | Provide a medium for `emptyDir` volumes.                                                                | `""`                     |
+| `replica.persistence.sizeLimit`                             | Set this to enable a size limit for `emptyDir` volumes.                                                 | `""`                     |
+| `replica.persistence.path`                                  | The path the volume will be mounted at on Redis&reg; replicas containers                                | `/data`                  |
+| `replica.persistence.subPath`                               | The subdirectory of the volume to mount on Redis&reg; replicas containers                               | `""`                     |
+| `replica.persistence.subPathExpr`                           | Used to construct the subPath subdirectory of the volume to mount on Redis&reg; replicas containers     | `""`                     |
+| `replica.persistence.storageClass`                          | Persistent Volume storage class                                                                         | `""`                     |
+| `replica.persistence.accessModes`                           | Persistent Volume access modes                                                                          | `["ReadWriteOnce"]`      |
+| `replica.persistence.size`                                  | Persistent Volume size                                                                                  | `8Gi`                    |
+| `replica.persistence.annotations`                           | Additional custom annotations for the PVC                                                               | `{}`                     |
+| `replica.persistence.labels`                                | Additional custom labels for the PVC                                                                    | `{}`                     |
+| `replica.persistence.selector`                              | Additional labels to match for the PVC                                                                  | `{}`                     |
+| `replica.persistence.dataSource`                            | Custom PVC data source                                                                                  | `{}`                     |
+| `replica.persistence.existingClaim`                         | Use a existing PVC which must be created manually before bound                                          | `""`                     |
+| `replica.service.type`                                      | Redis&reg; replicas service type                                                                        | `ClusterIP`              |
+| `replica.service.ports.redis`                               | Redis&reg; replicas service port                                                                        | `6379`                   |
+| `replica.service.nodePorts.redis`                           | Node port for Redis&reg; replicas                                                                       | `""`                     |
+| `replica.service.externalTrafficPolicy`                     | Redis&reg; replicas service external traffic policy                                                     | `Cluster`                |
+| `replica.service.internalTrafficPolicy`                     | Redis&reg; replicas service internal traffic policy (requires Kubernetes v1.22 or greater to be usable) | `Cluster`                |
+| `replica.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                          | `[]`                     |
+| `replica.service.clusterIP`                                 | Redis&reg; replicas service Cluster IP                                                                  | `""`                     |
+| `replica.service.loadBalancerIP`                            | Redis&reg; replicas service Load Balancer IP                                                            | `""`                     |
+| `replica.service.loadBalancerSourceRanges`                  | Redis&reg; replicas service Load Balancer sources                                                       | `[]`                     |
+| `replica.service.annotations`                               | Additional custom annotations for Redis&reg; replicas service                                           | `{}`                     |
+| `replica.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                    | `None`                   |
+| `replica.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                             | `{}`                     |
+| `replica.terminationGracePeriodSeconds`                     | Integer setting the termination grace period for the redis-replicas pods                                | `30`                     |
+| `replica.autoscaling.enabled`                               | Enable replica autoscaling settings                                                                     | `false`                  |
+| `replica.autoscaling.minReplicas`                           | Minimum replicas for the pod autoscaling                                                                | `1`                      |
+| `replica.autoscaling.maxReplicas`                           | Maximum replicas for the pod autoscaling                                                                | `11`                     |
+| `replica.autoscaling.targetCPU`                             | Percentage of CPU to consider when autoscaling                                                          | `""`                     |
+| `replica.autoscaling.targetMemory`                          | Percentage of Memory to consider when autoscaling                                                       | `""`                     |
+| `replica.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                    | `false`                  |
+| `replica.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                  | `""`                     |
+| `replica.serviceAccount.automountServiceAccountToken`       | Whether to auto mount the service account token                                                         | `true`                   |
+| `replica.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                    | `{}`                     |
 
 ### Redis&reg; Sentinel configuration parameters
 
-| Name                                          | Description                                                                                                                                 | Value                    |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `sentinel.enabled`                            | Use Redis&reg; Sentinel on Redis&reg; pods.                                                                                                 | `false`                  |
-| `sentinel.image.registry`                     | Redis&reg; Sentinel image registry                                                                                                          | `docker.io`              |
-| `sentinel.image.repository`                   | Redis&reg; Sentinel image repository                                                                                                        | `bitnami/redis-sentinel` |
-| `sentinel.image.tag`                          | Redis&reg; Sentinel image tag (immutable tags are recommended)                                                                              | `7.0.12-debian-11-r1`    |
-| `sentinel.image.digest`                       | Redis&reg; Sentinel image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                         | `""`                     |
-| `sentinel.image.pullPolicy`                   | Redis&reg; Sentinel image pull policy                                                                                                       | `IfNotPresent`           |
-| `sentinel.image.pullSecrets`                  | Redis&reg; Sentinel image pull secrets                                                                                                      | `[]`                     |
-| `sentinel.image.debug`                        | Enable image debug mode                                                                                                                     | `false`                  |
-| `sentinel.annotations`                        | Additional custom annotations for Redis&reg; Sentinel resource                                                                              | `{}`                     |
-| `sentinel.masterSet`                          | Master set name                                                                                                                             | `mymaster`               |
-| `sentinel.quorum`                             | Sentinel Quorum                                                                                                                             | `2`                      |
-| `sentinel.getMasterTimeout`                   | Amount of time to allow before get_sentinel_master_info() times out.                                                                        | `220`                    |
-| `sentinel.automateClusterRecovery`            | Automate cluster recovery in cases where the last replica is not considered a good replica and Sentinel won't automatically failover to it. | `false`                  |
-| `sentinel.redisShutdownWaitFailover`          | Whether the Redis&reg; master container waits for the failover at shutdown (in addition to the Redis&reg; Sentinel container).              | `true`                   |
-| `sentinel.downAfterMilliseconds`              | Timeout for detecting a Redis&reg; node is down                                                                                             | `60000`                  |
-| `sentinel.failoverTimeout`                    | Timeout for performing a election failover                                                                                                  | `180000`                 |
-| `sentinel.parallelSyncs`                      | Number of replicas that can be reconfigured in parallel to use the new master after a failover                                              | `1`                      |
-| `sentinel.configuration`                      | Configuration for Redis&reg; Sentinel nodes                                                                                                 | `""`                     |
-| `sentinel.command`                            | Override default container command (useful when using custom images)                                                                        | `[]`                     |
-| `sentinel.args`                               | Override default container args (useful when using custom images)                                                                           | `[]`                     |
-| `sentinel.preExecCmds`                        | Additional commands to run prior to starting Redis&reg; Sentinel                                                                            | `[]`                     |
-| `sentinel.extraEnvVars`                       | Array with extra environment variables to add to Redis&reg; Sentinel nodes                                                                  | `[]`                     |
-| `sentinel.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for Redis&reg; Sentinel nodes                                                          | `""`                     |
-| `sentinel.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis&reg; Sentinel nodes                                                             | `""`                     |
-| `sentinel.externalMaster.enabled`             | Use external master for bootstrapping                                                                                                       | `false`                  |
-| `sentinel.externalMaster.host`                | External master host to bootstrap from                                                                                                      | `""`                     |
-| `sentinel.externalMaster.port`                | Port for Redis service external master host                                                                                                 | `6379`                   |
-| `sentinel.containerPorts.sentinel`            | Container port to open on Redis&reg; Sentinel nodes                                                                                         | `26379`                  |
-| `sentinel.startupProbe.enabled`               | Enable startupProbe on Redis&reg; Sentinel nodes                                                                                            | `true`                   |
-| `sentinel.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                                      | `10`                     |
-| `sentinel.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                                             | `10`                     |
-| `sentinel.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                                            | `5`                      |
-| `sentinel.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                                          | `22`                     |
-| `sentinel.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                                          | `1`                      |
-| `sentinel.livenessProbe.enabled`              | Enable livenessProbe on Redis&reg; Sentinel nodes                                                                                           | `true`                   |
-| `sentinel.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                     | `20`                     |
-| `sentinel.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                            | `10`                     |
-| `sentinel.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                           | `5`                      |
-| `sentinel.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                         | `6`                      |
-| `sentinel.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                         | `1`                      |
-| `sentinel.readinessProbe.enabled`             | Enable readinessProbe on Redis&reg; Sentinel nodes                                                                                          | `true`                   |
-| `sentinel.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                    | `20`                     |
-| `sentinel.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                           | `5`                      |
-| `sentinel.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                          | `1`                      |
-| `sentinel.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                        | `6`                      |
-| `sentinel.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                        | `1`                      |
-| `sentinel.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                                                          | `{}`                     |
-| `sentinel.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                                                         | `{}`                     |
-| `sentinel.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                                                        | `{}`                     |
-| `sentinel.persistence.enabled`                | Enable persistence on Redis&reg; sentinel nodes using Persistent Volume Claims (Experimental)                                               | `false`                  |
-| `sentinel.persistence.storageClass`           | Persistent Volume storage class                                                                                                             | `""`                     |
-| `sentinel.persistence.accessModes`            | Persistent Volume access modes                                                                                                              | `["ReadWriteOnce"]`      |
-| `sentinel.persistence.size`                   | Persistent Volume size                                                                                                                      | `100Mi`                  |
-| `sentinel.persistence.annotations`            | Additional custom annotations for the PVC                                                                                                   | `{}`                     |
-| `sentinel.persistence.labels`                 | Additional custom labels for the PVC                                                                                                        | `{}`                     |
-| `sentinel.persistence.selector`               | Additional labels to match for the PVC                                                                                                      | `{}`                     |
-| `sentinel.persistence.dataSource`             | Custom PVC data source                                                                                                                      | `{}`                     |
-| `sentinel.persistence.medium`                 | Provide a medium for `emptyDir` volumes.                                                                                                    | `""`                     |
-| `sentinel.persistence.sizeLimit`              | Set this to enable a size limit for `emptyDir` volumes.                                                                                     | `""`                     |
-| `sentinel.resources.limits`                   | The resources limits for the Redis&reg; Sentinel containers                                                                                 | `{}`                     |
-| `sentinel.resources.requests`                 | The requested resources for the Redis&reg; Sentinel containers                                                                              | `{}`                     |
-| `sentinel.containerSecurityContext.enabled`   | Enabled Redis&reg; Sentinel containers' Security Context                                                                                    | `true`                   |
-| `sentinel.containerSecurityContext.runAsUser` | Set Redis&reg; Sentinel containers' Security Context runAsUser                                                                              | `1001`                   |
-| `sentinel.lifecycleHooks`                     | for the Redis&reg; sentinel container(s) to automate configuration before or after startup                                                  | `{}`                     |
-| `sentinel.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&reg; Sentinel                                                             | `[]`                     |
-| `sentinel.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&reg; Sentinel container(s)                                           | `[]`                     |
-| `sentinel.service.type`                       | Redis&reg; Sentinel service type                                                                                                            | `ClusterIP`              |
-| `sentinel.service.ports.redis`                | Redis&reg; service port for Redis&reg;                                                                                                      | `6379`                   |
-| `sentinel.service.ports.sentinel`             | Redis&reg; service port for Redis&reg; Sentinel                                                                                             | `26379`                  |
-| `sentinel.service.nodePorts.redis`            | Node port for Redis&reg;                                                                                                                    | `""`                     |
-| `sentinel.service.nodePorts.sentinel`         | Node port for Sentinel                                                                                                                      | `""`                     |
-| `sentinel.service.externalTrafficPolicy`      | Redis&reg; Sentinel service external traffic policy                                                                                         | `Cluster`                |
-| `sentinel.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                                                              | `[]`                     |
-| `sentinel.service.clusterIP`                  | Redis&reg; Sentinel service Cluster IP                                                                                                      | `""`                     |
-| `sentinel.service.loadBalancerIP`             | Redis&reg; Sentinel service Load Balancer IP                                                                                                | `""`                     |
-| `sentinel.service.loadBalancerSourceRanges`   | Redis&reg; Sentinel service Load Balancer sources                                                                                           | `[]`                     |
-| `sentinel.service.annotations`                | Additional custom annotations for Redis&reg; Sentinel service                                                                               | `{}`                     |
-| `sentinel.service.sessionAffinity`            | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                                        | `None`                   |
-| `sentinel.service.sessionAffinityConfig`      | Additional settings for the sessionAffinity                                                                                                 | `{}`                     |
-| `sentinel.service.headless.annotations`       | Annotations for the headless service.                                                                                                       | `{}`                     |
-| `sentinel.terminationGracePeriodSeconds`      | Integer setting the termination grace period for the redis-node pods                                                                        | `30`                     |
+| Name                                                         | Description                                                                                                                                 | Value                    |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `sentinel.enabled`                                           | Use Redis&reg; Sentinel on Redis&reg; pods.                                                                                                 | `false`                  |
+| `sentinel.image.registry`                                    | Redis&reg; Sentinel image registry                                                                                                          | `docker.io`              |
+| `sentinel.image.repository`                                  | Redis&reg; Sentinel image repository                                                                                                        | `bitnami/redis-sentinel` |
+| `sentinel.image.tag`                                         | Redis&reg; Sentinel image tag (immutable tags are recommended)                                                                              | `7.0.12-debian-11-r1`    |
+| `sentinel.image.digest`                                      | Redis&reg; Sentinel image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                         | `""`                     |
+| `sentinel.image.pullPolicy`                                  | Redis&reg; Sentinel image pull policy                                                                                                       | `IfNotPresent`           |
+| `sentinel.image.pullSecrets`                                 | Redis&reg; Sentinel image pull secrets                                                                                                      | `[]`                     |
+| `sentinel.image.debug`                                       | Enable image debug mode                                                                                                                     | `false`                  |
+| `sentinel.annotations`                                       | Additional custom annotations for Redis&reg; Sentinel resource                                                                              | `{}`                     |
+| `sentinel.masterSet`                                         | Master set name                                                                                                                             | `mymaster`               |
+| `sentinel.quorum`                                            | Sentinel Quorum                                                                                                                             | `2`                      |
+| `sentinel.getMasterTimeout`                                  | Amount of time to allow before get_sentinel_master_info() times out.                                                                        | `220`                    |
+| `sentinel.automateClusterRecovery`                           | Automate cluster recovery in cases where the last replica is not considered a good replica and Sentinel won't automatically failover to it. | `false`                  |
+| `sentinel.redisShutdownWaitFailover`                         | Whether the Redis&reg; master container waits for the failover at shutdown (in addition to the Redis&reg; Sentinel container).              | `true`                   |
+| `sentinel.downAfterMilliseconds`                             | Timeout for detecting a Redis&reg; node is down                                                                                             | `60000`                  |
+| `sentinel.failoverTimeout`                                   | Timeout for performing a election failover                                                                                                  | `180000`                 |
+| `sentinel.parallelSyncs`                                     | Number of replicas that can be reconfigured in parallel to use the new master after a failover                                              | `1`                      |
+| `sentinel.configuration`                                     | Configuration for Redis&reg; Sentinel nodes                                                                                                 | `""`                     |
+| `sentinel.command`                                           | Override default container command (useful when using custom images)                                                                        | `[]`                     |
+| `sentinel.args`                                              | Override default container args (useful when using custom images)                                                                           | `[]`                     |
+| `sentinel.preExecCmds`                                       | Additional commands to run prior to starting Redis&reg; Sentinel                                                                            | `[]`                     |
+| `sentinel.extraEnvVars`                                      | Array with extra environment variables to add to Redis&reg; Sentinel nodes                                                                  | `[]`                     |
+| `sentinel.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Redis&reg; Sentinel nodes                                                          | `""`                     |
+| `sentinel.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Redis&reg; Sentinel nodes                                                             | `""`                     |
+| `sentinel.externalMaster.enabled`                            | Use external master for bootstrapping                                                                                                       | `false`                  |
+| `sentinel.externalMaster.host`                               | External master host to bootstrap from                                                                                                      | `""`                     |
+| `sentinel.externalMaster.port`                               | Port for Redis service external master host                                                                                                 | `6379`                   |
+| `sentinel.containerPorts.sentinel`                           | Container port to open on Redis&reg; Sentinel nodes                                                                                         | `26379`                  |
+| `sentinel.startupProbe.enabled`                              | Enable startupProbe on Redis&reg; Sentinel nodes                                                                                            | `true`                   |
+| `sentinel.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                                                      | `10`                     |
+| `sentinel.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                                                             | `10`                     |
+| `sentinel.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                                                            | `5`                      |
+| `sentinel.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                                          | `22`                     |
+| `sentinel.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                                          | `1`                      |
+| `sentinel.livenessProbe.enabled`                             | Enable livenessProbe on Redis&reg; Sentinel nodes                                                                                           | `true`                   |
+| `sentinel.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                                                     | `20`                     |
+| `sentinel.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                                                            | `10`                     |
+| `sentinel.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                                                           | `5`                      |
+| `sentinel.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                                                         | `6`                      |
+| `sentinel.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                                                         | `1`                      |
+| `sentinel.readinessProbe.enabled`                            | Enable readinessProbe on Redis&reg; Sentinel nodes                                                                                          | `true`                   |
+| `sentinel.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                                                    | `20`                     |
+| `sentinel.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                                                           | `5`                      |
+| `sentinel.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                                                          | `1`                      |
+| `sentinel.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                                                        | `6`                      |
+| `sentinel.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                                                        | `1`                      |
+| `sentinel.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                                          | `{}`                     |
+| `sentinel.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                                                         | `{}`                     |
+| `sentinel.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                                                        | `{}`                     |
+| `sentinel.persistence.enabled`                               | Enable persistence on Redis&reg; sentinel nodes using Persistent Volume Claims (Experimental)                                               | `false`                  |
+| `sentinel.persistence.storageClass`                          | Persistent Volume storage class                                                                                                             | `""`                     |
+| `sentinel.persistence.accessModes`                           | Persistent Volume access modes                                                                                                              | `["ReadWriteOnce"]`      |
+| `sentinel.persistence.size`                                  | Persistent Volume size                                                                                                                      | `100Mi`                  |
+| `sentinel.persistence.annotations`                           | Additional custom annotations for the PVC                                                                                                   | `{}`                     |
+| `sentinel.persistence.labels`                                | Additional custom labels for the PVC                                                                                                        | `{}`                     |
+| `sentinel.persistence.selector`                              | Additional labels to match for the PVC                                                                                                      | `{}`                     |
+| `sentinel.persistence.dataSource`                            | Custom PVC data source                                                                                                                      | `{}`                     |
+| `sentinel.persistence.medium`                                | Provide a medium for `emptyDir` volumes.                                                                                                    | `""`                     |
+| `sentinel.persistence.sizeLimit`                             | Set this to enable a size limit for `emptyDir` volumes.                                                                                     | `""`                     |
+| `sentinel.resources.limits`                                  | The resources limits for the Redis&reg; Sentinel containers                                                                                 | `{}`                     |
+| `sentinel.resources.requests`                                | The requested resources for the Redis&reg; Sentinel containers                                                                              | `{}`                     |
+| `sentinel.containerSecurityContext.enabled`                  | Enabled Redis&reg; Sentinel containers' Security Context                                                                                    | `true`                   |
+| `sentinel.containerSecurityContext.runAsUser`                | Set Redis&reg; Sentinel containers' Security Context runAsUser                                                                              | `1001`                   |
+| `sentinel.containerSecurityContext.runAsGroup`               | Set Redis&reg; Sentinel containers' Security Context runAsGroup                                                                             | `0`                      |
+| `sentinel.containerSecurityContext.runAsNonRoot`             | Set Redis&reg; Sentinel containers' Security Context runAsNonRoot                                                                           | `true`                   |
+| `sentinel.containerSecurityContext.allowPrivilegeEscalation` | Set Redis&reg; Sentinel containers' Security Context allowPrivilegeEscalation                                                               | `false`                  |
+| `sentinel.containerSecurityContext.seccompProfile.type`      | Set Redis&reg; Sentinel containers' Security Context seccompProfile                                                                         | `RuntimeDefault`         |
+| `sentinel.containerSecurityContext.capabilities.drop`        | Set Redis&reg; Sentinel containers' Security Context capabilities to drop                                                                   | `["ALL"]`                |
+| `sentinel.lifecycleHooks`                                    | for the Redis&reg; sentinel container(s) to automate configuration before or after startup                                                  | `{}`                     |
+| `sentinel.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Redis&reg; Sentinel                                                             | `[]`                     |
+| `sentinel.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Redis&reg; Sentinel container(s)                                           | `[]`                     |
+| `sentinel.service.type`                                      | Redis&reg; Sentinel service type                                                                                                            | `ClusterIP`              |
+| `sentinel.service.ports.redis`                               | Redis&reg; service port for Redis&reg;                                                                                                      | `6379`                   |
+| `sentinel.service.ports.sentinel`                            | Redis&reg; service port for Redis&reg; Sentinel                                                                                             | `26379`                  |
+| `sentinel.service.nodePorts.redis`                           | Node port for Redis&reg;                                                                                                                    | `""`                     |
+| `sentinel.service.nodePorts.sentinel`                        | Node port for Sentinel                                                                                                                      | `""`                     |
+| `sentinel.service.externalTrafficPolicy`                     | Redis&reg; Sentinel service external traffic policy                                                                                         | `Cluster`                |
+| `sentinel.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                                                              | `[]`                     |
+| `sentinel.service.clusterIP`                                 | Redis&reg; Sentinel service Cluster IP                                                                                                      | `""`                     |
+| `sentinel.service.loadBalancerIP`                            | Redis&reg; Sentinel service Load Balancer IP                                                                                                | `""`                     |
+| `sentinel.service.loadBalancerSourceRanges`                  | Redis&reg; Sentinel service Load Balancer sources                                                                                           | `[]`                     |
+| `sentinel.service.annotations`                               | Additional custom annotations for Redis&reg; Sentinel service                                                                               | `{}`                     |
+| `sentinel.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                                        | `None`                   |
+| `sentinel.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                                                                 | `{}`                     |
+| `sentinel.service.headless.annotations`                      | Annotations for the headless service.                                                                                                       | `{}`                     |
+| `sentinel.terminationGracePeriodSeconds`                     | Integer setting the termination grace period for the redis-node pods                                                                        | `30`                     |
 
 ### Other Parameters
 
@@ -448,71 +463,76 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics Parameters
 
-| Name                                         | Description                                                                                                         | Value                    |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `metrics.enabled`                            | Start a sidecar prometheus exporter to expose Redis&reg; metrics                                                    | `false`                  |
-| `metrics.image.registry`                     | Redis&reg; Exporter image registry                                                                                  | `docker.io`              |
-| `metrics.image.repository`                   | Redis&reg; Exporter image repository                                                                                | `bitnami/redis-exporter` |
-| `metrics.image.tag`                          | Redis&reg; Exporter image tag (immutable tags are recommended)                                                      | `1.51.0-debian-11-r11`   |
-| `metrics.image.digest`                       | Redis&reg; Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
-| `metrics.image.pullPolicy`                   | Redis&reg; Exporter image pull policy                                                                               | `IfNotPresent`           |
-| `metrics.image.pullSecrets`                  | Redis&reg; Exporter image pull secrets                                                                              | `[]`                     |
-| `metrics.startupProbe.enabled`               | Enable startupProbe on Redis&reg; replicas nodes                                                                    | `false`                  |
-| `metrics.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                              | `10`                     |
-| `metrics.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                     | `10`                     |
-| `metrics.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                    | `5`                      |
-| `metrics.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                  | `5`                      |
-| `metrics.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                  | `1`                      |
-| `metrics.livenessProbe.enabled`              | Enable livenessProbe on Redis&reg; replicas nodes                                                                   | `true`                   |
-| `metrics.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                             | `10`                     |
-| `metrics.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                    | `10`                     |
-| `metrics.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                   | `5`                      |
-| `metrics.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                 | `5`                      |
-| `metrics.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                 | `1`                      |
-| `metrics.readinessProbe.enabled`             | Enable readinessProbe on Redis&reg; replicas nodes                                                                  | `true`                   |
-| `metrics.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                            | `5`                      |
-| `metrics.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                   | `10`                     |
-| `metrics.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                  | `1`                      |
-| `metrics.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                | `3`                      |
-| `metrics.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                | `1`                      |
-| `metrics.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                                  | `{}`                     |
-| `metrics.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                                 | `{}`                     |
-| `metrics.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                                | `{}`                     |
-| `metrics.command`                            | Override default metrics container init command (useful when using custom images)                                   | `[]`                     |
-| `metrics.redisTargetHost`                    | A way to specify an alternative Redis&reg; hostname                                                                 | `localhost`              |
-| `metrics.extraArgs`                          | Extra arguments for Redis&reg; exporter, for example:                                                               | `{}`                     |
-| `metrics.extraEnvVars`                       | Array with extra environment variables to add to Redis&reg; exporter                                                | `[]`                     |
-| `metrics.containerSecurityContext.enabled`   | Enabled Redis&reg; exporter containers' Security Context                                                            | `true`                   |
-| `metrics.containerSecurityContext.runAsUser` | Set Redis&reg; exporter containers' Security Context runAsUser                                                      | `1001`                   |
-| `metrics.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&reg; metrics sidecar                              | `[]`                     |
-| `metrics.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&reg; metrics sidecar                         | `[]`                     |
-| `metrics.resources.limits`                   | The resources limits for the Redis&reg; exporter container                                                          | `{}`                     |
-| `metrics.resources.requests`                 | The requested resources for the Redis&reg; exporter container                                                       | `{}`                     |
-| `metrics.podLabels`                          | Extra labels for Redis&reg; exporter pods                                                                           | `{}`                     |
-| `metrics.podAnnotations`                     | Annotations for Redis&reg; exporter pods                                                                            | `{}`                     |
-| `metrics.service.type`                       | Redis&reg; exporter service type                                                                                    | `ClusterIP`              |
-| `metrics.service.port`                       | Redis&reg; exporter service port                                                                                    | `9121`                   |
-| `metrics.service.externalTrafficPolicy`      | Redis&reg; exporter service external traffic policy                                                                 | `Cluster`                |
-| `metrics.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                                      | `[]`                     |
-| `metrics.service.loadBalancerIP`             | Redis&reg; exporter service Load Balancer IP                                                                        | `""`                     |
-| `metrics.service.loadBalancerSourceRanges`   | Redis&reg; exporter service Load Balancer sources                                                                   | `[]`                     |
-| `metrics.service.annotations`                | Additional custom annotations for Redis&reg; exporter service                                                       | `{}`                     |
-| `metrics.service.clusterIP`                  | Redis&reg; exporter service Cluster IP                                                                              | `""`                     |
-| `metrics.serviceMonitor.enabled`             | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator                                     | `false`                  |
-| `metrics.serviceMonitor.namespace`           | The namespace in which the ServiceMonitor will be created                                                           | `""`                     |
-| `metrics.serviceMonitor.interval`            | The interval at which metrics should be scraped                                                                     | `30s`                    |
-| `metrics.serviceMonitor.scrapeTimeout`       | The timeout after which the scrape is ended                                                                         | `""`                     |
-| `metrics.serviceMonitor.relabellings`        | Metrics RelabelConfigs to apply to samples before scraping.                                                         | `[]`                     |
-| `metrics.serviceMonitor.metricRelabelings`   | Metrics RelabelConfigs to apply to samples before ingestion.                                                        | `[]`                     |
-| `metrics.serviceMonitor.honorLabels`         | Specify honorLabels parameter to add the scrape endpoint                                                            | `false`                  |
-| `metrics.serviceMonitor.additionalLabels`    | Additional labels that can be used so ServiceMonitor resource(s) can be discovered by Prometheus                    | `{}`                     |
-| `metrics.serviceMonitor.podTargetLabels`     | Labels from the Kubernetes pod to be transferred to the created metrics                                             | `[]`                     |
-| `metrics.serviceMonitor.sampleLimit`         | Limit of how many samples should be scraped from every Pod                                                          | `false`                  |
-| `metrics.serviceMonitor.targetLimit`         | Limit of how many targets should be scraped                                                                         | `false`                  |
-| `metrics.prometheusRule.enabled`             | Create a custom prometheusRule Resource for scraping metrics using PrometheusOperator                               | `false`                  |
-| `metrics.prometheusRule.namespace`           | The namespace in which the prometheusRule will be created                                                           | `""`                     |
-| `metrics.prometheusRule.additionalLabels`    | Additional labels for the prometheusRule                                                                            | `{}`                     |
-| `metrics.prometheusRule.rules`               | Custom Prometheus rules                                                                                             | `[]`                     |
+| Name                                                        | Description                                                                                                         | Value                    |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `metrics.enabled`                                           | Start a sidecar prometheus exporter to expose Redis&reg; metrics                                                    | `false`                  |
+| `metrics.image.registry`                                    | Redis&reg; Exporter image registry                                                                                  | `docker.io`              |
+| `metrics.image.repository`                                  | Redis&reg; Exporter image repository                                                                                | `bitnami/redis-exporter` |
+| `metrics.image.tag`                                         | Redis&reg; Exporter image tag (immutable tags are recommended)                                                      | `1.51.0-debian-11-r11`   |
+| `metrics.image.digest`                                      | Redis&reg; Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `metrics.image.pullPolicy`                                  | Redis&reg; Exporter image pull policy                                                                               | `IfNotPresent`           |
+| `metrics.image.pullSecrets`                                 | Redis&reg; Exporter image pull secrets                                                                              | `[]`                     |
+| `metrics.startupProbe.enabled`                              | Enable startupProbe on Redis&reg; replicas nodes                                                                    | `false`                  |
+| `metrics.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                              | `10`                     |
+| `metrics.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                                     | `10`                     |
+| `metrics.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                                    | `5`                      |
+| `metrics.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                  | `5`                      |
+| `metrics.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                  | `1`                      |
+| `metrics.livenessProbe.enabled`                             | Enable livenessProbe on Redis&reg; replicas nodes                                                                   | `true`                   |
+| `metrics.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                             | `10`                     |
+| `metrics.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                                    | `10`                     |
+| `metrics.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                                   | `5`                      |
+| `metrics.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                                 | `5`                      |
+| `metrics.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                                 | `1`                      |
+| `metrics.readinessProbe.enabled`                            | Enable readinessProbe on Redis&reg; replicas nodes                                                                  | `true`                   |
+| `metrics.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                            | `5`                      |
+| `metrics.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                                   | `10`                     |
+| `metrics.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                                  | `1`                      |
+| `metrics.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                                | `3`                      |
+| `metrics.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                                | `1`                      |
+| `metrics.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                  | `{}`                     |
+| `metrics.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                                 | `{}`                     |
+| `metrics.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                                | `{}`                     |
+| `metrics.command`                                           | Override default metrics container init command (useful when using custom images)                                   | `[]`                     |
+| `metrics.redisTargetHost`                                   | A way to specify an alternative Redis&reg; hostname                                                                 | `localhost`              |
+| `metrics.extraArgs`                                         | Extra arguments for Redis&reg; exporter, for example:                                                               | `{}`                     |
+| `metrics.extraEnvVars`                                      | Array with extra environment variables to add to Redis&reg; exporter                                                | `[]`                     |
+| `metrics.containerSecurityContext.enabled`                  | Enabled Redis&reg; exporter containers' Security Context                                                            | `true`                   |
+| `metrics.containerSecurityContext.runAsUser`                | Set Redis&reg; exporter containers' Security Context runAsUser                                                      | `1001`                   |
+| `metrics.containerSecurityContext.runAsGroup`               | Set Redis&reg; exporter containers' Security Context runAsGroup                                                     | `0`                      |
+| `metrics.containerSecurityContext.runAsNonRoot`             | Set Redis&reg; exporter containers' Security Context runAsNonRoot                                                   | `true`                   |
+| `metrics.containerSecurityContext.allowPrivilegeEscalation` | Set Redis&reg; exporter containers' Security Context allowPrivilegeEscalation                                       | `false`                  |
+| `metrics.containerSecurityContext.seccompProfile.type`      | Set Redis&reg; exporter containers' Security Context seccompProfile                                                 | `RuntimeDefault`         |
+| `metrics.containerSecurityContext.capabilities.drop`        | Set Redis&reg; exporter containers' Security Context capabilities to drop                                           | `["ALL"]`                |
+| `metrics.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Redis&reg; metrics sidecar                              | `[]`                     |
+| `metrics.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Redis&reg; metrics sidecar                         | `[]`                     |
+| `metrics.resources.limits`                                  | The resources limits for the Redis&reg; exporter container                                                          | `{}`                     |
+| `metrics.resources.requests`                                | The requested resources for the Redis&reg; exporter container                                                       | `{}`                     |
+| `metrics.podLabels`                                         | Extra labels for Redis&reg; exporter pods                                                                           | `{}`                     |
+| `metrics.podAnnotations`                                    | Annotations for Redis&reg; exporter pods                                                                            | `{}`                     |
+| `metrics.service.type`                                      | Redis&reg; exporter service type                                                                                    | `ClusterIP`              |
+| `metrics.service.port`                                      | Redis&reg; exporter service port                                                                                    | `9121`                   |
+| `metrics.service.externalTrafficPolicy`                     | Redis&reg; exporter service external traffic policy                                                                 | `Cluster`                |
+| `metrics.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                                      | `[]`                     |
+| `metrics.service.loadBalancerIP`                            | Redis&reg; exporter service Load Balancer IP                                                                        | `""`                     |
+| `metrics.service.loadBalancerSourceRanges`                  | Redis&reg; exporter service Load Balancer sources                                                                   | `[]`                     |
+| `metrics.service.annotations`                               | Additional custom annotations for Redis&reg; exporter service                                                       | `{}`                     |
+| `metrics.service.clusterIP`                                 | Redis&reg; exporter service Cluster IP                                                                              | `""`                     |
+| `metrics.serviceMonitor.enabled`                            | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator                                     | `false`                  |
+| `metrics.serviceMonitor.namespace`                          | The namespace in which the ServiceMonitor will be created                                                           | `""`                     |
+| `metrics.serviceMonitor.interval`                           | The interval at which metrics should be scraped                                                                     | `30s`                    |
+| `metrics.serviceMonitor.scrapeTimeout`                      | The timeout after which the scrape is ended                                                                         | `""`                     |
+| `metrics.serviceMonitor.relabellings`                       | Metrics RelabelConfigs to apply to samples before scraping.                                                         | `[]`                     |
+| `metrics.serviceMonitor.metricRelabelings`                  | Metrics RelabelConfigs to apply to samples before ingestion.                                                        | `[]`                     |
+| `metrics.serviceMonitor.honorLabels`                        | Specify honorLabels parameter to add the scrape endpoint                                                            | `false`                  |
+| `metrics.serviceMonitor.additionalLabels`                   | Additional labels that can be used so ServiceMonitor resource(s) can be discovered by Prometheus                    | `{}`                     |
+| `metrics.serviceMonitor.podTargetLabels`                    | Labels from the Kubernetes pod to be transferred to the created metrics                                             | `[]`                     |
+| `metrics.serviceMonitor.sampleLimit`                        | Limit of how many samples should be scraped from every Pod                                                          | `false`                  |
+| `metrics.serviceMonitor.targetLimit`                        | Limit of how many targets should be scraped                                                                         | `false`                  |
+| `metrics.prometheusRule.enabled`                            | Create a custom prometheusRule Resource for scraping metrics using PrometheusOperator                               | `false`                  |
+| `metrics.prometheusRule.namespace`                          | The namespace in which the prometheusRule will be created                                                           | `""`                     |
+| `metrics.prometheusRule.additionalLabels`                   | Additional labels for the prometheusRule                                                                            | `{}`                     |
+| `metrics.prometheusRule.rules`                              | Custom Prometheus rules                                                                                             | `[]`                     |
 
 ### Init Container Parameters
 

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -279,10 +279,23 @@ master:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param master.containerSecurityContext.enabled Enabled Redis&reg; master containers' Security Context
   ## @param master.containerSecurityContext.runAsUser Set Redis&reg; master containers' Security Context runAsUser
+  ## @param master.containerSecurityContext.runAsGroup Set Redis&reg; master containers' Security Context runAsGroup
+  ## @param master.containerSecurityContext.runAsNonRoot Set Redis&reg; master containers' Security Context runAsNonRoot
+  ## @param master.containerSecurityContext.allowPrivilegeEscalation Is it possible to escalate Redis&reg; pod(s) privileges
+  ## @param master.containerSecurityContext.seccompProfile.type Set Redis&reg; master containers' Security Context seccompProfile
+  ## @param master.containerSecurityContext.capabilities.drop Set Redis&reg; master containers' Security Context capabilities to drop
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    runAsGroup: 0
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
   ## @param master.kind Use either Deployment or StatefulSet (default)
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
   ##
@@ -696,10 +709,23 @@ replica:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param replica.containerSecurityContext.enabled Enabled Redis&reg; replicas containers' Security Context
   ## @param replica.containerSecurityContext.runAsUser Set Redis&reg; replicas containers' Security Context runAsUser
+  ## @param replica.containerSecurityContext.runAsGroup Set Redis&reg; replicas containers' Security Context runAsGroup
+  ## @param replica.containerSecurityContext.runAsNonRoot Set Redis&reg; replicas containers' Security Context runAsNonRoot
+  ## @param replica.containerSecurityContext.allowPrivilegeEscalation Set Redis&reg; replicas pod's Security Context allowPrivilegeEscalation
+  ## @param replica.containerSecurityContext.seccompProfile.type Set Redis&reg; replicas containers' Security Context seccompProfile
+  ## @param replica.containerSecurityContext.capabilities.drop Set Redis&reg; replicas containers' Security Context capabilities to drop
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    runAsGroup: 0
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
   ## @param replica.schedulerName Alternate scheduler for Redis&reg; replicas pods
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
@@ -1197,10 +1223,23 @@ sentinel:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param sentinel.containerSecurityContext.enabled Enabled Redis&reg; Sentinel containers' Security Context
   ## @param sentinel.containerSecurityContext.runAsUser Set Redis&reg; Sentinel containers' Security Context runAsUser
+  ## @param sentinel.containerSecurityContext.runAsGroup Set Redis&reg; Sentinel containers' Security Context runAsGroup
+  ## @param sentinel.containerSecurityContext.runAsNonRoot Set Redis&reg; Sentinel containers' Security Context runAsNonRoot
+  ## @param sentinel.containerSecurityContext.allowPrivilegeEscalation Set Redis&reg; Sentinel containers' Security Context allowPrivilegeEscalation
+  ## @param sentinel.containerSecurityContext.seccompProfile.type Set Redis&reg; Sentinel containers' Security Context seccompProfile
+  ## @param sentinel.containerSecurityContext.capabilities.drop Set Redis&reg; Sentinel containers' Security Context capabilities to drop
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    runAsGroup: 0
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
   ## @param sentinel.lifecycleHooks for the Redis&reg; sentinel container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
@@ -1534,10 +1573,23 @@ metrics:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param metrics.containerSecurityContext.enabled Enabled Redis&reg; exporter containers' Security Context
   ## @param metrics.containerSecurityContext.runAsUser Set Redis&reg; exporter containers' Security Context runAsUser
+  ## @param metrics.containerSecurityContext.runAsGroup Set Redis&reg; exporter containers' Security Context runAsGroup
+  ## @param metrics.containerSecurityContext.runAsNonRoot Set Redis&reg; exporter containers' Security Context runAsNonRoot
+  ## @param metrics.containerSecurityContext.allowPrivilegeEscalation Set Redis&reg; exporter containers' Security Context allowPrivilegeEscalation
+  ## @param metrics.containerSecurityContext.seccompProfile.type Set Redis&reg; exporter containers' Security Context seccompProfile
+  ## @param metrics.containerSecurityContext.capabilities.drop Set Redis&reg; exporter containers' Security Context capabilities to drop
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    runAsGroup: 0
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
   ## @param metrics.extraVolumes Optionally specify extra list of additional volumes for the Redis&reg; metrics sidecar
   ##
   extraVolumes: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Enhance security controls for redis pods

### Benefits

Greater compliance with kubernetes pod security best practices

### Possible drawbacks

Users doing custom things may need to adjust their settings.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

https://kubernetes.io/docs/concepts/security/pod-security-standards/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
