### PR TITLE
[bitnami/pinniped] Bump Helm chart version

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: pinniped
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.2.4
+version: 1.2.5


### PR DESCRIPTION
### Description of the change

Follow-up of https://github.com/bitnami/charts/pull/17737.

The Helm chart version needs to be bumped again because some other change also bumped the version and the commit when the https://github.com/bitnami/charts/pull/17737 was merged.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
