### PR TITLE
[bitnami/oauth2-proxy] make google-group as list instead of string

### DIFF
--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: oauth2-proxy
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 3.7.4
+version: 3.7.5

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -131,7 +131,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `configuration.existingSecret`                         | Secret with the client ID, secret and cookie secret                                                      | `""`               |
 | `configuration.google.enabled`                         | Enable Google service account                                                                            | `false`            |
 | `configuration.google.adminEmail`                      | Google admin email                                                                                       | `""`               |
-| `configuration.google.groups`                          | Restrict logins to members of this google group                                                          | `[]`               |
+| `configuration.google.groups`                          | Restrict logins to members of these google groups                                                        | `[]`               |
 | `configuration.google.serviceAccountJson`              | Google Service account JSON                                                                              | `""`               |
 | `configuration.google.existingSecret`                  | Existing secret containing Google Service Account                                                        | `""`               |
 | `configuration.content`                                | Default configuration                                                                                    | `""`               |

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -131,7 +131,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `configuration.existingSecret`                         | Secret with the client ID, secret and cookie secret                                                      | `""`               |
 | `configuration.google.enabled`                         | Enable Google service account                                                                            | `false`            |
 | `configuration.google.adminEmail`                      | Google admin email                                                                                       | `""`               |
-| `configuration.google.googleGroups`                    | Restrict logins to members of this google groups                                                         | `""`               |
+| `configuration.google.groups`                          | Restrict logins to members of this google group                                                          | `[]`               |
 | `configuration.google.serviceAccountJson`              | Google Service account JSON                                                                              | `""`               |
 | `configuration.google.existingSecret`                  | Existing secret containing Google Service Account                                                        | `""`               |
 | `configuration.content`                                | Default configuration                                                                                    | `""`               |

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -131,7 +131,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `configuration.existingSecret`                         | Secret with the client ID, secret and cookie secret                                                      | `""`               |
 | `configuration.google.enabled`                         | Enable Google service account                                                                            | `false`            |
 | `configuration.google.adminEmail`                      | Google admin email                                                                                       | `""`               |
-| `configuration.google.googleGroup`                     | Restrict logins to members of this google group                                                          | `""`               |
+| `configuration.google.googleGroups`                    | Restrict logins to members of this google groups                                                         | `""`               |
 | `configuration.google.serviceAccountJson`              | Google Service account JSON                                                                              | `""`               |
 | `configuration.google.existingSecret`                  | Existing secret containing Google Service Account                                                        | `""`               |
 | `configuration.content`                                | Default configuration                                                                                    | `""`               |

--- a/bitnami/oauth2-proxy/templates/deployment.yaml
+++ b/bitnami/oauth2-proxy/templates/deployment.yaml
@@ -104,8 +104,8 @@ spec:
             {{- if .Values.configuration.google.enabled }}
             - --google-admin-email={{ .Values.configuration.google.adminEmail }}
             - --google-service-account-json=/bitnami/oauth2-proxy/conf/google/service-account.json
-            {{- if .Values.configuration.google.googleGroups }}
-            {{- range $group := .Values.configuration.google.googleGroups }}
+            {{- if .Values.configuration.google.groups }}
+            {{- range $group := .Values.configuration.google.groups }}
             - --google-group={{ $group }}
             {{- end }}
             {{- end }}

--- a/bitnami/oauth2-proxy/templates/deployment.yaml
+++ b/bitnami/oauth2-proxy/templates/deployment.yaml
@@ -104,7 +104,11 @@ spec:
             {{- if .Values.configuration.google.enabled }}
             - --google-admin-email={{ .Values.configuration.google.adminEmail }}
             - --google-service-account-json=/bitnami/oauth2-proxy/conf/google/service-account.json
-            - --google-group={{ .Values.configuration.google.googleGroup }}
+            {{- if .Values.configuration.google.googleGroups }}
+            {{- range $group := .Values.configuration.google.googleGroups }}
+            - --google-group={{ $group }}
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.configuration.htpasswdFile.enabled }}
             - --htpasswd-file=/bitnami/oauth2-proxy/conf/htpasswd/users.txt

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -294,14 +294,14 @@ configuration:
   ##
   ## @param configuration.google.enabled Enable Google service account
   ## @param configuration.google.adminEmail Google admin email
-  ## @param configuration.google.googleGroup Restrict logins to members of this google group
+  ## @param configuration.google.groups Restrict logins to members of this google group
   ## @param configuration.google.serviceAccountJson Google Service account JSON
   ## @param configuration.google.existingSecret Existing secret containing Google Service Account
   ##
   google:
     enabled: false
     adminEmail: ""
-    googleGroups: []
+    groups: []
     serviceAccountJson: ""
     existingSecret: ""
   ## Custom configuration file: oauth2_proxy.cfg

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -294,7 +294,7 @@ configuration:
   ##
   ## @param configuration.google.enabled Enable Google service account
   ## @param configuration.google.adminEmail Google admin email
-  ## @param configuration.google.groups Restrict logins to members of this google group
+  ## @param configuration.google.groups Restrict logins to members of these google groups
   ## @param configuration.google.serviceAccountJson Google Service account JSON
   ## @param configuration.google.existingSecret Existing secret containing Google Service Account
   ##

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -301,7 +301,7 @@ configuration:
   google:
     enabled: false
     adminEmail: ""
-    googleGroup: ""
+    googleGroups: []
     serviceAccountJson: ""
     existingSecret: ""
   ## Custom configuration file: oauth2_proxy.cfg


### PR DESCRIPTION
Signed-off-by: omer nitzan <omer2500@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The --google-group flag on oauth2proxy may be given multiple times depends of how many groups you have.
so i converted the variable name to groups(because its already nested inside google property) and made it of type list and not string.

### Benefits

Will give the option to pass multiple google groups without the need to add it as extra args

### Possible drawbacks

None its how oauth2-proxy working

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<img width="712" alt="image" src="https://github.com/bitnami/charts/assets/29802207/61a5df97-d812-4a98-9c93-88be202ae155">

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
