### PR TITLE
[bitnami/kiam] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: kiam
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kiam
-version: 1.3.2
+version: 1.3.3

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}-agent-psp
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
@@ -19,4 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}-agent-psp
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,5 +19,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.agent.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}-server-psp
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
     {{- if .Values.commonLabels }}

--- a/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}-server-psp
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,5 +19,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.server.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
@@ -19,4 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kiam/templates/server/server-read-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}-server-read
-  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
     {{- if .Values.commonLabels }}

--- a/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}-server-read
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -19,5 +18,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.server.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
@@ -18,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kiam/templates/server/server-write-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}-server-write
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
@@ -19,5 +19,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}
 {{- end }}

--- a/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}-server-write
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,6 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kiam.server.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)