### PR TITLE
[bitnami/kafka] Use regexMatch instead of regexFind, becuase we expect boolean

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kafka
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.1
+version: 24.0.2

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -272,7 +272,7 @@ sasl.mechanism=SCRAM-SHA-512
 {{- else }}
 sasl.mechanism=PLAIN
 {{- end }}
-{{- $securityModule := ternary "org.apache.kafka.common.security.scram.ScramLoginModule required" "org.apache.kafka.common.security.plain.PlainLoginModule required" (regexFind "SCRAM" (upper .Values.sasl.enabledMechanisms)) }}
+{{- $securityModule := ternary "org.apache.kafka.common.security.scram.ScramLoginModule required" "org.apache.kafka.common.security.plain.PlainLoginModule required" (regexMatch "SCRAM" (upper .Values.sasl.enabledMechanisms)) }}
 sasl.jaas.config={{ $securityModule }} \
     username="{{ index .Values.sasl.client.users 0 }}" \
     password="$(kubectl get secret {{ $fullname }}-user-passwords --namespace {{ $releaseNamespace }} -o jsonpath='{.data.client-passwords}' | base64 -d | cut -d , -f 1)";


### PR DESCRIPTION
### Description of the change

Use `regexMatch` instead of `regexFind`, becuase we expect `boolean`

### Benefits

Fixes a bug with enabling `externalAccess`

### Possible drawbacks

none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #18196

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
