### PR TITLE
[bitnami/mariadb-galera] Pass credentials correctly to mysqld_exporter 0.15.x

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: mariadb-galera
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 9.0.0
+version: 9.0.1

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -390,7 +390,7 @@ spec:
               if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                   password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
               fi
-              DATA_SOURCE_NAME="${MARIADB_ROOT_USER}:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter $MARIADB_METRICS_EXTRA_FLAGS
+              MYSQLD_EXPORTER_PASSWORD=${password_aux} /bin/mysqld_exporter --mysqld.address=localhost:3306 --mysqld.username=${MARIADB_ROOT_USER} $MARIADB_METRICS_EXTRA_FLAGS
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

[mysqld_exporter 0.15.0](https://github.com/prometheus/mysqld_exporter/releases/tag/v0.15.0) introduced a breaking change in how credentials and target hostname is passed on to the exporter:

> The exporter no longer supports the monolithic DATA_SOURCE_NAME environment variable.
To configure connections to MySQL you can either use a my.cnf style config file or command line arguments.
>
> For example:
>
>```
>export MYSQLD_EXPORTER_PASSWORD=secret
>mysqld_exporter --mysqld.address=localhost:3306 --mysqld.username=exporter
>```

This PR adds this variable and arguments to the exporter container.

### Benefits

Metrics container works with mysqld_exporter versions 0.15.0+

### Possible drawbacks

Metrics container stops working with mysqld_exporter versions lower than 0.15.0

### Applicable issues

- fixes #17994

### Additional information

-

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
