### PR TITLE
[bitnami/milvus] Bump kafka major version and update license header

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.1
+  version: 9.0.4
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 22.1.6
+  version: 23.0.2
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.6.5
+  version: 12.6.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.4.0
-digest: sha256:5eae1e79847d4d07fbd748e9bfba886fbab63f5a3489ebb6fb839340e5fa04f7
-generated: "2023-06-26T16:29:59.726101+02:00"
+  version: 2.6.0
+digest: sha256:98c79c06b3b830b6db1b53fa9dcfc2ca90f58cde5e463f7fe904db963d188d9b
+generated: "2023-07-10T09:13:55.360286+02:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: kafka.enabled
     name: kafka
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 22.x.x
+    version: 23.x.x
   - condition: minio.enabled
     name: minio
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -39,4 +39,4 @@ maintainers:
 name: milvus
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 0.1.0
+version: 1.0.0

--- a/bitnami/milvus/templates/attu/deployment.yaml
+++ b/bitnami/milvus/templates/attu/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/attu/service.yaml
+++ b/bitnami/milvus/templates/attu/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/configmap.yaml
+++ b/bitnami/milvus/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/data-coordinator/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/data-coordinator/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/data-coordinator/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-coordinator/service.yaml
+++ b/bitnami/milvus/templates/data-coordinator/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/data-coordinator/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-node/configmap.yaml
+++ b/bitnami/milvus/templates/data-node/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-node/deployment.yaml
+++ b/bitnami/milvus/templates/data-node/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-node/extra-configmap.yaml
+++ b/bitnami/milvus/templates/data-node/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-node/service.yaml
+++ b/bitnami/milvus/templates/data-node/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/data-node/servicemonitor.yaml
+++ b/bitnami/milvus/templates/data-node/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/extra-configmap.yaml
+++ b/bitnami/milvus/templates/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/extra-list.yaml
+++ b/bitnami/milvus/templates/extra-list.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/index-coordinator/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/index-coordinator/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/index-coordinator/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-coordinator/service.yaml
+++ b/bitnami/milvus/templates/index-coordinator/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/index-coordinator/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-node/configmap.yaml
+++ b/bitnami/milvus/templates/index-node/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-node/deployment.yaml
+++ b/bitnami/milvus/templates/index-node/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-node/extra-configmap.yaml
+++ b/bitnami/milvus/templates/index-node/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-node/service.yaml
+++ b/bitnami/milvus/templates/index-node/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/index-node/servicemonitor.yaml
+++ b/bitnami/milvus/templates/index-node/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/proxy/configmap.yaml
+++ b/bitnami/milvus/templates/proxy/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/proxy/deployment.yaml
+++ b/bitnami/milvus/templates/proxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/proxy/extra-configmap.yaml
+++ b/bitnami/milvus/templates/proxy/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/proxy/service.yaml
+++ b/bitnami/milvus/templates/proxy/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/proxy/servicemonitor.yaml
+++ b/bitnami/milvus/templates/proxy/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/query-coordinator/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/query-coordinator/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/query-coordinator/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-coordinator/service.yaml
+++ b/bitnami/milvus/templates/query-coordinator/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/query-coordinator/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-node/configmap.yaml
+++ b/bitnami/milvus/templates/query-node/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-node/deployment.yaml
+++ b/bitnami/milvus/templates/query-node/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-node/extra-configmap.yaml
+++ b/bitnami/milvus/templates/query-node/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-node/service.yaml
+++ b/bitnami/milvus/templates/query-node/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/query-node/servicemonitor.yaml
+++ b/bitnami/milvus/templates/query-node/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/root-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/root-coordinator/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/root-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/root-coordinator/deployment.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/root-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/root-coordinator/extra-configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/root-coordinator/service.yaml
+++ b/bitnami/milvus/templates/root-coordinator/service.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}

--- a/bitnami/milvus/templates/root-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/root-coordinator/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}


### PR DESCRIPTION
### Description of the change

This PR bumps the major Kafka subchart version to use the latest one, see https://github.com/bitnami/charts/pull/17354
In the same way, license headers were fixed in order to follow the agreed format