### PR TITLE
[bitnami/nginx-ingress-controller] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 9.7.2
+version: 9.7.3

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -18,5 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "nginx-ingress-controller.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
@@ -17,4 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "nginx-ingress-controller.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)