### PR TITLE
[bitnami/argo-workflows] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: argo-workflows
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 5.3.4
+version: 5.3.5

--- a/bitnami/argo-workflows/templates/controller/aggregate-cluster-roles.yaml
+++ b/bitnami/argo-workflows/templates/controller/aggregate-cluster-roles.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}-view
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     app.kubernetes.io/part-of: argo-workflows
@@ -37,7 +36,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}-edit
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     app.kubernetes.io/part-of: argo-workflows
@@ -76,7 +74,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}-admin
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/part-of: argo-workflows

--- a/bitnami/argo-workflows/templates/controller/clusterrolebinding.yaml
+++ b/bitnami/argo-workflows/templates/controller/clusterrolebinding.yaml
@@ -7,7 +7,9 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ include "argo-workflows.controller.fullname.namespace" . }}
+  {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
@@ -47,7 +49,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "argo-workflows.controller.fullname.namespace" . }}-cluster-template
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: controller
     {{- if .Values.commonLabels }}

--- a/bitnami/argo-workflows/templates/controller/controller-cluster-roles.yaml
+++ b/bitnami/argo-workflows/templates/controller/controller-cluster-roles.yaml
@@ -7,7 +7,9 @@ kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ include "argo-workflows.controller.fullname.namespace" . }}
+  {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
@@ -165,7 +167,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "argo-workflows.controller.fullname.namespace" . }}-cluster-template
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller

--- a/bitnami/argo-workflows/templates/server/cluster-role.yaml
+++ b/bitnami/argo-workflows/templates/server/cluster-role.yaml
@@ -7,7 +7,9 @@ kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ include "argo-workflows.server.fullname.namespace" . }}
+  {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
@@ -135,7 +137,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "argo-workflows.server.fullname.namespace" . }}-cluster-template
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server

--- a/bitnami/argo-workflows/templates/server/clusterrolebinding.yaml
+++ b/bitnami/argo-workflows/templates/server/clusterrolebinding.yaml
@@ -7,7 +7,9 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ include "argo-workflows.server.fullname.namespace" . }}
+  {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
@@ -36,7 +38,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "argo-workflows.server.fullname.namespace" . }}-cluster-template
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)