### PR TITLE
[bitnami/flux] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: flux
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 0.3.3
+version: 0.3.4

--- a/bitnami/flux/templates/helm-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/helm-controller/clusterroles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-manager" (include "flux.helm-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller
@@ -73,7 +72,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-helmrelease-editor" (include "flux.helm-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller
@@ -107,7 +105,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-helmrelease-viewer" (include "flux.helm-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller

--- a/bitnami/flux/templates/image-automation-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/image-automation-controller/clusterroles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-manager" (include "flux.image-automation-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-automation-controller
@@ -62,7 +61,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-imgupdaut-editor" (include "flux.image-automation-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-automation-controller
@@ -96,7 +94,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-imgupdaut-viewer" (include "flux.image-automation-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-automation-controller

--- a/bitnami/flux/templates/image-reflector-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/clusterroles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-manager" (include "flux.image-reflector-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
@@ -79,7 +78,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-imagepolicy-editor" (include "flux.image-reflector-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
@@ -113,7 +111,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-imagepolicy-viewer" (include "flux.image-reflector-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
@@ -143,7 +140,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-imagerepository-editor" (include "flux.image-reflector-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
@@ -177,7 +173,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-imagerepository-viewer" (include "flux.image-reflector-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller

--- a/bitnami/flux/templates/kustomize-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/kustomize-controller/clusterroles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-manager" (include "flux.kustomize-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: kustomize-controller
@@ -87,7 +86,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-kustomization-editor" (include "flux.kustomize-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: kustomize-controller
@@ -121,7 +119,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-kustomization-viewer" (include "flux.kustomize-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: kustomize-controller

--- a/bitnami/flux/templates/notification-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/notification-controller/clusterroles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-manager" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
@@ -177,7 +176,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-alert-editor" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
@@ -211,7 +209,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-alert-viewer" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
@@ -241,7 +238,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-provider-editor" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
@@ -275,7 +271,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-provider-viewer" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
@@ -305,7 +300,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-receiver-editor" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
@@ -339,7 +333,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-receiver-viewer" (include "flux.notification-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller

--- a/bitnami/flux/templates/source-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/source-controller/clusterroles.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-manager" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -187,7 +186,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-bucket-editor" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -221,7 +219,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-bucket-viewer" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -251,7 +248,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-gitrepository-editor" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -285,7 +281,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-gitrepository-viewer" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -315,7 +310,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-helmchart-editor" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -349,7 +343,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-helmchart-viewer" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -379,7 +372,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-helmrepository-editor" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -413,7 +405,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-helmrepository-viewer" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -443,7 +434,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-ocirepository-editor" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
@@ -477,7 +467,6 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ printf "%s-ocirepository-viewer" (include "flux.source-controller.fullname.namespace" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)