### PR TITLE
[bitnami/grafana-loki] Add the ability to set extra args for all containers

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: grafana-loki
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.9.2
+version: 2.10.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -109,6 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for compactor nodes                               | `""`                |
 | `compactor.command`                               | Override default container command (useful when using custom images)                                | `[]`                |
 | `compactor.args`                                  | Override default container args (useful when using custom images)                                   | `[]`                |
+| `compactor.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)          | `[]`                |
 | `compactor.replicaCount`                          | Number of Compactor replicas to deploy                                                              | `1`                 |
 | `compactor.livenessProbe.enabled`                 | Enable livenessProbe on Compactor nodes                                                             | `true`              |
 | `compactor.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                             | `60`                |
@@ -201,6 +202,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for gateway nodes                                   | `""`                  |
 | `gateway.command`                               | Override default container command (useful when using custom images)                                  | `[]`                  |
 | `gateway.args`                                  | Override default container args (useful when using custom images)                                     | `[]`                  |
+| `gateway.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)            | `[]`                  |
 | `gateway.verboseLogging`                        | Show the gateway access_log                                                                           | `false`               |
 | `gateway.replicaCount`                          | Number of Gateway replicas to deploy                                                                  | `1`                   |
 | `gateway.auth.enabled`                          | Enable basic auth                                                                                     | `false`               |
@@ -297,6 +299,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexGateway.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for indexGateway nodes                               | `""`            |
 | `indexGateway.command`                               | Override default container command (useful when using custom images)                                   | `[]`            |
 | `indexGateway.args`                                  | Override default container args (useful when using custom images)                                      | `[]`            |
+| `indexGateway.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)             | `[]`            |
 | `indexGateway.replicaCount`                          | Number of index-gateway replicas to deploy                                                             | `1`             |
 | `indexGateway.podManagementPolicy`                   | podManagementPolicy to manage scaling operation                                                        | `""`            |
 | `indexGateway.livenessProbe.enabled`                 | Enable livenessProbe on index-gateway nodes                                                            | `true`          |
@@ -376,6 +379,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for distributor nodes                               | `""`            |
 | `distributor.command`                               | Override default container command (useful when using custom images)                                  | `[]`            |
 | `distributor.args`                                  | Override default container args (useful when using custom images)                                     | `[]`            |
+| `distributor.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)            | `[]`            |
 | `distributor.replicaCount`                          | Number of Distributor replicas to deploy                                                              | `1`             |
 | `distributor.livenessProbe.enabled`                 | Enable livenessProbe on Distributor nodes                                                             | `true`          |
 | `distributor.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                               | `10`            |
@@ -454,6 +458,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for ingester nodes                               | `""`            |
 | `ingester.command`                               | Override default container command (useful when using custom images)                               | `[]`            |
 | `ingester.args`                                  | Override default container args (useful when using custom images)                                  | `[]`            |
+| `ingester.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)         | `[]`            |
 | `ingester.replicaCount`                          | Number of Ingester replicas to deploy                                                              | `1`             |
 | `ingester.livenessProbe.enabled`                 | Enable livenessProbe on Ingester nodes                                                             | `true`          |
 | `ingester.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                            | `10`            |
@@ -546,6 +551,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Querier nodes                               | `""`            |
 | `querier.command`                               | Override default container command (useful when using custom images)                              | `[]`            |
 | `querier.args`                                  | Override default container args (useful when using custom images)                                 | `[]`            |
+| `querier.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)        | `[]`            |
 | `querier.podManagementPolicy`                   | podManagementPolicy to manage scaling operation                                                   | `""`            |
 | `querier.livenessProbe.enabled`                 | Enable livenessProbe on Querier nodes                                                             | `true`          |
 | `querier.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                           | `10`            |
@@ -636,6 +642,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for queryFrontend nodes                               | `""`            |
 | `queryFrontend.command`                               | Override default container command (useful when using custom images)                                    | `[]`            |
 | `queryFrontend.args`                                  | Override default container args (useful when using custom images)                                       | `[]`            |
