### PR TITLE
[bitnami/jupyterhub] Allow multiple images to be specified for imagePuller

### DIFF
--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: jupyterhub
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 4.1.8
+version: 5.0.0

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -576,7 +576,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 5.0.0
 
-This major version adds the ability to pre-pull extra images through the imagePuller daemonset, which previously supported pulling only a few fixed images. extraImages can be specified through the auxiliaryImage.extraImages configuration.
+This major version adds the ability to pre-pull extra images through the imagePuller daemonset, which previously supported pulling only a few fixed images. extraImages can be specified through the auxiliaryImage.extraImages configuration. The auxiliaryImage values section to specify the singular image previously has been modified to auxiliaryImage.image.
 
 ### To 3.0.0
 

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -463,14 +463,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Auxiliary image parameters
 
-| Name                         | Description                                                                                               | Value              |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------ |
-| `auxiliaryImage.registry`    | Auxiliary image registry                                                                                  | `docker.io`        |
-| `auxiliaryImage.repository`  | Auxiliary image repository                                                                                | `bitnami/os-shell` |
-| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended)                                                       | `11-debian-11-r25` |
-| `auxiliaryImage.digest`      | Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`               |
-| `auxiliaryImage.pullPolicy`  | Auxiliary image pull policy                                                                               | `IfNotPresent`     |
-| `auxiliaryImage.pullSecrets` | Auxiliary image pull secrets                                                                              | `[]`               |
+| Name                               | Description                                                                                               | Value              |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------ |
+| `auxiliaryImage.image.registry`    | Auxiliary image registry                                                                                  | `docker.io`        |
+| `auxiliaryImage.image.repository`  | Auxiliary image repository                                                                                | `bitnami/os-shell` |
+| `auxiliaryImage.image.tag`         | Auxiliary image tag (immutabe tags are recommended)                                                       | `11-debian-11-r25` |
+| `auxiliaryImage.image.digest`      | Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`               |
+| `auxiliaryImage.image.pullPolicy`  | Auxiliary image pull policy                                                                               | `IfNotPresent`     |
+| `auxiliaryImage.image.pullSecrets` | Auxiliary image pull secrets                                                                              | `[]`               |
+| `auxiliaryImage.extraImages`       | Extra Images that should be pulled by imagePuller                                                         | `[]`               |
 
 ### JupyterHub database parameters
 
@@ -572,6 +573,10 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 5.0.0
+
+This major version adds the ability to pre-pull extra images through the imagePuller daemonset, which previously supported pulling only a few fixed images. extraImages can be specified through the auxiliaryImage.extraImages configuration.
 
 ### To 3.0.0
 

--- a/bitnami/jupyterhub/templates/NOTES.txt
+++ b/bitnami/jupyterhub/templates/NOTES.txt
@@ -48,7 +48,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 {{- include "common.warnings.rollingTag" .Values.hub.image }}
 {{- include "common.warnings.rollingTag" .Values.proxy.image }}
 {{- include "common.warnings.rollingTag" .Values.singleuser.image }}
-{{- include "common.warnings.rollingTag" .Values.auxiliaryImage }}
+{{- include "common.warnings.rollingTag" .Values.auxiliaryImage.image }}
 
 {{- $passwordValidationErrors := list -}}
 

