### PR TITLE
[bitnami/postgresql] Fix postgres random password generation

### DIFF
--- a/bitnami/postgresql/Chart.lock
+++ b/bitnami/postgresql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.5.0
-digest: sha256:79f3252b369ae10fe4c84a50441c7d2e014130b3a4b9b99b299611b02db3d58e
-generated: "2023-06-30T16:15:11.613863+02:00"
+  version: 2.6.0
+digest: sha256:6ce7c85dcb43ad1fc5ff600850f28820ddc2f1a7c8cb25c5ff542fe1f852165a
+generated: "2023-07-06T11:00:24.484042+02:00"

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: postgresql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/post
-version: 12.6.3
+version: 12.6.4

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -160,7 +160,7 @@ Return true if a secret object should be created
 */}}
 {{- define "postgresql.createSecret" -}}
 {{- $customUser := include "postgresql.username" . -}}
-{{- $postgresPassword := include "common.secrets.lookup" (dict "secret" (include "common.names.fullname" .) "key" .Values.auth.secretKeys.adminPasswordKey "defaultValue" (ternary .Values.auth.postgresPassword .Values.auth.password  (eq $customUser "postgres")) "context" $) -}}
+{{- $postgresPassword := include "common.secrets.lookup" (dict "secret" (include "common.names.fullname" .) "key" .Values.auth.secretKeys.adminPasswordKey "defaultValue" (ternary (coalesce .Values.global.postgresql.auth.postgresPassword .Values.auth.postgresPassword) (coalesce .Values.global.postgresql.auth.password .Values.auth.password) (or (empty $customUser) (eq $customUser "postgres"))) "context" $) -}}
 {{- if and (not (or .Values.global.postgresql.auth.existingSecret .Values.auth.existingSecret))
     (or $postgresPassword .Values.auth.enablePostgresUser (and (not (empty $customUser)) (ne $customUser "postgres")) (eq .Values.architecture "replication") (and .Values.ldap.enabled (or .Values.ldap.bind_password .Values.ldap.bindpw))) -}}
     {{- true -}}

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -6,13 +6,13 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $host := include "postgresql.primary.fullname" . }}
 {{- $port := include "postgresql.service.port" . }}
 {{- $customUser := include "postgresql.username" . }}
-{{- $postgresPassword := include "common.secrets.lookup" (dict "secret" (include "postgresql.secretName" .) "key" $.Values.auth.secretKeys.adminPasswordKey "defaultValue" (ternary .Values.auth.postgresPassword .Values.auth.password  (eq $customUser "postgres")) "context" $) | trimAll "\"" | b64dec }}
+{{- $postgresPassword := include "common.secrets.lookup" (dict "secret" (include "postgresql.secretName" .) "key" .Values.auth.secretKeys.adminPasswordKey "defaultValue" (ternary (coalesce .Values.global.postgresql.auth.postgresPassword .Values.auth.postgresPassword) (coalesce .Values.global.postgresql.auth.password .Values.auth.password) (or (empty $customUser) (eq $customUser "postgres"))) "context" $) | trimAll "\"" | b64dec }}
 {{- if and (not $postgresPassword) .Values.auth.enablePostgresUser }}
 {{- $postgresPassword = randAlphaNum 10 }}
 {{- end }}
 {{- $replicationPassword := "" }}
 {{- if eq .Values.architecture "replication" }}
-{{- $replicationPassword = include "common.secrets.passwords.manage" (dict "secret" (include "postgresql.secretName" .) "key" $.Values.auth.secretKeys.replicationPasswordKey "providedValues" (list "auth.replicationPassword") "context" $) | trimAll "\"" | b64dec }}
+{{- $replicationPassword = include "common.secrets.passwords.manage" (dict "secret" (include "postgresql.secretName" .) "key" .Values.auth.secretKeys.replicationPasswordKey "providedValues" (list "auth.replicationPassword") "context" $) | trimAll "\"" | b64dec }}
 {{- end }}
 {{- $ldapPassword := "" }}
 {{- if and .Values.ldap.enabled (or .Values.ldap.bind_password .Values.ldap.bindpw) }}
@@ -20,7 +20,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- end }}
 {{- $password := "" }}
 {{- if and (not (empty $customUser)) (ne $customUser "postgres") }}
-{{- $password = include "common.secrets.passwords.manage" (dict "secret" (include "postgresql.secretName" .) "key" $.Values.auth.secretKeys.userPasswordKey "providedValues" (list "global.postgresql.auth.password" "auth.password") "context" $) | trimAll "\"" | b64dec }}
+{{- $password = include "common.secrets.passwords.manage" (dict "secret" (include "postgresql.secretName" .) "key" .Values.auth.secretKeys.userPasswordKey "providedValues" (list "global.postgresql.auth.password" "auth.password") "context" $) | trimAll "\"" | b64dec }}
 {{- end }}
 {{- $database := include "postgresql.database" . }}
 {{- if (include "postgresql.createSecret" .) }}


### PR DESCRIPTION
### Description of the change

This PR fixes an issue where the values `global.postgresql.auth.postgresPassword` and `auth.postgresPassword` were being ignored and therefore a random password was being generated.

The issue affects versions from 12.6.0 to 12.6.3.

### Affected issues

- fixes https://github.com/bitnami/charts/issues/17490

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
