### PR TITLE
[bitnami/fluent-bit] Remove namespace field for cluster wide resources

### DIFF
--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: fluent-bit
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 0.4.4
+version: 0.4.5

--- a/bitnami/fluent-bit/templates/clusterrole.yaml
+++ b/bitnami/fluent-bit/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: fluent-bit
     {{- if .Values.commonLabels }}

--- a/bitnami/fluent-bit/templates/clusterrolebinding.yaml
+++ b/bitnami/fluent-bit/templates/clusterrolebinding.yaml
@@ -18,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluent-bit.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end -}}

--- a/bitnami/fluent-bit/templates/clusterrolebinding.yaml
+++ b/bitnami/fluent-bit/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: fluent-bit
     {{- if .Values.commonLabels }}
@@ -19,5 +18,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "fluent-bit.serviceAccountName" . }}
-    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

`Cluster Role` and `Cluster Role Binding` do not need the `namespace` field in the metadata section since they are cluster-wide resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)