### PR TITLE
[bitnami/mxnet] Fix git init container

### DIFF
--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 name: mxnet
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mxnet
-version: 3.3.6
+version: 3.3.7

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -370,7 +370,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
 | `git.registry`                         | Git image registry                                                                                                                | `docker.io`            |
 | `git.repository`                       | Git image repository                                                                                                              | `bitnami/git`          |
-| `git.tag`                              | Git image tag (immutable tags are recommended)                                                                                    | `2.41.0-debian-11-r14` |
+| `git.tag`                              | Git image tag (immutable tags are recommended)                                                                                    | `2.41.0-debian-11-r16` |
 | `git.digest`                           | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                               | `""`                   |
 | `git.pullPolicy`                       | Git image pull policy                                                                                                             | `IfNotPresent`         |
 | `git.pullSecrets`                      | Specify docker-registry secret names as an array                                                                                  | `[]`                   |

--- a/bitnami/mxnet/templates/distributed/scheduler/deployment.yaml
+++ b/bitnami/mxnet/templates/distributed/scheduler/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"

--- a/bitnami/mxnet/templates/distributed/server/statefulset.yaml
+++ b/bitnami/mxnet/templates/distributed/server/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
           command:
-            - /bin/sh
+            - /bin/bash
           args:
             - -c
             - |

--- a/bitnami/mxnet/templates/distributed/worker/statefulset.yaml
+++ b/bitnami/mxnet/templates/distributed/worker/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"

--- a/bitnami/mxnet/templates/standalone/deployment.yaml
+++ b/bitnami/mxnet/templates/standalone/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
           command:
-            - /bin/sh
+            - /bin/bash
           args:
             - -c
             - |

--- a/bitnami/mxnet/values.yaml
+++ b/bitnami/mxnet/values.yaml
@@ -1177,7 +1177,7 @@ scheduler:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.41.0-debian-11-r14
+  tag: 2.41.0-debian-11-r16
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
### Description of the change

Use `bash` instead of `sh` in order to match the command syntax, which is not POSIX-compliant. This lead to errors in which the script is not correctly executed, like:

```console
$ k logs mxnet-55f44dbdff-lpchn -f -c git-clone-repository
+ [[ -f /opt/bitnami/scripts/git/entrypoint.sh ]]
/bin/sh: 2: [[: not found
+ git clone https://github.com/apache/incubator-mxnet.git --branch v1.2.0 /app
Cloning into '/app'...
```

### Benefits

The git container is initialized properly:

```console
$ k logs  mxnet-55f44dbdff-lpchn -f -c git-clone-repository
+ [[ -f /opt/bitnami/scripts/git/entrypoint.sh ]]
+ source /opt/bitnami/scripts/git/entrypoint.sh
++ set -o errexit
++ set -o nounset
++ set -o pipefail
+++ id -u
++ getent passwd 1002
++ '[' -e /opt/bitnami/common/lib/libnss_wrapper.so ']'
++ export LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
++ LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
+++ mktemp
++ export NSS_WRAPPER_PASSWD=/tmp/tmp.5BHS5IM8uS
++ NSS_WRAPPER_PASSWD=/tmp/tmp.5BHS5IM8uS
+++ mktemp
++ export NSS_WRAPPER_GROUP=/tmp/tmp.DBRNFeVmOQ
++ NSS_WRAPPER_GROUP=/tmp/tmp.DBRNFeVmOQ
+++ id -u
+++ id -g
++ echo git:x:1002:0:Git:/:/bin/false
+++ id -g
++ echo git:x:0:
++ [[ ! -f /etc/ssh/ssh_host_rsa_key ]]
++ ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
++ [[ ! -f /etc/ssh/ssh_host_ecdsa_key ]]
++ ssh-keygen -q -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N ''
++ [[ ! -f /etc/ssh/ssh_host_ed25519_key ]]
++ ssh-keygen -q -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ''
++ '[' 0 -eq 0 ']'
+ git clone https://github.com/apache/incubator-mxnet.git --branch v1.2.0 /app
Cloning into '/app'...
```

### Possible drawbacks

None.

### Applicable issues

NA

### Additional information

This PR also updates the Git container to https://github.com/bitnami/containers/commit/5a2f0c36d86083a4d294e4b02021cdfdafe06938, which addresses problems when generating ssh keys for non-root users.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
