### PR TITLE
[bitnami/kube-prometheus] Bump Helm chart version

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 8.15.2
+version: 8.15.3


### PR DESCRIPTION
### Description of the change

Follow-up of https://github.com/bitnami/charts/pull/17707.

The Helm chart version needs to be bumped again because some other change also bumped the version and the commit when the https://github.com/bitnami/charts/pull/17707 was merged didn't: https://github.com/bitnami/charts/commit/dfc44e255a84b3f7cb0bf0953c3bdb111c8fd977

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
