### PR TITLE
chore: Rename GH action used to run readme generator

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -1,7 +1,7 @@
 # Copyright VMware, Inc.
 # SPDX-License-Identifier: APACHE-2.0
 
-name: '[Support] Update README metadata'
+name: '[CI/CD] Update README metadata'
 
 on:
   pull_request_target:


### PR DESCRIPTION
### Description of the change

This PR renames the GH action used to run readme generator that's part of the CI/CD since it's currently marked as part of the support GH actions.

### Benefits

Actions to properly reflect the stage they belong to.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
