### PR TITLE
[bitnami/metallb] Allow overriding speaker log level from values

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: metallb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 4.5.7
+version: 4.5.8

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -88,6 +88,7 @@ spec:
           {{- else }}
           args:
             - --port={{ .Values.speaker.containerPorts.metrics }}
+            - --log-level={{ .Values.speaker.logLevel }}
           {{- end }}
           {{- if .Values.speaker.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -746,7 +746,9 @@ speaker:
   ## @param speaker.customReadinessProbe Custom readiness probe for the Web component
   ##
   customReadinessProbe: {}
-
+  ## @param speaker.logLevel sets the speaker log level. Does not work if the args are overridden
+  ##
+  logLevel: "info"
   ## @section Speaker Prometheus metrics export
   metrics:
     ## @param speaker.metrics.enabled Enable the export of Prometheus metrics


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Allows setting the speaker log level without overriding all arguments.
### Benefits
This allows a user to benefit from default arguments added later, even if they override the log leve.
<!-- What benefits will be realized by the code change? -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
