### PR TITLE
[bitnami/grafana-mimir] Fix helm error when gateway.auth.existingSecret is set

### DIFF
--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -50,4 +50,4 @@ maintainers:
 name: grafana-mimir
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 0.5.3
+version: 0.5.4

--- a/bitnami/grafana-mimir/templates/_helpers.tpl
+++ b/bitnami/grafana-mimir/templates/_helpers.tpl
@@ -24,7 +24,7 @@ Return the proper the name of the secret with the auth credentials for the gatew
 {{- if not .Values.gateway.auth.existingSecret }}
   {{- include "grafana-mimir.gateway.fullname" . }}
 {{- else }}
-  {{- include "" .Values.gateway.auth.existingSecret }}
+  {{- printf "%s" .Values.gateway.auth.existingSecret -}}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Correctly return the existing secret name in grafana-mimir.gateway.secretName when gateway.auth.existingSecret is set.

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows pre-existing secrets to be used for gateway authentication.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #17468

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
