### PR TITLE
[bitnami/cert-manager] fix wrong ServiceAccount used for cainjector ClusterRoleBinding

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: cert-manager
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.11.4
+version: 0.11.5

--- a/bitnami/cert-manager/templates/cainjector/rbac.yaml
+++ b/bitnami/cert-manager/templates/cainjector/rbac.yaml
@@ -102,7 +102,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "certmanager.cainjector.fullname" . }}
 subjects:
-  - name: {{ template "certmanager.cainjector.fullname" . }}
+  - name: {{ template "certmanager.cainjector.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
 {{- end -}}


### PR DESCRIPTION
### Description of the change

The ClusterRoleBinding for cainjector template was using the wrong helper and so the subjects ServiceAccount was not right especially when you use a custom ServiceAccount name.

### Benefits

It will let you use a different ServiceAccount for cainjector than cert-manager-cainjector in the cert-manager Helm Chart.

### Possible drawbacks

There is no drawbacks.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
