### PR TITLE
[bitnami/grafana-operator] fix host for ingress.rules if ingress is enabled

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -147,9 +147,14 @@ spec:
         {{- else }}
         - http:
         {{- end }}
-          paths:
-            - path: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.path "context" $) }}
-            - pathType: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.pathType "context" $) }}
+            paths:
+              - path: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.path "context" $) }}
+                pathType: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.pathType "context" $) }}
+                backend:
+                  service:
+                    name: {{ printf "%s-grafana-service" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+                    port:
+                      number: 3000
     {{- if or .Values.commonLabels .Values.grafana.ingress.labels .Values.grafana.labels }}
     labels:
       {{- if .Values.commonLabels }}

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -142,9 +142,11 @@ spec:
       tlsSecretName: {{ .Values.grafana.ingress.tlsSecret }}
       rules:
         {{- if .Values.grafana.ingress.host }}
-        host: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.host "context" $) }}
-        {{- end }}
+        - host: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.host "context" $) }}
+          http:
+        {{- else }}
         - http:
+        {{- end }}
           paths:
             - path: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.path "context" $) }}
             - pathType: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.pathType "context" $) }}


### PR DESCRIPTION
### Description of the change

Fixes  the `host` value in `ingress.rules` to generate correct Ingress spec.

### Benefits

Correct ingress spec rendered.

### Possible drawbacks

N/A

### Applicable issues

Should fix #17554

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
