### PR TITLE
[bitnami/spark] Add extraVolumeClaimTemplates in master and worker StatefulSets

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: spark
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 7.0.2
+version: 7.1.0

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -137,6 +137,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.lifecycleHooks`                                  | for the master container(s) to automate configuration before or after startup                                            | `{}`            |
 | `master.extraVolumes`                                    | Optionally specify extra list of additional volumes for the master pod(s)                                                | `[]`            |
 | `master.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the master container(s)                                     | `[]`            |
+| `master.extraVolumeClaimTemplates`                       | Optionally specify extra list of volumesClaimTemplates for the master statefulset                                        | `[]`            |
 | `master.resources.limits`                                | The resources limits for the container                                                                                   | `{}`            |
 | `master.resources.requests`                              | The requested resources for the container                                                                                | `{}`            |
 | `master.livenessProbe.enabled`                           | Enable livenessProbe                                                                                                     | `true`          |
@@ -213,6 +214,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.lifecycleHooks`                                  | for the worker container(s) to automate configuration before or after startup                                            | `{}`            |
 | `worker.extraVolumes`                                    | Optionally specify extra list of additional volumes for the worker pod(s)                                                | `[]`            |
 | `worker.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the master container(s)                                     | `[]`            |
+| `worker.extraVolumeClaimTemplates`                       | Optionally specify extra list of volumesClaimTemplates for the worker statefulset                                        | `[]`            |
 | `worker.resources.limits`                                | The resources limits for the container                                                                                   | `{}`            |
 | `worker.resources.requests`                              | The requested resources for the container                                                                                | `{}`            |
 | `worker.livenessProbe.enabled`                           | Enable livenessProbe                                                                                                     | `true`          |

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -349,3 +349,6 @@ spec:
             secretName: {{ template ".Values.initScriptsSecret" . }}
             defaultMode: 0755
         {{- end }}
+  {{- if .Values.master.extraVolumeClaimTemplates }}
+  volumeClaimTemplates: {{- include "common.tplvalues.render" (dict "value" .Values.master.extraVolumeClaimTemplates "context" $) | nindent 8 }}
+  {{- end }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -373,3 +373,6 @@ spec:
             secretName: {{ template ".Values.initScriptsSecret" . }}
             defaultMode: 0755
         {{- end }}
+  {{- if .Values.worker.extraVolumeClaimTemplates }}
+  volumeClaimTemplates: {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeClaimTemplates "context" $) | nindent 8 }}
+  {{- end }}

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -280,6 +280,9 @@ master:
   ## @param master.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the master container(s)
   ##
   extraVolumeMounts: []
+  ## @param master.extraVolumeClaimTemplates Optionally specify extra list of volumesClaimTemplates for the master statefulset
+  ##
+  extraVolumeClaimTemplates: []
   ## Container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -561,6 +564,9 @@ worker:
   ## @param worker.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the master container(s)
   ##
   extraVolumeMounts: []
+  ## @param worker.extraVolumeClaimTemplates Optionally specify extra list of volumesClaimTemplates for the worker statefulset
+  ##
+  extraVolumeClaimTemplates: []
   ## Container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Description of the change

I just added the ability to mount volumes (PVC) to master and worker nodes

### Benefits

I we run Kubernetes nodes with HDD, Spark would be very slow. So, if we mount PVC which could be premium SSD on Azure or gp3 on AWS, Spark can have much better performance.

### Possible drawbacks

There is not drawbacks

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #17283

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
