### PR TITLE
[bitnami/spark] Add noprompt to init certs command to avoid crash on resume

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: spark
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 7.1.2
+version: 7.1.3

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -103,7 +103,8 @@ spec:
                   -srcstoretype PKCS12 \
                   -srcstorepass "${SPARK_SSL_KEYSTORE_PASSWORD}" \
                   -deststorepass "${SPARK_SSL_KEYSTORE_PASSWORD}" \
-                  -destkeystore "/opt/bitnami/spark/conf/certs/spark-keystore.jks"
+                  -destkeystore "/opt/bitnami/spark/conf/certs/spark-keystore.jks" \
+                  -noprompt
               rm "/tmp/keystore.p12"
               keytool -import -file "/certs/ca.crt" \
                       -keystore "/opt/bitnami/spark/conf/certs/spark-truststore.jks" \

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -105,7 +105,8 @@ spec:
                   -srcstoretype PKCS12 \
                   -srcstorepass "$SPARK_SSL_KEYSTORE_PASSWORD" \
                   -deststorepass "$SPARK_SSL_KEYSTORE_PASSWORD" \
-                  -destkeystore "/opt/bitnami/spark/conf/certs/spark-keystore.jks"
+                  -destkeystore "/opt/bitnami/spark/conf/certs/spark-keystore.jks" \
+                  -noprompt
               rm "/tmp/keystore.p12"
               keytool -import -file "/certs/ca.crt" \
                       -keystore "/opt/bitnami/spark/conf/certs/spark-truststore.jks" \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR fixes issues in the initContainer script for the spark helm chart. By adding the noprompt option, the keytool command is able to successfully complete even if the container is being resumed and the certificate is already added to the keystore, instead of erroring out and expecting interactive user input.

### Benefits

<!-- What benefits will be realized by the code change? -->

With this change, spark statefulset pods will be able to successfully startup even if the init script has been executed on the filesystem before.

### Possible drawbacks

NA

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
NA

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
