### PR TITLE
[bitnami/common] Update common.secrets.passwords.manage and common.secrets.lookup

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.4.0
+appVersion: 2.5.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.4.0
+version: 2.5.0

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -72,7 +72,7 @@ Params:
   - strong - Boolean - Optional - Whether to add symbols to the generated random password.
   - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
   - context - Context - Required - Parent context.
-
+  - failOnNew - Boolean - Optional - Default to true. If set to false, skip errors adding new keys to existing secrets.
 The order in which this function returns a secret password:
   1. Already existing 'Secret' resource
      (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
@@ -86,6 +86,7 @@ The order in which this function returns a secret password:
 
 {{- $password := "" }}
 {{- $subchart := "" }}
+{{- $failOnNew := default true .failOnNew }}
 {{- $chartName := default "" .chartName }}
 {{- $passwordLength := default 10 .length }}
 {{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
@@ -94,7 +95,7 @@ The order in which this function returns a secret password:
 {{- if $secretData }}
   {{- if hasKey $secretData .key }}
     {{- $password = index $secretData .key | quote }}
-  {{- else }}
+  {{- else if $failOnNew }}
     {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- end -}}
 {{- else if $providedPasswordValue }}
@@ -137,14 +138,15 @@ Params:
 */}}
 {{- define "common.secrets.lookup" -}}
 {{- $value := "" -}}
-{{- $defaultValue := required "\n'common.secrets.lookup': Argument 'defaultValue' missing or empty" .defaultValue -}}
 {{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data -}}
 {{- if and $secretData (hasKey $secretData .key) -}}
   {{- $value = index $secretData .key -}}
-{{- else -}}
-  {{- $value = $defaultValue | toString | b64enc -}}
+{{- else if .defaultValue -}}
+  {{- $value = .defaultValue | toString | b64enc -}}
 {{- end -}}
+{{- if $value -}}
 {{- printf "%s" $value -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

Adds two changes to the 'secrets' helpers group.

* Adds the variable `failOnNew`for "common.secrets.passwords.manage", which avoids a failure if the secrets exist but the key that is being searched does not exist. Default behavior stays as it currently is.
* Makes defaultValue optional on "common.secrets.lookup", if not set and lookup actions returns nothing, the helper will return nothing too.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
