### PR TITLE
[bitnami/cert-manager] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: cert-manager
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.11.4
+version: 0.11.5

--- a/bitnami/cert-manager/templates/cainjector/rbac.yaml
+++ b/bitnami/cert-manager/templates/cainjector/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ printf "%s-leader-election" (include "certmanager.cainjector.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Values.leaderElection.namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: cainjector
     {{- if .Values.commonLabels }}
@@ -32,7 +31,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ printf "%s-leader-election" (include "certmanager.cainjector.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Values.leaderElection.namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: cainjector
     {{- if .Values.commonLabels }}
@@ -48,7 +46,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.cainjector.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
@@ -103,6 +100,5 @@ roleRef:
   name: {{ include "certmanager.cainjector.fullname" . }}
 subjects:
   - name: {{ template "certmanager.cainjector.fullname" . }}
-    namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
 {{- end -}}

--- a/bitnami/cert-manager/templates/controller/rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ printf "%s-leader-election" (include "certmanager.controller.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Values.leaderElection.namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: controller
     {{- if .Values.commonLabels }}
@@ -32,7 +31,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ printf "%s-leader-election" (include "certmanager.controller.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Values.leaderElection.namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: controller
     {{- if .Values.commonLabels }}
@@ -49,7 +47,6 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
@@ -269,7 +266,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
@@ -290,7 +286,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
@@ -311,7 +306,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
@@ -332,7 +326,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
@@ -353,7 +346,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
@@ -374,7 +366,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "certmanager.controller.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
@@ -452,6 +443,5 @@ roleRef:
   name: {{ printf "%s-controller-approve" (include "certmanager.controller.fullname" .) | trunc 63 | trimSuffix "-" }}
 subjects:
   - kind: ServiceAccount
-    namespace: {{ .Release.Namespace | quote }}
     name: {{ template "certmanager.controller.serviceAccountName" . }}
 {{- end -}}

--- a/bitnami/cert-manager/templates/webhook/rbac.yaml
+++ b/bitnami/cert-manager/templates/webhook/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ printf "%s-dynamic-serving" (include "certmanager.webhook.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: webhook
     {{- if .Values.commonLabels }}
@@ -26,7 +25,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ printf "%s-dynamic-serving" (include "certmanager.webhook.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: webhook
     {{- if .Values.commonLabels }}
@@ -43,7 +41,6 @@ subjects:
 - apiGroup: ""
   kind: ServiceAccount
   name: {{ template "certmanager.webhook.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
@@ -82,5 +79,4 @@ subjects:
 - apiGroup: ""
   kind: ServiceAccount
   name: {{ template "certmanager.webhook.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)