### PR TITLE
[bitnami/clickhouse] Add shard label to pods

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: clickhouse
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.5.6
+version: 3.5.7

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
         {{- if $.Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" $.Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
+        shard: {{ $i | quote }}
     spec:
       serviceAccountName: {{ template "clickhouse.serviceAccountName" $ }}
       {{- include "clickhouse.imagePullSecrets" $ | nindent 6 }}


### PR DESCRIPTION
### Description of the change

Idea originated from stale PR: https://github.com/bitnami/charts/pull/17333.

Set a label that allows identifying the shard the pod belongs to. Similar to what we are doing in [bitnami/mongodb-sharded](https://github.com/bitnami/charts/blob/a8eb95ec6a71e695157a56c3d60122c8e3844b5e/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml#L40).

### Benefits

Identify pods for affinity/anti-affinity policies.

### Possible drawbacks

n/a

### Applicable issues

n/a

### Additional information

n/a

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
