### PR TITLE
[bitnami/contour] Fix the mismatch between the defaultBackend port in default values and the actual listening port of nginx

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: contour
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 12.1.2
+version: 12.1.3

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -334,7 +334,7 @@ helm uninstall my-release
 | `defaultBackend.extraVolumeMounts`                     | Array to add extra mounts (normally used with extraVolumes)                                                     | `[]`                     |
 | `defaultBackend.initContainers`                        | Attach additional init containers to the http backend pods                                                      | `[]`                     |
 | `defaultBackend.sidecars`                              | Add additional sidecar containers to the default backend                                                        | `[]`                     |
-| `defaultBackend.containerPorts.http`                   | Set http port inside Contour pod                                                                                | `8001`                   |
+| `defaultBackend.containerPorts.http`                   | Set http port inside Contour pod                                                                                | `8080`                   |
 | `defaultBackend.updateStrategy`                        | Strategy to use to update Pods                                                                                  | `{}`                     |
 | `defaultBackend.command`                               | Override default command                                                                                        | `[]`                     |
 | `defaultBackend.args`                                  | Override default args                                                                                           | `[]`                     |

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -1007,7 +1007,7 @@ defaultBackend:
   ## @param defaultBackend.containerPorts.http Set http port inside Contour pod
   ##
   containerPorts:
-    http: 8001
+    http: 8080
   ## @param defaultBackend.updateStrategy Strategy to use to update Pods
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix the mismatch between the defaultBackend port in default values and the actual listening port of nginx.

in values.yaml The default value of 8001

defaultBackend nginx pod listen is 8080

```sh
> kc -n sks-system-contour exec -it contour-default-backend-698d7cbb95-jlz8s bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
I have no name!@contour-default-backend-698d7cbb95-jlz8s:/app$ cat /opt/bitnami/nginx/conf/nginx.conf
# Based on https://www.nginx.com/resources/wiki/start/topics/examples/full/#nginx-conf
# user              www www;  ## Default: nobody

****

http {
   ****

    # HTTP Server
    server {
        # Port to listen on, can also be set in IP:PORT format
        listen  8080;   <---- is Here

        include  "/opt/bitnami/nginx/conf/bitnami/*.conf";

        location /status {
            stub_status on;
            access_log   off;
            allow 127.0.0.1;
            deny all;
        }
    }
}
```


### Benefits

User will be able to use and includes `defaultBackend.enabled: true` without the default-backend  pod error.

The template or helm install will proceed as expected

```yaml
defaultBackend:
  enabled: true
```

before
```
> kc -n sks-system-contour get pod
NAME                                       READY   STATUS      RESTARTS      AGE
contour-contour-8597955d9d-tghs6           1/1     Running     0             76s
contour-contour-8597955d9d-z6ntj           1/1     Running     0             76s
contour-contour-certgen-c9znc              0/1     Completed   0             76s
contour-default-backend-656bdb89cc-lp7lf   0/1     Running     1 (26s ago)   76s
contour-envoy-ddqsp                        2/2     Running     0             76s
contour-envoy-jhkhc                        2/2     Running     0             76s

> kc -n sks-system-contour describe pod contour-default-backend-656bdb89cc-lp7lf
  Normal   Scheduled  78s                default-scheduler  Successfully assigned sks-system-contour/contour-default-backend-656bdb89cc-lp7lf to siyi-cluster-rocky-4-group1-2d2lr
  Normal   Pulled     67s                kubelet            Successfully pulled image "docker.io/bitnami/nginx:1.25.1-debian-11-r1" in 9.747971482s
  Normal   Pulling    28s (x2 over 77s)  kubelet            Pulling image "docker.io/bitnami/nginx:1.25.1-debian-11-r1"
  Normal   Killing    28s                kubelet            Container default-backend failed liveness probe, will be restarted
  Warning  Unhealthy  28s                kubelet            Readiness probe failed: Get "http://172.17.0.59:8001/": dial tcp 172.17.0.59:8001: connect: connection refused
  Normal   Pulled     26s                kubelet            Successfully pulled image "docker.io/bitnami/nginx:1.25.1-debian-11-r1" in 2.15122597s
  Normal   Created    25s (x2 over 67s)  kubelet            Created container default-backend
  Normal   Started    25s (x2 over 67s)  kubelet            Started container default-backend
  Warning  Unhealthy  8s (x4 over 48s)   kubelet            Liveness probe failed: Get "http://172.17.0.59:8001/": dial tcp 172.17.0.59:8001: connect: connection refused
```

after
```
> kc -n sks-system-contour get pod -w
NAME                                       READY   STATUS      RESTARTS   AGE
contour-contour-bbcb6ff58-fph5z            1/1     Running     0          70s
contour-contour-certgen-c2cbb              0/1     Completed   0          70s
contour-default-backend-5fdf645564-hdl6z   1/1     Running     0          70s
contour-envoy-6mkff                        2/2     Running     0          70s
contour-envoy-6p954                        2/2     Running     0          70s
```

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

Nothing more, only the defaultBackend enable are affected for this change.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
