### PR TITLE
[bitnami/pinniped] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: pinniped
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.2.2
+version: 1.2.3

--- a/bitnami/pinniped/templates/concierge/rbac.yaml
+++ b/bitnami/pinniped/templates/concierge/rbac.yaml
@@ -106,7 +106,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: ClusterRole
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "aggregated-api-server" | trunc 63 | trimSuffix "-" }}
@@ -157,7 +156,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.impersonation-proxy.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: ClusterRole
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "impersonation-proxy" | trunc 63 | trimSuffix "-" }}
@@ -167,7 +165,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "kube-cert-agent" | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -189,7 +186,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "kube-cert-agent" | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -202,7 +198,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.kube-cert-agent.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "kube-cert-agent" | trunc 63 | trimSuffix "-" }}
@@ -212,7 +207,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "aggregated-api-server" | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -306,7 +300,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "aggregated-api-server" | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -319,7 +312,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "aggregated-api-server" | trunc 63 | trimSuffix "-" }}
@@ -329,7 +321,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "kube-system-pod-read" | trunc 63 | trimSuffix "-" }}
-  namespace: kube-system
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -353,7 +344,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "kube-system-pod-read" | trunc 63 | trimSuffix "-" }}
-  namespace: kube-system
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -366,7 +356,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "kube-system-pod-read" | trunc 63 | trimSuffix "-" }}
@@ -442,7 +431,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: ClusterRole
   name: system:auth-delegator
@@ -452,7 +440,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "extension-apiserver-authentication-reader" | trunc 63 | trimSuffix "-" }}
-  namespace: kube-system
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -465,7 +452,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -475,7 +461,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "cluster-info-lister-watcher" | trunc 63 | trimSuffix "-" }}
-  namespace: kube-public
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -498,7 +483,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "cluster-info-lister-watcher" | trunc 63 | trimSuffix "-" }}
-  namespace: kube-public
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
@@ -511,7 +495,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.concierge.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: {{ printf "%s-%s" (include "pinniped.concierge.fullname.namespace" .) "cluster-info-lister-watcher" | trunc 63 | trimSuffix "-" }}

--- a/bitnami/pinniped/templates/supervisor/rbac.yaml
+++ b/bitnami/pinniped/templates/supervisor/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "pinniped.supervisor.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
@@ -132,7 +131,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "pinniped.supervisor.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
@@ -145,7 +143,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.supervisor.fullname" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: {{ template "pinniped.supervisor.fullname" . }}
@@ -156,7 +153,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ printf "%s-%s" (include "pinniped.supervisor.fullname.namespace" .) "extension-apiserver-authentication-reader" | trunc 63 | trimSuffix "-" }}
-  namespace: kube-system
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
@@ -169,7 +165,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.supervisor.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -191,7 +186,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.supervisor.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: ClusterRole
   name: system:auth-delegator
@@ -264,7 +258,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pinniped.supervisor.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 roleRef:
   kind: ClusterRole
   name: {{ printf "%s-%s" (include "pinniped.supervisor.fullname.namespace" .) "aggregated-api-server" | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)