### PR TITLE
[bitnami/kube-prometheus] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 8.14.0
+version: 8.14.1

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}-psp
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}-psp
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -19,5 +18,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.alertmanager.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -18,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.alertmanager.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -18,5 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
@@ -17,4 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}-psp
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -18,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}-psp
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -19,5 +18,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
@@ -17,4 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -18,5 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-psp
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
@@ -18,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-psp
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -19,5 +18,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)