### PR TITLE
[bitnami/pinniped] Allow array for loadBalancerSourceRanges

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: pinniped
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.2.5
+version: 1.2.6

--- a/bitnami/pinniped/templates/concierge/service-proxy.yaml
+++ b/bitnami/pinniped/templates/concierge/service-proxy.yaml
@@ -42,7 +42,7 @@ spec:
   externalTrafficPolicy: {{ .Values.concierge.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .Values.concierge.service.type "LoadBalancer") (not (empty .Values.concierge.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.concierge.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.concierge.service.loadBalancerSourceRanges | toJson }}
   {{- end }}
   {{- if and (eq .Values.concierge.service.type "LoadBalancer") (not (empty .Values.concierge.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.concierge.service.loadBalancerIP }}

--- a/bitnami/pinniped/templates/supervisor/service-api.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-api.yaml
@@ -43,7 +43,7 @@ spec:
   externalTrafficPolicy: {{ .externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .loadBalancerSourceRanges | toJson }}
   {{- end }}
   {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerIP)) }}
   loadBalancerIP: {{ .loadBalancerIP }}

--- a/bitnami/pinniped/templates/supervisor/service.yaml
+++ b/bitnami/pinniped/templates/supervisor/service.yaml
@@ -43,7 +43,7 @@ spec:
   externalTrafficPolicy: {{ .externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .loadBalancerSourceRanges | toJson }}
   {{- end }}
   {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerIP)) }}
   loadBalancerIP: {{ .loadBalancerIP }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This is just a propagation of [this](https://github.com/bitnami/charts/issues/17450) fix but for `pinniped`

### Benefits

Allows to provide multiple elements to primary.service.loadBalancerSourceRanges.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
