### PR TITLE
fix: allow HPA to manage replicas when autoscaling is enabled

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: haproxy
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/haproxy
-version: 0.9.0
+version: 0.8.8

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: haproxy
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/haproxy
-version: 0.8.7
+version: 0.9.0

--- a/bitnami/haproxy/templates/deployment.yaml
+++ b/bitnami/haproxy/templates/deployment.yaml
@@ -17,7 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Description of the change
This change modifies the HAProxy chart's Deployment.yaml to conditionally set replicaCount based on whether autoscaling is enabled. This change allows the Horizontal Pod Autoscaler (HPA) to properly control the number of replicas when autoscaling is enabled and falls back to use the value from replicaCount when autoscaling is not enabled.

### Benefits
This fix allows users of the HAProxy chart to properly use Kubernetes HPA with the chart. This resolves an issue where the `replicaCount` setting in values.yaml would override the HPA's replica count, preventing proper autoscaling.

### Possible drawbacks
As this change is adding a condition to the setting of replicaCount, it should not introduce any drawbacks unless there is a dependency on the replicaCount field being explicitly set in the Deployment even when autoscaling is enabled.

### Applicable issues
- Fixes https://github.com/bitnami/charts/issues/18172

### Additional information
The conditional check for autoscaling has been added in the Deployment.yaml as follows:
```yaml
{{- if not .Values.autoscaling.enabled }}
replicas: {{ .Values.replicaCount }}
{{- end }}
```

### Checklist:

-  Chart version bumped in Chart.yaml according to [semver](http://semver.org/).
-  Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
-  Title of the pull request follows this pattern [bitnami/haproxy] Conditionally set replicaCount
-  All commits signed off and in agreement of [Developer Certificate of Origin (DCO)]