### PR TITLE
[bitnami/apisix] Reorder chart dependencies

### DIFF
--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.4.0
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.0
-digest: sha256:8cbfdaba469747c52876c3ec54970bca7d526dbcd2228f66bc83c87ef5c5909a
-generated: "2023-06-19T16:40:43.931629+02:00"
+  version: 9.0.4
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.6.0
+digest: sha256:a4e457270ef2b95291e941cb4260c9d8d38c33730c32bb9c93f02c2b219583fc
+generated: "2023-07-12T19:51:06.517393+02:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -7,17 +7,15 @@ annotations:
 apiVersion: v2
 appVersion: 3.3.0
 dependencies:
+  - name: etcd
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: etcd.enabled
+    version: 9.x.x
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x
-  - name: etcd
-    repository: oci://registry-1.docker.io/bitnamicharts
-    condition: etcd.enabled
-    tags:
-      - bitnami-common
-    version: 9.x.x
 description: Apache APISIX is high-performance, real-time API Gateway. Features load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, amongst others.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/apisix/img/apisix-stack-220x234.png
@@ -38,4 +36,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 2.0.2
+version: 2.0.3


### PR DESCRIPTION
### Description of the change

There is an issue when working with OCI registries and the definition order of the subcharts.
While the issue is solved in the Helm CLI, we are reordering the dependencies.

### Possible drawbacks

None

### Related issues

- #9299

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)