### PR TITLE
[bitnami/grafana-operator] Add missing image pull secrets for Grafana deployment

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.1.1
+version: 3.1.2

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -98,8 +98,9 @@ spec:
       replicas: {{ .Values.grafana.replicaCount }}
       template:
         spec:
+          {{- include "common.images.pullSecrets" (dict "images" (list .Values.grafana.image) "global" .Values.global) | nindent 10 }}
           {{- if .Values.grafana.affinity }}
-          affinity: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.affinity "context" $) | nindent 6 }}
+          affinity: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.affinity "context" $) | nindent 12 }}
           {{- else }}
           affinity:
             {{- if not (empty .Values.grafana.podAffinityPreset) }}


### PR DESCRIPTION
### Description of the change

This PR ensures we properly set the image pull secrets required for pulling Grafana images when indicated at `grafana.image.pullSecrets` parameter.

### Benefits

Operator to be compatible with using private images.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

It also fixes an indentation issue with affinity

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
