### PR TITLE
[bitnami/redis] Remove worker nodes setting from VIB tests

### DIFF
--- a/.vib/redis/vib-publish.json
+++ b/.vib/redis/vib-publish.json
@@ -25,8 +25,7 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
-            "name": "S4",
-            "worker_nodes_instance_count": 1
+            "name": "S4"
           }
         }
       },

--- a/.vib/redis/vib-verify.json
+++ b/.vib/redis/vib-verify.json
@@ -25,8 +25,7 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
-            "name": "S4",
-            "worker_nodes_instance_count": 1
+            "name": "S4"
           }
         }
       },


### PR DESCRIPTION
We're finding some issues when testing the Redis Helm chart using `worker_nodes_instance_count: 1`; without this option, everything is working as expected

Just for the records, this parameter was introduced at https://github.com/bitnami/charts/pull/13021