### PR TITLE
[bitnami/clickhouse] Fix clickhouse external access annotation assignment 

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 4.0.1
+version: 4.0.2

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -201,7 +201,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Traffic Exposure Parameters
 
 | Name                                              | Description                                                                                                                      | Value                    |
-| ------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------------| ------------------------ |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `service.type`                                    | ClickHouse service type                                                                                                          | `ClusterIP`              |
 | `service.ports.http`                              | ClickHouse service HTTP port                                                                                                     | `8123`                   |
 | `service.ports.https`                             | ClickHouse service HTTPS port                                                                                                    | `443`                    |
@@ -248,7 +248,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalAccess.service.ports.interserver`        | ClickHouse service Interserver port                                                                                              | `9009`                   |
 | `externalAccess.service.ports.metrics`            | ClickHouse service metrics port                                                                                                  | `8001`                   |
 | `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each ClickHouse . Length must be the same as replicaCount                                         | `[]`                     |
-| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each ClickHouse . Length must be the same shards multiplied by replicaCount               | `[]`                     |
+| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each ClickHouse . Length must be the same as shards multiplied by replicaCount            | `[]`                     |
 | `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                                                        | `[]`                     |
 | `externalAccess.service.nodePorts.http`           | Node port for HTTP                                                                                                               | `[]`                     |
 | `externalAccess.service.nodePorts.https`          | Node port for HTTPS                                                                                                              | `[]`                     |

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -201,7 +201,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Traffic Exposure Parameters
 
 | Name                                              | Description                                                                                                                      | Value                    |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| ------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------------| ------------------------ |
 | `service.type`                                    | ClickHouse service type                                                                                                          | `ClusterIP`              |
 | `service.ports.http`                              | ClickHouse service HTTP port                                                                                                     | `8123`                   |
 | `service.ports.https`                             | ClickHouse service HTTPS port                                                                                                    | `443`                    |
@@ -248,7 +248,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalAccess.service.ports.interserver`        | ClickHouse service Interserver port                                                                                              | `9009`                   |
 | `externalAccess.service.ports.metrics`            | ClickHouse service metrics port                                                                                                  | `8001`                   |
 | `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each ClickHouse . Length must be the same as replicaCount                                         | `[]`                     |
-| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each ClickHouse . Length must be the same as replicaCount                                 | `[]`                     |
+| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each ClickHouse . Length must be the same shards multiplied by replicaCount               | `[]`                     |
 | `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                                                        | `[]`                     |
 | `externalAccess.service.nodePorts.http`           | Node port for HTTP                                                                                                               | `[]`                     |
 | `externalAccess.service.nodePorts.https`          | Node port for HTTPS                                                                                                              | `[]`                     |

--- a/bitnami/clickhouse/templates/service-external-access.yaml
+++ b/bitnami/clickhouse/templates/service-external-access.yaml
@@ -9,6 +9,8 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $totalNodes := mul $shards $replicas }}
 {{- range $shard, $e := until $shards }}
 {{- range $i, $_e := until $replicas }}
+{{- $loadBalancerAnnotationPosOffset := mul $shard $replicas }}
+{{- $loadBalancerAnnotationPosition := add $loadBalancerAnnotationPosOffset $i }}
 {{- $targetPod := printf "%s-shard%d-%d" (include "common.names.fullname" $) $shard $i }}
 apiVersion: v1
 kind: Service
@@ -22,7 +24,7 @@ metadata:
   {{- if or $.Values.externalAccess.service.annotations $.Values.commonAnnotations $.Values.externalAccess.service.loadBalancerAnnotations }}
   annotations:
     {{- if and (not (empty $.Values.externalAccess.service.loadBalancerAnnotations)) (eq (len $.Values.externalAccess.service.loadBalancerAnnotations) $totalNodes) }}
-    {{ include "common.tplvalues.render" ( dict "value" (index $.Values.externalAccess.service.loadBalancerAnnotations $i) "context" $) | nindent 4 }}
+    {{ include "common.tplvalues.render" ( dict "value" (index $.Values.externalAccess.service.loadBalancerAnnotations $loadBalancerAnnotationPosition) "context" $) | nindent 4 }}
     {{- end }}
     {{- if $.Values.externalAccess.service.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" $.Values.externalAccess.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -740,7 +740,7 @@ externalAccess:
     ##   - Y.Y.Y.Y
     ##
     loadBalancerIPs: []
-    ## @param externalAccess.service.loadBalancerAnnotations Array of load balancer annotations for each ClickHouse . Length must be the same as replicaCount
+    ## @param externalAccess.service.loadBalancerAnnotations Array of load balancer annotations for each ClickHouse . Length must be the same as shards multiplied by replicaCount
     ## e.g:
     ## loadBalancerAnnotations:
     ##   - external-dns.alpha.kubernetes.io/hostname: 1.external.example.com.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Current logic is not assigning correctly pod annotations for external access to each shard-replica. In order to assign a DNS address to each loadbalancer for external access, if we have a cluster with 3 shards and 2 replicas per shard, we need to assign 6 annotations. Currently this process is not possible as they are not being assigned in the correct order. 

### Benefits

Now you can assign annotations in the correct order

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
