### PR TITLE
[bitnami/concourse] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: concourse
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/concourse
-version: 2.2.1
+version: 2.2.2

--- a/bitnami/concourse/templates/web/role.yaml
+++ b/bitnami/concourse/templates/web/role.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "concourse.web.fullname.namespace" . }}
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: web
     {{- if .Values.commonLabels }}

--- a/bitnami/concourse/templates/worker/role.yaml
+++ b/bitnami/concourse/templates/worker/role.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "concourse.worker.fullname.namespace" . }}
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)