--- a/bitnami/jupyterhub/templates/_helpers.tpl
+++ b/bitnami/jupyterhub/templates/_helpers.tpl
@@ -108,14 +108,14 @@ Return the proper hub image name
 Return the proper hub image name
 */}}
 {{- define "jupyterhub.auxiliary.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.auxiliaryImage "global" .Values.global) }}
+{{ include "common.images.image" (dict "imageRoot" .Values.auxiliaryImage.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "jupyterhub.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.hub.image .Values.proxy.image .Values.auxiliaryImage) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.hub.image .Values.proxy.image .Values.auxiliaryImage.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
@@ -148,7 +148,7 @@ Return the proper Docker Image Registry Secret Names
 Return the proper Docker Image Registry Secret Names list
 */}}
 {{- define "jupyterhub.imagePullSecrets.list" -}}
-{{- include "jupyterhub.imagePullSecretsList" (dict "images" (list .Values.hub.image .Values.proxy.image .Values.auxiliaryImage) "global" .Values.global) -}}
+{{- include "jupyterhub.imagePullSecretsList" (dict "images" (list .Values.hub.image .Values.proxy.image .Values.auxiliaryImage.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
@@ -71,8 +71,8 @@ spec:
       initContainers:
       {{- range $index, $image := (list .Values.singleuser.image .Values.auxiliaryImage.image) }}
         - name: pull-{{ $index }}
-          image: {{ include "common.images.image" (dict "imageRoot" $image "global" $.Values.global) }}
-          imagePullPolicy: {{ $image.pullPolicy }}
+          image: {{ include "common.images.image" (dict "imageRoot" . "global" $.Values.global) }}
+          imagePullPolicy: {{ .pullPolicy }}
           {{- if $.Values.imagePuller.resources }}
           resources: {{- toYaml $.Values.imagePuller.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
@@ -69,11 +69,26 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.imagePuller.terminationGracePeriodSeconds }}
       {{- end }}
       initContainers:
-      {{- range $index, $image := (list .Values.singleuser.image .Values.auxiliaryImage) }}
+      {{- range $index, $image := (list .Values.singleuser.image .Values.auxiliaryImage.image) }}
         - name: pull-{{ $index }}
-          image: {{ include "common.images.image" (dict "imageRoot" . "global" $.Values.global) }}
-          imagePullPolicy: {{ .pullPolicy }}
+          image: {{ include "common.images.image" (dict "imageRoot" $image "global" $.Values.global) }}
+          imagePullPolicy: {{ $image.pullPolicy }}
           {{- if $.Values.imagePuller.resources }}
+          resources: {{- toYaml $.Values.imagePuller.resources | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - echo "Pulling complete"
+          {{- if $.Values.imagePuller.containerSecurityContext.enabled }}
+          securityContext: {{- omit $.Values.imagePuller.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- end }}
+      {{- range $index, $image := .Values.auxiliaryImage.extraImages }}
+        - name: extra-pull-{{$index}}
+          image: {{ include "common.images.image" (dict "imageRoot" $image "global" $.Values.global) }}
+          imagePullPolicy: {{$image.pullPolicy}}
+                    {{- if $.Values.imagePuller.resources }}
           resources: {{- toYaml $.Values.imagePuller.resources | nindent 12 }}
           {{- end }}
           command:
@@ -90,7 +105,7 @@ spec:
       containers:
         - name: pause
           image: {{ template "jupyterhub.auxiliary.image" . }}
-          imagePullPolicy: {{ .Values.auxiliaryImage.pullPolicy }}
+          imagePullPolicy: {{ .Values.auxiliaryImage.image.pullPolicy }}
           {{- if .Values.imagePuller.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.imagePuller.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -908,7 +908,6 @@ proxy:
     ##
     annotations: {}
 
-
   ## @section Proxy Traffic Exposure Parameters
   ##
 
@@ -1590,27 +1589,45 @@ singleuser:
 ## @section Auxiliary image parameters
 ##
 
-## @param auxiliaryImage.registry Auxiliary image registry
-## @param auxiliaryImage.repository Auxiliary image repository
-## @param auxiliaryImage.tag Auxiliary image tag (immutabe tags are recommended)
-## @param auxiliaryImage.digest Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-## @param auxiliaryImage.pullPolicy Auxiliary image pull policy
-## @param auxiliaryImage.pullSecrets Auxiliary image pull secrets
+## @param auxiliaryImage.image.registry Auxiliary image registry
+## @param auxiliaryImage.image.repository Auxiliary image repository
+## @param auxiliaryImage.image.tag Auxiliary image tag (immutabe tags are recommended)
+## @param auxiliaryImage.image.digest Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param auxiliaryImage.image.pullPolicy Auxiliary image pull policy
+## @param auxiliaryImage.image.pullSecrets Auxiliary image pull secrets
 ##
 auxiliaryImage:
-  registry: docker.io
-  repository: bitnami/os-shell
-  tag: 11-debian-11-r25
-  digest: ""
-  pullPolicy: IfNotPresent
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ## e.g:
-  ## pullSecrets:
-  ##   - myRegistryKeySecretName
-  ##
-  pullSecrets: []
+  image:
+    registry: docker.io
+    repository: bitnami/os-shell
+    tag: 11-debian-11-r25
+    digest: ""
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+    #   - myAnotherRegistryKeySecretName
+    #   - yetAnotherRegistryKeySecretName
+  ## @param auxiliaryImage.extraImages Extra Images that should be pulled by imagePuller
+  extraImages: []
+  # extraImages:
+  #   - registry: docker.io
+  #     repository: bitnami/os-shell
+  #     tag: 11-debian-11-r24
+  #     digest: ""
+  #     pullPolicy: IfNotPresent
+  #   - registry: docker.io
+  #     repository: bitnami/os-shell
+  #     tag: 11-debian-11-r23
+  #     digest: ""
+  #     pullPolicy: IfNotPresent
 
 ## @section JupyterHub database parameters
 

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -1611,23 +1611,20 @@ auxiliaryImage:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-    #   - myAnotherRegistryKeySecretName
-    #   - yetAnotherRegistryKeySecretName
   ## @param auxiliaryImage.extraImages Extra Images that should be pulled by imagePuller
+  ## e.g:
+  ## extraImages:
+  ##   - registry: docker.io
+  ##     repository: bitnami/os-shell
+  ##     tag: 11-debian-11-r24
+  ##     digest: ""
+  ##     pullPolicy: IfNotPresent
+  ##   - registry: docker.io
+  ##     repository: bitnami/os-shell
+  ##     tag: 11-debian-11-r23
+  ##     digest: ""
+  ##     pullPolicy: IfNotPresent
   extraImages: []
-  # extraImages:
-  #   - registry: docker.io
-  #     repository: bitnami/os-shell
-  #     tag: 11-debian-11-r24
-  #     digest: ""
-  #     pullPolicy: IfNotPresent
-  #   - registry: docker.io
-  #     repository: bitnami/os-shell
-  #     tag: 11-debian-11-r23
-  #     digest: ""
-  #     pullPolicy: IfNotPresent
 
 ## @section JupyterHub database parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR enhances the jupyterhub helm chart to allow specifying an arbitrary number of images into the auxiliaryImage section so the chart user can specify an exhaustive list of images that need to be pulled at install-time.

### Benefits

<!-- What benefits will be realized by the code change? -->
With this change, the chart users can specify any number of images in the auxiliaryImage.extraImages section thus allowing them to pre-pull all required images at install time and reducing the time it takes to start a new notebook server.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None, this functionality is available in the upstream application's chart already.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #18097 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
The structure of the values.yaml has changed to specify the auxiliaryImage into auxiliaryImage.image (standardized as other image sections) in order to introduce auxiliaryImage.extraImages. The chart version has been bumped accordingly.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
