### PR TITLE
[bitnami/grafana-operator] Fix TLS for ingress

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.1.3
+version: 3.1.4

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -149,8 +149,6 @@ spec:
       {{- if and .Values.grafana.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
       ingressClassName: {{ .Values.grafana.ingress.ingressClassName | quote }}
       {{- end }}
-      tlsEnabled: {{ .Values.grafana.ingress.tls }}
-      tlsSecretName: {{ .Values.grafana.ingress.tlsSecret }}
       rules:
         {{- if .Values.grafana.ingress.host }}
         - host: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.host "context" $) }}
@@ -166,6 +164,12 @@ spec:
                     name: {{ printf "%s-grafana-service" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
                     port:
                       number: 3000
+      {{- if .Values.grafana.ingress.tls }}
+      tls:
+        - hosts:
+            - {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.host "context" $) }}
+          secretName: {{ .Values.grafana.ingress.tlsSecret }}
+      {{- end }}
     {{- if or .Values.commonLabels .Values.grafana.ingress.labels .Values.grafana.labels }}
     labels:
       {{- if .Values.commonLabels }}


### PR DESCRIPTION
### Description of the change

Fixes TLS configuration for the Ingress resource in the Grafana CRD, which previously leaded to an installation error/warning:

```
error validating data: [ValidationError(Grafana.spec.ingress.spec): unknown field "tlsEnabled" in org.integreatly.grafana.v1beta1.Grafana.spec.ingress.spec, ValidationError(Grafana.spec.ingress.spec): unknown field "tlsSecretName" in org.integreatly.grafana.v1beta1.Grafana.spec.ingress.spec]
```

### Benefits

TLS for Ingress can be enabled again.

### Possible drawbacks

None.

### Applicable issues

- fixes #18003

### Additional information

Updated to match the new version of the CRD:

```
...
                      tls:
                        items:
                          properties:
                            hosts:
                              items:
                                type: string
                              type: array
                              x-kubernetes-list-type: atomic
                            secretName:
                              type: string
                          type: object
                        type: array
                        x-kubernetes-list-type: atomic
...
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
