### PR TITLE
[bitnami/kube-state-metrics] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: kube-state-metrics
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
-version: 3.5.5
+version: 3.5.6

--- a/bitnami/kube-state-metrics/templates/clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "common.names.fullname.namespace" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname.namespace" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -18,5 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -17,4 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -19,5 +18,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -18,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)