### PR TITLE
[bitnami/kafka] Mount /tmp as an emptyDir volume

### DIFF
--- a/.vib/kafka/runtime-parameters.yaml
+++ b/.vib/kafka/runtime-parameters.yaml
@@ -35,7 +35,6 @@ controller:
   containerSecurityContext:
     enabled: true
     runAsUser: 1002
-    readOnlyRootFilesystem: false
 serviceAccount:
   create: true
   automountServiceAccountToken: true

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kafka
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.1
+version: 24.0.2

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -280,6 +280,8 @@ spec:
             - name: kafka-config
               mountPath: /opt/bitnami/kafka/config/server.properties
               subPath: server.properties
+            - name: tmp
+              mountPath: /tmp
             {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
             - name: log4j-config
               mountPath: /opt/bitnami/kafka/config/log4j.properties
@@ -338,6 +340,8 @@ spec:
           configMap:
             name: {{ include "kafka.broker.configmapName" . }}
         - name: kafka-config
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         - name: scripts
           configMap:

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -273,6 +273,8 @@ spec:
             - name: kafka-config
               mountPath: /opt/bitnami/kafka/config/server.properties
               subPath: server.properties
+            - name: tmp
+              mountPath: /tmp
             {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
             - name: log4j-config
               mountPath: /opt/bitnami/kafka/config/log4j.properties
@@ -331,6 +333,8 @@ spec:
           configMap:
             name: {{ include "kafka.controller.configmapName" . }}
         - name: kafka-config
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         - name: scripts
           configMap:


### PR DESCRIPTION
### Description of the change

Fixes an issue where Kafka would fail with error "Cannot unpack libzstd" because it can't write to `/tmp` directory due to `readOnlyRootFilesystem=true`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
