### PR TITLE
[bitnami/kafka] Bump Kafka versión 24.0.3

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kafka
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.2
+version: 24.0.3


### PR DESCRIPTION
Bumps chart version missing in commit d6572e463d2914edccd431620a6ff65db65c53d7