+| `queryFrontend.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)              | `[]`            |
 | `queryFrontend.replicaCount`                          | Number of queryFrontend replicas to deploy                                                              | `1`             |
 | `queryFrontend.livenessProbe.enabled`                 | Enable livenessProbe on queryFrontend nodes                                                             | `true`          |
 | `queryFrontend.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                 | `10`            |
@@ -715,6 +722,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryScheduler.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for queryScheduler nodes                               | `""`            |
 | `queryScheduler.command`                               | Override default container command (useful when using custom images)                                     | `[]`            |
 | `queryScheduler.args`                                  | Override default container args (useful when using custom images)                                        | `[]`            |
+| `queryScheduler.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)               | `[]`            |
 | `queryScheduler.replicaCount`                          | Number of queryScheduler replicas to deploy                                                              | `1`             |
 | `queryScheduler.livenessProbe.enabled`                 | Enable livenessProbe on queryScheduler nodes                                                             | `true`          |
 | `queryScheduler.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                  | `10`            |
@@ -795,6 +803,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ruler.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for ruler nodes                               | `""`            |
 | `ruler.command`                               | Override default container command (useful when using custom images)                            | `[]`            |
 | `ruler.args`                                  | Override default container args (useful when using custom images)                               | `[]`            |
+| `ruler.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)      | `[]`            |
 | `ruler.podManagementPolicy`                   | podManagementPolicy to manage scaling operation                                                 | `""`            |
 | `ruler.replicaCount`                          | Number of Ruler replicas to deploy                                                              | `1`             |
 | `ruler.livenessProbe.enabled`                 | Enable livenessProbe on Ruler nodes                                                             | `true`          |
@@ -887,6 +896,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tableManager.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for tableManager nodes                               | `""`            |
 | `tableManager.command`                               | Override default container command (useful when using custom images)                                   | `[]`            |
 | `tableManager.args`                                  | Override default container args (useful when using custom images)                                      | `[]`            |
+| `tableManager.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)             | `[]`            |
 | `tableManager.replicaCount`                          | Number of table-manager replicas to deploy                                                             | `1`             |
 | `tableManager.livenessProbe.enabled`                 | Enable livenessProbe on table-manager nodes                                                            | `true`          |
 | `tableManager.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                | `10`            |
@@ -972,6 +982,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `promtail.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for promtail nodes                                             | `""`                  |
 | `promtail.command`                               | Override default container command (useful when using custom images)                                             | `[]`                  |
 | `promtail.args`                                  | Override default container args (useful when using custom images)                                                | `[]`                  |
+| `promtail.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)                       | `[]`                  |
 | `promtail.containerPorts.http`                   | Promtail HTTP port                                                                                               | `8080`                |
 | `promtail.livenessProbe.enabled`                 | Enable livenessProbe on Promtail nodes                                                                           | `true`                |
 | `promtail.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                          | `10`                  |

--- a/bitnami/grafana-loki/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/compactor/deployment.yaml
@@ -93,6 +93,9 @@ spec:
             - -target=compactor
             - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
             - -boltdb.shipper.compactor.working-directory={{ .Values.loki.dataDir }}/loki/compactor
