### PR TITLE
[bitnami/elasticsearch] Fix ingest containerPorts.restAPI

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: elasticsearch
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 19.10.3
+version: 19.10.4

--- a/bitnami/elasticsearch/templates/ingest/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest/statefulset.yaml
@@ -207,9 +207,9 @@ spec:
           {{- end }}
           ports:
             - name: rest-api
-              containerPort: {{ .Values.containerPorts.restAPI }}
+              containerPort: {{ .Values.ingest.containerPorts.restAPI }}
             - name: transport
-              containerPort: {{ .Values.containerPorts.transport }}
+              containerPort: {{ .Values.ingest.containerPorts.transport }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.ingest.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingest.customStartupProbe "context" $) | nindent 12 }}

--- a/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
@@ -23,10 +23,10 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api
-      port: {{ .Values.containerPorts.restAPI }}
+      port: {{ .Values.containerPorts.ingest.restAPI }}
       targetPort: rest-api
     - name: tcp-transport
-      port: {{ .Values.containerPorts.transport }}
+      port: {{ .Values.containerPorts.ingest.transport }}
       targetPort: transport
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: ingest


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Ingest is using global containerPorts references instead its owns

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
