### PR TITLE
[bitnami/common] Revert #18194 changes

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.7.0
+appVersion: 2.7.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.7.0
+version: 2.7.1

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -12,7 +12,6 @@ app.kubernetes.io/name: {{ include "common.names.name" . }}
 helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

The `app.kubernetes.io/version` label must be treated with caution given its non-inmutable values (Helm will set a different value to the `appVersion` changes on `Chart.yaml`).

There are fields on K8s objects that are inmutable (e.g. `deployment.spec.selector` or `statefulset.spec.volumeClaimTemplates.metadata.labels`). Therefore, we might be very cautious to avoid including these kind of labels to avoid introducing backwards incompatibilities.

### Benefits

Before applying a changes such as the one introduced at https://github.com/bitnami/charts/pull/18194, we should previously ensure we're not making a bad use of `common.labels.matchLabels` helper **on every single chart**. Without doing this study, we shouldn't include it.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
