### PR TITLE
[bitnami/thanos] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.8.0
+version: 12.8.1

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -19,4 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccountName" (dict "component" "query-frontend" "context" $) }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}
@@ -20,5 +19,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccountName" (dict "component" "query-frontend" "context" $) }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrole.yaml
@@ -5,7 +5,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -20,4 +20,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccountName" (dict "component" "query" "context" $) }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -5,7 +5,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}
@@ -21,5 +20,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccountName" (dict "component" "query" "context" $) }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)