### PR TITLE
chore: New GH workflow to validate VIB pipeline files

### DIFF
--- a/.github/workflows/vib-files-validator.yml
+++ b/.github/workflows/vib-files-validator.yml
@@ -28,14 +28,14 @@ jobs:
           files: |
             .vib/**
       - name: Validate VIB pipeline files
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           exit_code=0
           for dir in ${{ steps.changed-files.outputs.all_changed_files }}; do
             diff <(jq .phases.verify < "${dir}/vib-publish.json") <(jq .phases.verify < "${dir}/vib-verify.json") || exit_code=$?
           done
           if [[ $exit_code -ne 0 ]]; then
-            echo "::error:: Please ensure verify phase is aligned on VIB pipeline files"
+            echo "::error:: Please ensure the VIB's verify phase is aligned both in vib-verify and vib-publish pipeline files"
             exit "$exit_code"
           fi
         shell: bash

--- a/.github/workflows/vib-files-validator.yml
+++ b/.github/workflows/vib-files-validator.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
-      - name: Get changed src code
+      - name: Get changed VIB pipeline files
         id: changed-files
         uses: tj-actions/changed-files@v37
         with:

--- a/.github/workflows/vib-files-validator.yml
+++ b/.github/workflows/vib-files-validator.yml
@@ -29,6 +29,7 @@ jobs:
             .vib/**
       - name: Validate VIB pipeline files
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        shell: bash
         run: |
           exit_code=0
           for dir in ${{ steps.changed-files.outputs.all_changed_files }}; do
@@ -38,4 +39,3 @@ jobs:
             echo "::error:: Please ensure the VIB's verify phase is aligned both in vib-verify and vib-publish pipeline files"
             exit "$exit_code"
           fi
-        shell: bash

--- a/.github/workflows/vib-files-validator.yml
+++ b/.github/workflows/vib-files-validator.yml
@@ -1,0 +1,41 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: '[CI/CD] Validate VIB pipeline files'
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.vib/*/vib-publish.json'
+      - '.vib/*/vib-verify.json'
+# Remove all permissions by default
+permissions: {}
+jobs:
+  validate-vib-files:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+      - name: Get changed src code
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          dir_names: "true"
+          dir_names_max_depth: "2"
+          files: |
+            .vib/**
+      - name: Validate VIB pipeline files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          exit_code=0
+          for dir in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            diff <(jq .phases.verify < "${dir}/vib-publish.json") <(jq .phases.verify < "${dir}/vib-verify.json") || exit_code=$?
+          done
+          if [[ $exit_code -ne 0 ]]; then
+            echo "::error:: Please ensure verify phase is aligned on VIB pipeline files"
+            exit "$exit_code"
+          fi
+        shell: bash


### PR DESCRIPTION
### Description of the change

This PR adds a new GH workflow to validate VIB pipeline files by ensuring the **_verify_** phases are identical on both `vib-verify.json` & `vib-publish.json`. As it's explained in [testing guidelines](https://github.com/bitnami/charts/blob/main/TESTING.md#vib-verifyjson-vs-vib-publishjson):

> _it was decided that the verification process should be identical in both cases_

### Benefits

Ensure no discrepancies are introduced by mistake.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
