### PR TITLE
[bitnami/appsmith] Release 0.3.8

### DIFF
--- a/.vib/appsmith/cypress/cypress/integration/appsmith_spec.js
+++ b/.vib/appsmith/cypress/cypress/integration/appsmith_spec.js
@@ -14,10 +14,11 @@ it('allows to create a new project', () => {
   cy.get('[class*="templates-tab"]').click();
 
   // Create an application from the Marketing Portal template
-  cy.contains('[data-cy="template-card"]', 'Marketing Portal').within(() => {
-    cy.get('[class*="fork-button"]').click();
-  })
-  cy.contains('FORK TEMPLATE').click();
+  cy.get('input[data-testid*="search-input"]').type('Marketing Portal');
+  // Wait for only the Marketplace template to show in the search
+  cy.wait(5000);
+  cy.get('.fork-button').click();
+  cy.contains('Fork template').click();
   cy.contains('Deploy');
   // Check if the application exists in the applications page
   cy.visit('/applications');
@@ -26,10 +27,11 @@ it('allows to create a new project', () => {
 
 it('allows to change workspace settings', () => {
   cy.login();
-  cy.get('span[class*="workspace-name"]').click();
-  cy.get('[data-cy*="workspace-setting"]').click();
+  cy.get('.t--options-icon').click();
+  cy.contains('Settings').click();
+
   cy.fixture('user-settings').then(($us) => {
-    cy.get('input[placeholder="Workspace Name"]')
+    cy.get('input[placeholder="Workspace name"]')
       .clear()
       .type(`${$us.instanceName}-${random}`, { force: true });
     cy.get('h2').contains(`${$us.instanceName}-${random}`);

--- a/.vib/appsmith/cypress/cypress/support/commands.js
+++ b/.vib/appsmith/cypress/cypress/support/commands.js
@@ -23,8 +23,8 @@ Cypress.Commands.add(
     cy.visit('/');
     cy.get('[type="email"]').should('be.enabled').type(username);
     cy.get('[type="password"]').should('be.enabled').type(password);
-    cy.contains('button', 'sign in').click();
-    cy.contains('WORKSPACES').should('be.visible');
+    cy.contains('button', 'Sign in').click();
+    cy.contains('Workspaces').should('be.visible');
   }
 );
 

--- a/bitnami/appsmith/Chart.lock
+++ b/bitnami/appsmith/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.11.3
+  version: 17.11.6
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.15.1
+  version: 13.15.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.4.0
-digest: sha256:f34fc529c6273a499edd2dc3d635943eee47bd28444862b73074e05e3e5de3f4
-generated: "2023-05-26T18:37:37.973391256Z"
+digest: sha256:5687eee3182ff01f5a45e03729d2ffebea186489b13e6a36507e9daba9568331
+generated: "2023-06-25T12:54:54.593170736Z"

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   category: CMS
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 1.9.21
+appVersion: 1.9.23
 dependencies:
   - condition: redis.enabled
     name: redis
@@ -32,4 +32,4 @@ maintainers:
 name: appsmith
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 0.3.7
+version: 0.3.8

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                                                                                   | `["infinity"]`        |
 | `image.registry`         | Appsmith image registry                                                                                                                             | `docker.io`           |
 | `image.repository`       | Appsmith image repository                                                                                                                           | `bitnami/appsmith`    |
-| `image.tag`              | Appsmith image tag (immutable tags are recommended)                                                                                                 | `1.9.21-debian-11-r2` |
+| `image.tag`              | Appsmith image tag (immutable tags are recommended)                                                                                                 | `1.9.23-debian-11-r0` |
 | `image.digest`           | Appsmith image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                  |
 | `image.pullPolicy`       | Appsmith image pull policy                                                                                                                          | `IfNotPresent`        |
 | `image.pullSecrets`      | Appsmith image pull secrets                                                                                                                         | `[]`                  |
@@ -367,7 +367,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r119`     |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r129`     |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -76,7 +76,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/appsmith
-  tag: 1.9.21-debian-11-r2
+  tag: 1.9.23-debian-11-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -1114,7 +1114,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r119
+    tag: 11-debian-11-r129
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
- Creating a manual PR to avoid Github action errors with the automatic PR
- Updating Appsmith to 0.3.8 and fixing cypress tests. 

App version: 1.9.23.
Chart version: 0.3.8.
Immutable tags inside the values files:
docker.io/bitnami/appsmith:1.9.23-debian-11-r0
docker.io/bitnami/bitnami-shell:11-debian-11-r129