### PR TITLE
[bitnami/kafka] Always create system-user if client SASL enabled

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kafka
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.0
+version: 24.0.1

--- a/bitnami/kafka/templates/secrets.yaml
+++ b/bitnami/kafka/templates/secrets.yaml
@@ -36,9 +36,7 @@ data:
     {{- $secretValue = join "," $clientPasswords | toString | b64enc }}
   {{- end }}
   client-passwords: {{ $secretValue | quote }}
-  {{- if and (or .Values.provisioning.enabled .Values.metrics.kafka.enabled) (regexFind "SASL" (upper .Values.listeners.client.protocol)) }}
   system-user-password: {{ index (splitList "," (b64dec $secretValue)) 0 | b64enc | quote }}
-  {{- end }}
   {{- end }}
   {{- if or .Values.sasl.zookeeper.user .Values.zookeeper.auth.client.enabled }}
   zookeeper-password: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "zookeeper-password" "providedValues" (list "sasl.zookeeper.password" "zookeeper.auth.client.clientPassword") "failOnNew" false "context" $) }}


### PR DESCRIPTION
### Description of the change

Fixes an issue where the `system-user-password` password was created only if metrics/provisioning was enabled.

This makes sense in the Kafka chart, but other applications use this secret key to access a single password instead of the comma-separated list of passwords, as it is the case of Milvus.

### Benefits

Unblocks Milvus update.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #18186 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
