### PR TITLE
[bitnami/jupyterhub] Fix tests issues on some clusters

### DIFF
--- a/.vib/jupyterhub/cypress/cypress/support/commands.js
+++ b/.vib/jupyterhub/cypress/cypress/support/commands.js
@@ -25,7 +25,8 @@ Cypress.Commands.add(
     cy.get('#password_input').type(password);
     cy.get('#login_submit').click();
     // The authentication is not completed until the page is rendered
-    cy.contains('Launcher');
+    // Accessing the for the first time may take extra-time: "Your server is starting up"
+    cy.contains('Launcher', {timeout: 60000});
   }
 );
 

--- a/.vib/jupyterhub/goss/goss.yaml
+++ b/.vib/jupyterhub/goss/goss.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 http:
+  # For this test to work, the pod should have the proper label to allow ingress
+  # traffic as per the NetworkPolicy
   http://jupyterhub-hub:{{ .Vars.hub.service.ports.http }}/hub/health:
     status: 200
   http://jupyterhub-proxy-api:{{ .Vars.proxy.service.api.ports.http }}:

--- a/.vib/jupyterhub/runtime-parameters.yaml
+++ b/.vib/jupyterhub/runtime-parameters.yaml
@@ -15,6 +15,9 @@ hub:
     automountServiceAccountToken: true
   rbac:
     create: true
+  # The label is needed for GOSS tests
+  podLabels:
+    hub.jupyter.org/network-access-hub: "true"
   service:
     ports:
       http: 8082


### PR DESCRIPTION
### Description of the change

This PR aims two address two problems we have detected when running JupyterHub tests on different performing clusters:

- The UI may take some extra-time to be ready the first time is accessed, leading to timeouts in Cypress.
- GOSS tests may (correctly) fail in clusters that enforce the default NetworkPolicies created by the chart.

### Benefits

Tests work on a broader set of clusters.

### Possible drawbacks

None.

### Applicable issues

NA

### Additional information

NA

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
