### PR TITLE
[bitnami/clickhouse]  Add support for persistence.existingClaim

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: clickhouse
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.5.8
+version: 3.6.0

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -283,6 +283,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                       | Description                                                            | Value               |
 | -------------------------- | ---------------------------------------------------------------------- | ------------------- |
 | `persistence.enabled`      | Enable persistence using Persistent Volume Claims                      | `true`              |
+| `persistence.existingClaim`| Name of an existing PVC to use                                         | `""`                |
 | `persistence.storageClass` | Storage class of backing PVC                                           | `""`                |
 | `persistence.labels`       | Persistent Volume Claim labels                                         | `{}`                |
 | `persistence.annotations`  | Persistent Volume Claim annotations                                    | `{}`                |

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -280,17 +280,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence Parameters
 
-| Name                       | Description                                                            | Value               |
-| -------------------------- | ---------------------------------------------------------------------- | ------------------- |
-| `persistence.enabled`      | Enable persistence using Persistent Volume Claims                      | `true`              |
-| `persistence.existingClaim`| Name of an existing PVC to use                                         | `""`                |
-| `persistence.storageClass` | Storage class of backing PVC                                           | `""`                |
-| `persistence.labels`       | Persistent Volume Claim labels                                         | `{}`                |
-| `persistence.annotations`  | Persistent Volume Claim annotations                                    | `{}`                |
-| `persistence.accessModes`  | Persistent Volume Access Modes                                         | `["ReadWriteOnce"]` |
-| `persistence.size`         | Size of data volume                                                    | `8Gi`               |
-| `persistence.selector`     | Selector to match an existing Persistent Volume for WordPress data PVC | `{}`                |
-| `persistence.dataSource`   | Custom PVC data source                                                 | `{}`                |
+| Name                        | Description                                                            | Value               |
+| --------------------------- | ---------------------------------------------------------------------- | ------------------- |
+| `persistence.enabled`       | Enable persistence using Persistent Volume Claims                      | `true`              |
+| `persistence.existingClaim` | Name of an existing PVC to use                                         | `""`                |
+| `persistence.storageClass`  | Storage class of backing PVC                                           | `""`                |
+| `persistence.labels`        | Persistent Volume Claim labels                                         | `{}`                |
+| `persistence.annotations`   | Persistent Volume Claim annotations                                    | `{}`                |
+| `persistence.accessModes`   | Persistent Volume Access Modes                                         | `["ReadWriteOnce"]` |
+| `persistence.size`          | Size of data volume                                                    | `8Gi`               |
+| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC | `{}`                |
+| `persistence.dataSource`    | Custom PVC data source                                                 | `{}`                |
 
 ### Init Container Parameters
 

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -389,6 +389,10 @@ spec:
         {{- if not $.Values.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- else if $.Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ tpl $.Values.persistence.existingClaim $ }}
         {{- end }}
         {{- if  $.Values.tls.enabled }}
         - name: raw-certificates
@@ -400,7 +404,7 @@ spec:
         {{- if $.Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" $.Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if $.Values.persistence.enabled }}
+  {{- if and $.Values.persistence.enabled (not $.Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -903,6 +903,9 @@ persistence:
   ## @param persistence.enabled Enable persistence using Persistent Volume Claims
   ##
   enabled: true
+  ## @param persistence.existingClaim Name of an existing PVC to use
+  ##
+  existingClaim: ""
   ## @param persistence.storageClass Storage class of backing PVC
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
### Description of the change

Adds support for using an existing PVC in the clickhouse chart 

### Benefits

Let's you use a custom PVC for clickhouse

### Possible drawbacks

Might only support single replica situations

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #17893

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
