### PR TITLE
[bitnami/multus-cni] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: multus-cni
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/multus-cni
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/multus-cni/templates/clusterrole.yaml
+++ b/bitnami/multus-cni/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/multus-cni/templates/clusterrolebinding.yaml
+++ b/bitnami/multus-cni/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -18,5 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "multus-cni.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/multus-cni/templates/clusterrolebinding.yaml
+++ b/bitnami/multus-cni/templates/clusterrolebinding.yaml
@@ -17,4 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "multus-cni.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)