+          {{- if .Values.compactor.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.compactor.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.compactor.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/distributor/deployment.yaml
@@ -93,6 +93,9 @@ spec:
           args:
             - -target=distributor
             - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
+          {{- if .Values.distributor.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.distributor.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.distributor.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-loki/templates/gateway/deployment.yaml
@@ -96,6 +96,9 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.gateway.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.args "context" $) | nindent 12 }}
+          {{- if .Values.gateway.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.gateway.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           env:
             - name: BITNAMI_DEBUG

--- a/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
@@ -97,6 +97,9 @@ spec:
           args:
             - -target=index-gateway
             - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
+          {{- if .Values.indexGateway.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.indexGateway.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ingester/statefulset.yaml
@@ -118,6 +118,9 @@ spec:
           args:
             - -target=ingester
             - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
+          {{- if .Values.ingester.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.ingester.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.ingester.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/promtail/daemonset.yaml
+++ b/bitnami/grafana-loki/templates/promtail/daemonset.yaml
@@ -90,6 +90,9 @@ spec:
           {{- else }}
           args:
             - -config.file=/bitnami/promtail/conf/promtail.yaml
+          {{- if .Values.promtail.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.promtail.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           env:
             - name: HOSTNAME

--- a/bitnami/grafana-loki/templates/querier/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/querier/statefulset.yaml
@@ -123,6 +123,9 @@ spec:
             {{- if .Values.queryScheduler.enabled }}
             - -querier.scheduler-address={{ template "grafana-loki.query-scheduler.fullname" . }}:{{ .Values.queryScheduler.service.ports.grpc }}
             {{- end }}
+          {{- if .Values.querier.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.querier.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.querier.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.querier.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             {{- if .Values.queryScheduler.enabled }}
             - -frontend.scheduler-address={{ template "grafana-loki.query-scheduler.fullname" . }}:{{ .Values.queryScheduler.service.ports.grpc }}
             {{- end }}
+          {{- if .Values.queryFrontend.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.queryFrontend.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
@@ -92,9 +92,12 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.args "context" $) | nindent 12 }}
           {{- else }}
           args:
-          - '-config.file={{ .Values.loki.dataDir }}/conf/loki.yaml'
-          - -log.level=debug
-          - -target=query-scheduler
+            - -target=query-scheduler
+            - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
+            - -log.level=debug
+          {{- if .Values.queryScheduler.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.queryScheduler.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/ruler/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ruler/statefulset.yaml
@@ -121,6 +121,9 @@ spec:
           args:
             - -target=ruler
             - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
+          {{- if .Values.ruler.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.ruler.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.ruler.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/templates/table-manager/deployment.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/deployment.yaml
@@ -92,6 +92,9 @@ spec:
           args:
             - -target=table-manager
             - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
+          {{- if .Values.tableManager.extraArgs }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.extraArgs "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.tableManager.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -291,6 +291,9 @@ compactor:
   ## @param compactor.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param compactor.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param compactor.replicaCount Number of Compactor replicas to deploy
   ##
   replicaCount: 1
@@ -625,6 +628,9 @@ gateway:
   ## @param gateway.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param gateway.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param gateway.verboseLogging Show the gateway access_log
   ##
   verboseLogging: false
@@ -999,6 +1005,9 @@ indexGateway:
   ## @param indexGateway.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param indexGateway.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param indexGateway.replicaCount Number of index-gateway replicas to deploy
   ##
   replicaCount: 1
@@ -1267,6 +1276,9 @@ distributor:
   ## @param distributor.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param distributor.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param distributor.replicaCount Number of Distributor replicas to deploy
   ##
   replicaCount: 1
@@ -1531,6 +1543,9 @@ ingester:
   ## @param ingester.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param ingester.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param ingester.replicaCount Number of Ingester replicas to deploy
   ##
   replicaCount: 1
@@ -1842,6 +1857,9 @@ querier:
   ## @param querier.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param querier.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param querier.podManagementPolicy podManagementPolicy to manage scaling operation
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   ##
@@ -2147,6 +2165,9 @@ queryFrontend:
   ## @param queryFrontend.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param queryFrontend.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param queryFrontend.replicaCount Number of queryFrontend replicas to deploy
   ##
   replicaCount: 1
@@ -2416,6 +2437,9 @@ queryScheduler:
   ## @param queryScheduler.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param queryScheduler.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param queryScheduler.replicaCount Number of queryScheduler replicas to deploy
   ##
   replicaCount: 1
@@ -2688,6 +2712,9 @@ ruler:
   ## @param ruler.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param ruler.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param ruler.podManagementPolicy podManagementPolicy to manage scaling operation
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   ##
@@ -2999,6 +3026,9 @@ tableManager:
   ## @param tableManager.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param tableManager.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
   ## @param tableManager.replicaCount Number of table-manager replicas to deploy
   ##
   replicaCount: 1
@@ -3294,6 +3324,9 @@ promtail:
   ## @param promtail.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param promtail.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
+  ##
+  extraArgs: []
 
   ## @param promtail.containerPorts.http Promtail HTTP port
   ##


### PR DESCRIPTION
### Description of the change

This PR is related to #16890

This change aims to give the ability to provide extra arguments to all containers managed by this Helm chart

### Benefits

As explained in #16890, in order to add extra arguments, we must inspect containers default args and then repeat them in the YAML value file before adding extra arguments

With `extraArgs` value, we'll be able for any container to set additional arguments, eg. `-config.expand-env=true`

### Possible drawbacks

N/A

### Applicable issues

- fixes #16890 

### Additional information

This change has been tested by rendering the Helm chart with `extraArgs` values and multiple scenarii

For every testcase, following command was used (only values.yaml differs) : 

```bash
helm template . \
  -f values.yaml \
  	| yq -r '. | select (((.kind == "Deployment") or (.kind == "StatefulSet") or (.kind == "DaemonSet")) 
  		and ((.metadata.name | contains("compactor")) 
  		    or (.metadata.name | contains("distributor")) 
  		    or (.metadata.name | contains("gateway")) 
  		    or (.metadata.name | contains("ingester")) 
  		    or (.metadata.name | contains("promtail")) 
  		    or (.metadata.name | contains("querier")) 
  		    or (.metadata.name | contains("query-frontend")) 
  		    or (.metadata.name | contains("query-scheduler")) 
  		    or (.metadata.name | contains("ruler")) 
  		    or (.metadata.name | contains("table-manager")))) 
  		    	| "kind: \(.kind)\nname: \(.metadata.name)\nargs:\n\(.spec.template.spec.containers[] | .args)\n"'
```

#### Scenario 1 - Nominal case (no extraArgs)

`values.yaml` input

```yaml
indexGateway:
  enabled: true
gateway:
  enabled: true
queryScheduler:
  enabled: true
tableManager:
  enabled: true
ruler:
  enabled: true
```

Result : default args are shown

```
kind: DaemonSet
name: release-name-grafana-loki-promtail
args:
["-config.file=/bitnami/promtail/conf/promtail.yaml"]

kind: Deployment
name: release-name-grafana-loki-compactor
args:
["-target=compactor","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-boltdb.shipper.compactor.working-directory=/bitnami/grafana-loki/loki/compactor"]

kind: Deployment
name: release-name-grafana-loki-distributor
args:
["-target=distributor","-config.file=/bitnami/grafana-loki/conf/loki.yaml"]

kind: Deployment
name: release-name-grafana-loki-gateway
args:
null

kind: Deployment
name: release-name-grafana-loki-query-frontend
args:
["-target=query-frontend","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-frontend.scheduler-address=release-name-grafana-loki-query-scheduler:9095"]

kind: Deployment
name: release-name-grafana-loki-query-scheduler
args:
["-target=query-scheduler","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-log.level=debug"]

kind: Deployment
name: release-name-grafana-loki-table-manager
args:
["-target=table-manager","-config.file=/bitnami/grafana-loki/conf/loki.yaml"]

kind: StatefulSet
name: release-name-grafana-loki-index-gateway
args:
["-target=index-gateway","-config.file=/bitnami/grafana-loki/conf/loki.yaml"]

kind: StatefulSet
name: release-name-grafana-loki-ingester
args:
["-target=ingester","-config.file=/bitnami/grafana-loki/conf/loki.yaml"]

kind: StatefulSet
name: release-name-grafana-loki-querier
args:
["-target=querier","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-querier.scheduler-address=release-name-grafana-loki-query-scheduler:9095"]

kind: StatefulSet
name: release-name-grafana-loki-ruler
args:
["-target=ruler","-config.file=/bitnami/grafana-loki/conf/loki.yaml"]
```

#### Scenario 2 -  Add extraArgs `-config.expand-env=true`

`values.yaml` input

```yaml
indexGateway:
  enabled: true
  extraArgs:
  - -config.expand-env=true
gateway:
  enabled: true
  extraArgs:
  - -config.expand-env=true
compactor:
  extraArgs:
  - -config.expand-env=true
distributor:
  extraArgs:
  - -config.expand-env=true
ingester:
  extraArgs:
  - -config.expand-env=true
querier:
  extraArgs:
  - -config.expand-env=true
queryFrontend:
  extraArgs:
  - -config.expand-env=true
queryScheduler:
  enabled: true
  extraArgs:
  - -config.expand-env=true
promtail:
  extraArgs:
  - -config.expand-env=true
tableManager:
  enabled: true
  extraArgs:
  - -config.expand-env=true
ruler:
  enabled: true
  extraArgs:
  - -config.expand-env=true
```

Result : default args are left untouched, and extraArg is added to the existing list (except for gateway component which doesn't have any default args)

```
kind: DaemonSet
name: release-name-grafana-loki-promtail
args:
["-config.file=/bitnami/promtail/conf/promtail.yaml","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-compactor
args:
["-target=compactor","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-boltdb.shipper.compactor.working-directory=/bitnami/grafana-loki/loki/compactor","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-distributor
args:
["-target=distributor","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-gateway
args:
null

kind: Deployment
name: release-name-grafana-loki-query-frontend
args:
["-target=query-frontend","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-frontend.scheduler-address=release-name-grafana-loki-query-scheduler:9095","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-query-scheduler
args:
["-target=query-scheduler","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-log.level=debug","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-table-manager
args:
["-target=table-manager","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-index-gateway
args:
["-target=index-gateway","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-ingester
args:
["-target=ingester","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-querier
args:
["-target=querier","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-querier.scheduler-address=release-name-grafana-loki-query-scheduler:9095","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-ruler
args:
["-target=ruler","-config.file=/bitnami/grafana-loki/conf/loki.yaml","-config.expand-env=true"]
```

#### Scenario 3 -  Override args and add extraArgs `-config.expand-env=true`

`values.yaml` input

```yaml
indexGateway:
  enabled: true
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
gateway:
  enabled: true
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
compactor:
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
distributor:
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
ingester:
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
querier:
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
queryFrontend:
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
queryScheduler:
  args:
  - -my=arg
  enabled: true
  extraArgs:
  - -config.expand-env=true
promtail:
  args:
  - -my=arg
  extraArgs:
  - -config.expand-env=true
tableManager:
  args:
  - -my=arg
  enabled: true
  extraArgs:
  - -config.expand-env=true
ruler:
  args:
  - -my=arg
  enabled: true
  extraArgs:
  - -config.expand-env=true
```

Result : args are overriden and extraArgs is added

```
kind: DaemonSet
name: release-name-grafana-loki-promtail
args:
["-my=arg","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-compactor
args:
["-my=arg","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-distributor
args:
["-my=arg","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-gateway
args:
["-my=arg","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-query-frontend
args:
["-my=arg","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-query-scheduler
args:
["-my=arg","-config.expand-env=true"]

kind: Deployment
name: release-name-grafana-loki-table-manager
args:
["-my=arg","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-index-gateway
args:
["-my=arg","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-ingester
args:
["-my=arg","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-querier
args:
["-my=arg","-config.expand-env=true"]

kind: StatefulSet
name: release-name-grafana-loki-ruler
args:
["-my=arg","-config.expand-env=true"]
```

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
