### PR TITLE
[bitnami/grafana-operator]: Use Bitnami Grafana image by default

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.0.4
+version: 3.1.0

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -72,7 +72,6 @@ For more information, refer to the [documentation on the differences between the
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 
-
 ### Common parameters
 
 | Name                | Description                                                                                               | Value           |
@@ -85,7 +84,6 @@ For more information, refer to the [documentation on the differences between the
 | `commonLabels`      | Common Labels which are applied to every resource deployed                                                | `{}`            |
 | `commonAnnotations` | Common Annotations which are applied to every ressource deployed                                          | `{}`            |
 | `clusterDomain`     | Kubernetes cluster domain name                                                                            | `cluster.local` |
-
 
 ### Grafana Operator parameters
 
@@ -186,7 +184,6 @@ For more information, refer to the [documentation on the differences between the
 | `operator.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                                        | `3`                        |
 | `operator.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                                        | `1`                        |
 
-
 ### Grafana parameters
 
 | Name                                                        | Description                                                                                             | Value                    |
@@ -196,6 +193,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.image.repository`                                  | Grafana image name                                                                                      | `bitnami/grafana`        |
 | `grafana.image.tag`                                         | Grafana image tag                                                                                       | `10.0.2-debian-11-r0`    |
 | `grafana.image.digest`                                      | Grafana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `grafana.image.pullPolicy`                                  | Grafana image pull policy                                                                               | `IfNotPresent`           |
 | `grafana.image.pullSecrets`                                 | Grafana image pull secrets                                                                              | `[]`                     |
 | `grafana.serviceAccount`                                    | Additional service account configuration                                                                | `{}`                     |
 | `grafana.podSecurityContext.enabled`                        | Enable pods security context                                                                            | `true`                   |

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -264,7 +264,6 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the grafana container(s)                   | `[]`                     |
 | `grafana.sidecars`                                          | Add additional sidecar containers to the grafana pod(s)                                                 | `[]`                     |
 
-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -72,6 +72,7 @@ For more information, refer to the [documentation on the differences between the
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 
+
 ### Common parameters
 
 | Name                | Description                                                                                               | Value           |
@@ -84,6 +85,7 @@ For more information, refer to the [documentation on the differences between the
 | `commonLabels`      | Common Labels which are applied to every resource deployed                                                | `{}`            |
 | `commonAnnotations` | Common Annotations which are applied to every ressource deployed                                          | `{}`            |
 | `clusterDomain`     | Kubernetes cluster domain name                                                                            | `cluster.local` |
+
 
 ### Grafana Operator parameters
 
@@ -184,78 +186,86 @@ For more information, refer to the [documentation on the differences between the
 | `operator.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                                        | `3`                        |
 | `operator.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                                        | `1`                        |
 
+
 ### Grafana parameters
 
-| Name                                                        | Description                                                                                            | Value                    |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `grafana.enabled`                                           | Enabled the deployment of the Grafana CRD object into the cluster                                      | `true`                   |
-| `grafana.serviceAccount`                                    | Additional service account configuration                                                               | `{}`                     |
-| `grafana.podSecurityContext.enabled`                        | Enable pods security context                                                                           | `true`                   |
-| `grafana.podSecurityContext.runAsUser`                      | User ID for the pods                                                                                   | `1001`                   |
-| `grafana.podSecurityContext.runAsGroup`                     | User ID for the pods                                                                                   | `0`                      |
-| `grafana.podSecurityContext.runAsNonRoot`                   | Grafana Operator must run as nonRoot                                                                   | `true`                   |
-| `grafana.podSecurityContext.fsGroup`                        | Group ID for the pods                                                                                  | `1001`                   |
-| `grafana.podSecurityContext.supplementalGroups`             | Which group IDs containers add                                                                         | `[]`                     |
-| `grafana.containerSecurityContext.enabled`                  | Enable containers security context                                                                     | `true`                   |
-| `grafana.containerSecurityContext.runAsUser`                | User ID for the containers                                                                             | `1001`                   |
-| `grafana.containerSecurityContext.runAsGroup`               | Group ID for the containers                                                                            | `0`                      |
-| `grafana.containerSecurityContext.privileged`               | Decide if the container runs privileged.                                                               | `false`                  |
-| `grafana.containerSecurityContext.runAsNonRoot`             | Force the container to run as non-root                                                                 | `true`                   |
-| `grafana.containerSecurityContext.allowPrivilegeEscalation` | Don't allow privilege escalation for the containers                                                    | `false`                  |
-| `grafana.resources.limits`                                  | The resources limits for the container                                                                 | `{}`                     |
-| `grafana.resources.requests`                                | The requested resources for the container                                                              | `{}`                     |
-| `grafana.replicaCount`                                      | Specify the amount of replicas running                                                                 | `1`                      |
-| `grafana.podAffinityPreset`                                 | Pod affinity preset                                                                                    | `""`                     |
-| `grafana.podAntiAffinityPreset`                             | Pod anti-affinity preset                                                                               | `soft`                   |
-| `grafana.nodeAffinityPreset.type`                           | Set nodeAffinity preset type                                                                           | `""`                     |
-| `grafana.nodeAffinityPreset.key`                            | Set nodeAffinity preset key                                                                            | `""`                     |
-| `grafana.nodeAffinityPreset.values`                         | Set nodeAffinity preset values                                                                         | `[]`                     |
-| `grafana.affinity`                                          | Affinity for controller pod assignment                                                                 | `{}`                     |
-| `grafana.nodeSelector`                                      | Node labels for controller pod assignment                                                              | `{}`                     |
-| `grafana.tolerations`                                       | Tolerations for controller pod assignment                                                              | `[]`                     |
-| `grafana.envFrom`                                           | Extra environment variable to pass to the running container                                            | `[]`                     |
-| `grafana.client.timeout`                                    | The timeout in seconds for the Grafana Rest API on that instance                                       | `5`                      |
-| `grafana.labels`                                            | Add additional labels to the grafana deployment, service and ingress resources                         | `{}`                     |
-| `grafana.service.type`                                      | Kubernetes Service type                                                                                | `ClusterIP`              |
-| `grafana.service.annotations`                               | Additional custom annotations for Grafana service                                                      | `{}`                     |
-| `grafana.service.extraPorts`                                | Extra ports to expose in the Grafana service                                                           | `[]`                     |
-| `grafana.ingress.enabled`                                   | If an ingress or OpenShift Route should be created                                                     | `false`                  |
-| `grafana.ingress.ingressClassName`                          | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                          | `""`                     |
-| `grafana.ingress.host`                                      | The host under which the grafana instance should be reachable. If empty the parameter will not be set. | `grafana.local`          |
-| `grafana.ingress.path`                                      | The path for the ingress instance to forward to the grafana app                                        | `/`                      |
-| `grafana.ingress.pathType`                                  | The pathType for the ingress instance to forward to the grafana app                                    | `ImplementationSpecific` |
-| `grafana.ingress.labels`                                    | Additional Labels for the ingress resource                                                             | `{}`                     |
-| `grafana.ingress.annotations`                               | Additional Annotations for the ingress resource                                                        | `{}`                     |
-| `grafana.ingress.tls`                                       | This enables tls support for the ingress resource                                                      | `false`                  |
-| `grafana.ingress.tlsSecret`                                 | The name for the secret to use for the tls termination                                                 | `grafana.local-tls`      |
-| `grafana.persistence.enabled`                               | Enable persistent storage for the grafana deployment                                                   | `false`                  |
-| `grafana.persistence.storageClass`                          | Define the storageClass for the persistent storage if not defined default is used                      | `""`                     |
-| `grafana.persistence.existingVolume`                        | Define the existingVolume for the persistent storage provisioned outside this chart                    | `""`                     |
-| `grafana.persistence.accessModes`                           | Define the accessModes for the persistent storage                                                      | `["ReadWriteOnce"]`      |
-| `grafana.persistence.annotations`                           | Add annotations to the persistent volume                                                               | `{}`                     |
-| `grafana.persistence.size`                                  | Define the size of the PersistentVolumeClaim to request for                                            | `10Gi`                   |
-| `grafana.config`                                            | grafana.ini configuration for the instance for this to configure please look at upstream docs          | `{}`                     |
-| `grafana.configMaps`                                        | Extra configMaps to mount into the grafana pod                                                         | `[]`                     |
-| `grafana.secrets`                                           | Extra secrets to mount into the grafana pod                                                            | `[]`                     |
-| `grafana.jsonnetLibrarySelector`                            | Configuring the read for jsonnetLibraries to pull in.                                                  | `{}`                     |
-| `grafana.dashboardLabelSelectors`                           | This selects dashboards on the label.                                                                  | `{}`                     |
-| `grafana.dashboardNamespaceSelector`                        | Watch for dashboards only in the Namespaces that have the specified namespace label                    | `{}`                     |
-| `grafana.livenessProbe.enabled`                             | Enable livenessProbe                                                                                   | `true`                   |
-| `grafana.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                | `120`                    |
-| `grafana.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                       | `10`                     |
-| `grafana.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                      | `5`                      |
-| `grafana.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                    | `6`                      |
-| `grafana.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                    | `1`                      |
-| `grafana.readinessProbe.enabled`                            | Enable readinessProbe                                                                                  | `true`                   |
-| `grafana.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                               | `30`                     |
-| `grafana.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                      | `10`                     |
-| `grafana.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                     | `5`                      |
-| `grafana.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                   | `6`                      |
-| `grafana.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                   | `1`                      |
-| `grafana.updateStrategy`                                    | Set up update strategy for Grafana installation.                                                       | `{}`                     |
-| `grafana.extraVolumes`                                      | Optionally specify extra list of additional volumes for the grafana pod(s)                             | `[]`                     |
-| `grafana.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the grafana container(s)                  | `[]`                     |
-| `grafana.sidecars`                                          | Add additional sidecar containers to the grafana pod(s)                                                | `[]`                     |
+| Name                                                        | Description                                                                                             | Value                    |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `grafana.enabled`                                           | Enabled the deployment of the Grafana CRD object into the cluster                                       | `true`                   |
+| `grafana.image.registry`                                    | Grafana image registry                                                                                  | `docker.io`              |
+| `grafana.image.repository`                                  | Grafana image name                                                                                      | `bitnami/grafana`        |
+| `grafana.image.tag`                                         | Grafana image tag                                                                                       | `10.0.2-debian-11-r0`    |
+| `grafana.image.digest`                                      | Grafana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `grafana.image.pullSecrets`                                 | Grafana image pull secrets                                                                              | `[]`                     |
+| `grafana.serviceAccount`                                    | Additional service account configuration                                                                | `{}`                     |
+| `grafana.podSecurityContext.enabled`                        | Enable pods security context                                                                            | `true`                   |
+| `grafana.podSecurityContext.runAsUser`                      | User ID for the pods                                                                                    | `1001`                   |
+| `grafana.podSecurityContext.runAsGroup`                     | User ID for the pods                                                                                    | `0`                      |
+| `grafana.podSecurityContext.runAsNonRoot`                   | Grafana Operator must run as nonRoot                                                                    | `true`                   |
+| `grafana.podSecurityContext.fsGroup`                        | Group ID for the pods                                                                                   | `1001`                   |
+| `grafana.podSecurityContext.supplementalGroups`             | Which group IDs containers add                                                                          | `[]`                     |
+| `grafana.containerSecurityContext.enabled`                  | Enable containers security context                                                                      | `true`                   |
+| `grafana.containerSecurityContext.runAsUser`                | User ID for the containers                                                                              | `1001`                   |
+| `grafana.containerSecurityContext.runAsGroup`               | Group ID for the containers                                                                             | `0`                      |
+| `grafana.containerSecurityContext.privileged`               | Decide if the container runs privileged.                                                                | `false`                  |
+| `grafana.containerSecurityContext.runAsNonRoot`             | Force the container to run as non-root                                                                  | `true`                   |
+| `grafana.containerSecurityContext.allowPrivilegeEscalation` | Don't allow privilege escalation for the containers                                                     | `false`                  |
+| `grafana.containerSecurityContext.readOnlyRootFilesystem`   | Mount / (root) as a readonly filesystem                                                                 | `false`                  |
+| `grafana.resources.limits`                                  | The resources limits for the container                                                                  | `{}`                     |
+| `grafana.resources.requests`                                | The requested resources for the container                                                               | `{}`                     |
+| `grafana.replicaCount`                                      | Specify the amount of replicas running                                                                  | `1`                      |
+| `grafana.podAffinityPreset`                                 | Pod affinity preset                                                                                     | `""`                     |
+| `grafana.podAntiAffinityPreset`                             | Pod anti-affinity preset                                                                                | `soft`                   |
+| `grafana.nodeAffinityPreset.type`                           | Set nodeAffinity preset type                                                                            | `""`                     |
+| `grafana.nodeAffinityPreset.key`                            | Set nodeAffinity preset key                                                                             | `""`                     |
+| `grafana.nodeAffinityPreset.values`                         | Set nodeAffinity preset values                                                                          | `[]`                     |
+| `grafana.affinity`                                          | Affinity for controller pod assignment                                                                  | `{}`                     |
+| `grafana.nodeSelector`                                      | Node labels for controller pod assignment                                                               | `{}`                     |
+| `grafana.tolerations`                                       | Tolerations for controller pod assignment                                                               | `[]`                     |
+| `grafana.envFrom`                                           | Extra environment variable to pass to the running container                                             | `[]`                     |
+| `grafana.client.timeout`                                    | The timeout in seconds for the Grafana Rest API on that instance                                        | `5`                      |
+| `grafana.labels`                                            | Add additional labels to the grafana deployment, service and ingress resources                          | `{}`                     |
+| `grafana.service.type`                                      | Kubernetes Service type                                                                                 | `ClusterIP`              |
+| `grafana.service.annotations`                               | Additional custom annotations for Grafana service                                                       | `{}`                     |
+| `grafana.service.extraPorts`                                | Extra ports to expose in the Grafana service                                                            | `[]`                     |
+| `grafana.ingress.enabled`                                   | If an ingress or OpenShift Route should be created                                                      | `false`                  |
+| `grafana.ingress.ingressClassName`                          | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                           | `""`                     |
+| `grafana.ingress.host`                                      | The host under which the grafana instance should be reachable. If empty the parameter will not be set.  | `grafana.local`          |
+| `grafana.ingress.path`                                      | The path for the ingress instance to forward to the grafana app                                         | `/`                      |
+| `grafana.ingress.pathType`                                  | The pathType for the ingress instance to forward to the grafana app                                     | `ImplementationSpecific` |
+| `grafana.ingress.labels`                                    | Additional Labels for the ingress resource                                                              | `{}`                     |
+| `grafana.ingress.annotations`                               | Additional Annotations for the ingress resource                                                         | `{}`                     |
+| `grafana.ingress.tls`                                       | This enables tls support for the ingress resource                                                       | `false`                  |
+| `grafana.ingress.tlsSecret`                                 | The name for the secret to use for the tls termination                                                  | `grafana.local-tls`      |
+| `grafana.persistence.enabled`                               | Enable persistent storage for the grafana deployment                                                    | `false`                  |
+| `grafana.persistence.storageClass`                          | Define the storageClass for the persistent storage if not defined default is used                       | `""`                     |
+| `grafana.persistence.existingVolume`                        | Define the existingVolume for the persistent storage provisioned outside this chart                     | `""`                     |
+| `grafana.persistence.accessModes`                           | Define the accessModes for the persistent storage                                                       | `["ReadWriteOnce"]`      |
+| `grafana.persistence.annotations`                           | Add annotations to the persistent volume                                                                | `{}`                     |
+| `grafana.persistence.size`                                  | Define the size of the PersistentVolumeClaim to request for                                             | `10Gi`                   |
+| `grafana.config`                                            | grafana.ini configuration for the instance for this to configure please look at upstream docs           | `{}`                     |
+| `grafana.configMaps`                                        | Extra configMaps to mount into the grafana pod                                                          | `[]`                     |
+| `grafana.secrets`                                           | Extra secrets to mount into the grafana pod                                                             | `[]`                     |
+| `grafana.jsonnetLibrarySelector`                            | Configuring the read for jsonnetLibraries to pull in.                                                   | `{}`                     |
+| `grafana.dashboardLabelSelectors`                           | This selects dashboards on the label.                                                                   | `{}`                     |
+| `grafana.dashboardNamespaceSelector`                        | Watch for dashboards only in the Namespaces that have the specified namespace label                     | `{}`                     |
+| `grafana.livenessProbe.enabled`                             | Enable livenessProbe                                                                                    | `true`                   |
+| `grafana.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                 | `120`                    |
+| `grafana.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                        | `10`                     |
+| `grafana.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                       | `5`                      |
+| `grafana.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                     | `6`                      |
+| `grafana.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                     | `1`                      |
+| `grafana.readinessProbe.enabled`                            | Enable readinessProbe                                                                                   | `true`                   |
+| `grafana.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                | `30`                     |
+| `grafana.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                       | `10`                     |
+| `grafana.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                      | `5`                      |
+| `grafana.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                    | `6`                      |
+| `grafana.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                    | `1`                      |
+| `grafana.updateStrategy`                                    | Set up update strategy for Grafana installation.                                                        | `{}`                     |
+| `grafana.extraVolumes`                                      | Optionally specify extra list of additional volumes for the grafana pod(s)                              | `[]`                     |
+| `grafana.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the grafana container(s)                   | `[]`                     |
+| `grafana.sidecars`                                          | Add additional sidecar containers to the grafana pod(s)                                                 | `[]`                     |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -115,6 +115,16 @@ spec:
           {{- if .Values.grafana.podSecurityContext.enabled }}
           securityContext: {{- omit .Values.grafana.podSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+          containers:
+            - name: grafana
+              image: {{ include "common.images.image" (dict "imageRoot" .Values.grafana.image "global" .Values.global) }}
+              imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+              {{- if .Values.grafana.containerSecurityContext.enabled }}
+              securityContext: {{- omit .Values.grafana.containerSecurityContext "enabled" | toYaml | nindent 16 }}
+              {{- end }}
+              {{- if .Values.operator.resources }}
+              resources: {{- toYaml .Values.operator.resources | nindent 16 }}
+              {{- end }}
     {{- if .Values.grafana.tolerations }}
     tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.tolerations "context" $) | nindent 6 }}
     {{- end }}
@@ -133,8 +143,8 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.grafana.extraVolumes "context" $) | nindent 6 }}
     {{- end }}
   {{- if .Values.grafana.ingress.enabled }}
-  ingress: 
-    spec: 
+  ingress:
+    spec:
       {{- if and .Values.grafana.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
       ingressClassName: {{ .Values.grafana.ingress.ingressClassName | quote }}
       {{- end }}

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -122,8 +122,8 @@ spec:
               {{- if .Values.grafana.containerSecurityContext.enabled }}
               securityContext: {{- omit .Values.grafana.containerSecurityContext "enabled" | toYaml | nindent 16 }}
               {{- end }}
-              {{- if .Values.operator.resources }}
-              resources: {{- toYaml .Values.operator.resources | nindent 16 }}
+              {{- if .Values.grafana.resources }}
+              resources: {{- toYaml .Values.grafana.resources | nindent 16 }}
               {{- end }}
     {{- if .Values.grafana.tolerations }}
     tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.tolerations "context" $) | nindent 6 }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -418,6 +418,7 @@ grafana:
   ## @param grafana.image.repository Grafana image name
   ## @param grafana.image.tag Grafana image tag
   ## @param grafana.image.digest Grafana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param grafana.image.pullPolicy Grafana image pull policy
   ## @param grafana.image.pullSecrets Grafana image pull secrets
   ##
   image:

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -414,6 +414,30 @@ grafana:
   ## @param grafana.enabled Enabled the deployment of the Grafana CRD object into the cluster
   ##
   enabled: true
+  ## @param grafana.image.registry Grafana image registry
+  ## @param grafana.image.repository Grafana image name
+  ## @param grafana.image.tag Grafana image tag
+  ## @param grafana.image.digest Grafana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param grafana.image.pullSecrets Grafana image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/grafana
+    tag: 10.0.2-debian-11-r0
+    digest: ""
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param grafana.serviceAccount Additional service account configuration
   ## Ref: https://github.com/integr8ly/grafana-operator/blob/master/documentation/deploy_grafana.md#configuring-the-serviceaccount
   ## e.g:
@@ -446,6 +470,7 @@ grafana:
   ## @param grafana.containerSecurityContext.privileged Decide if the container runs privileged.
   ## @param grafana.containerSecurityContext.runAsNonRoot Force the container to run as non-root
   ## @param grafana.containerSecurityContext.allowPrivilegeEscalation Don't allow privilege escalation for the containers
+  ## @param grafana.containerSecurityContext.readOnlyRootFilesystem Mount / (root) as a readonly filesystem
   ##
   containerSecurityContext:
     enabled: true
@@ -454,6 +479,7 @@ grafana:
     privileged: false
     runAsNonRoot: true
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
   ## Grafana containers' resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -561,7 +587,7 @@ grafana:
     ##     protocol: TCP
     ##     targetPort: grafana-http
     extraPorts: []
-  ## 
+  ##
   ## Configure the ingress resource that allows you to access the
   ## Grafana web. Set up the URL
   ## Ref: https://kubernetes.io/docs/user-guide/ingress/


### PR DESCRIPTION
### Description of the change

This PR ensures the Bitnami Grafana Operator chart uses the [Bitnami Grafana image](https://hub.docker.com/r/bitnami/grafana) in the default's Grafana instance.

### Benefits

Bitnami charts to use exclusively Bitnami container images by default.

### Possible drawbacks

None

### Applicable issues

- fixes #17576
- fixes #17807

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
