### PR TITLE
[bitnami/clickhouse] Add clickhouse shard labels

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: clickhouse
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.4.4
+version: 3.4.5

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -163,6 +163,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `command`                       | Override default container command (useful when using custom images)                                                     | `["/scripts/setup.sh"]` |
 | `args`                          | Override default container args (useful when using custom images)                                                        | `[]`                    |
 | `hostAliases`                   | ClickHouse pods host aliases                                                                                             | `[]`                    |
+| `customShardLabel`              | Extra label with shard number (useful for custom affinity rules)                                                         | `{}`                    |
 | `podLabels`                     | Extra labels for ClickHouse pods                                                                                         | `{}`                    |
 | `podAnnotations`                | Annotations for ClickHouse pods                                                                                          | `{}`                    |
 | `podAffinityPreset`             | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                    |

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -39,6 +39,9 @@ spec:
         {{- if $.Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" $.Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
+        {{- if $.Values.customShardLabel }}
+        {{- printf "%s: %d" $.Values.customShardLabel.name $i | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "clickhouse.serviceAccountName" $ }}
       {{- include "clickhouse.imagePullSecrets" $ | nindent 6 }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -429,6 +429,9 @@ args: []
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
+## @param customShardLabel Extra label with shard number (useful for custom affinity rules)
+##
+customShardLabel: {}
 ## @param podLabels Extra labels for ClickHouse pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -430,6 +430,9 @@ args: []
 ##
 hostAliases: []
 ## @param customShardLabel Extra label with shard number (useful for custom affinity rules)
+## Example:
+## customShardLabel:
+##   name: app.clickhouse/shard 
 ##
 customShardLabel: {}
 ## @param podLabels Extra labels for ClickHouse pods


### PR DESCRIPTION
### Description of the change

Adds a customShardLabel to clickhouse statefullset podTemplate

### Benefits

Allows to create more accurate affinity rules. For example force replica pods of same shard to schedule in different AZ.

### Possible drawbacks

--

### Applicable issues

--

### Additional information

--

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
