### PR TITLE
[bitnami/postgresql] Fix invalid indentation for replica metrics extraEnvVars

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: postgresql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/post
-version: 12.6.4
+version: 12.6.5

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -429,24 +429,24 @@ spec:
           args: [ "--extend.query-path", "/conf/custom-metrics.yaml" ]
           {{- end }}
           env:
-            {{- $database := required "In order to enable metrics you need to specify a database (.Values.auth.database or .Values.global.postgresql.auth.database)" (include "postgresql.database" .) }}
-              - name: DATA_SOURCE_URI
-                value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.service.port" .)) $database }}
-              {{- if .Values.auth.usePasswordFiles }}
-              - name: DATA_SOURCE_PASS_FILE
+          {{- $database := required "In order to enable metrics you need to specify a database (.Values.auth.database or .Values.global.postgresql.auth.database)" (include "postgresql.database" .) }}
+            - name: DATA_SOURCE_URI
+              value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.service.port" .)) $database }}
+            {{- if .Values.auth.usePasswordFiles }}
+            - name: DATA_SOURCE_PASS_FILE
               value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include "postgresql.userPasswordKey" .) }}
-              {{- else }}
-              - name: DATA_SOURCE_PASS
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ include "postgresql.secretName" . }}
-                    key: {{ include "postgresql.userPasswordKey" . }}
-              {{- end }}
-              - name: DATA_SOURCE_USER
-                value: {{ default "postgres" $customUser | quote }}
-              {{- if .Values.metrics.extraEnvVars }}
-              {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
-              {{- end }}
+            {{- else }}
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgresql.secretName" . }}
+                  key: {{ include "postgresql.userPasswordKey" . }}
+            {{- end }}
+            - name: DATA_SOURCE_USER
+              value: {{ default "postgres" $customUser | quote }}
+            {{- if .Values.metrics.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http-metrics
               containerPort: {{ .Values.metrics.containerPorts.metrics }}


### PR DESCRIPTION
### Description of the change

This PR fixes failed rendering of the templates when using `architecture: replication`  and `metrics.extraEnvVars`. The issue was caused by an invalid indentation used. 

### Benefits

Setting `metrics.extraEnvVars` now works properly.

### Possible drawbacks

None identified.

### Applicable issues

None identified.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
