### PR TITLE
[bitnami/clickhouse]: Use inmutable labels on claim templates

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.6.4
+version: 3.6.5

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -415,7 +415,7 @@ spec:
           {{- if $.Values.commonAnnotations }}
           {{- include "common.tplvalues.render" (dict "value" $.Values.commonAnnotations "context" $) | nindent 10 }}
           {{- end }}
-        labels: {{- include "common.labels.standard" $ | nindent 10 }}
+        labels: {{- include "common.labels.matchLabels" $ | nindent 10 }}
           app.kubernetes.io/component: clickhouse
           {{- if $.Values.commonLabels }}
           {{- include "common.tplvalues.render" (dict "value" $.Values.commonLabels "context" $) | nindent 10 }}


### PR DESCRIPTION
### Description of the change

This PR ensures we don't use labels which values are likely to change (e.g. `helm.sh/chart`) on `volumeClaimTemplates.metadata.labels` since it's forbidden to update this field.

### Benefits

We stop breaking backwards compatibility on every single release.

### Possible drawbacks

None

### Applicable issues

- fixes #18215

### Additional information

Before:

```yaml
  (...)
  volumeClaimTemplates:
    - metadata:
        name: data
        annotations:
        labels:
          app.kubernetes.io/name: clickhouse
          helm.sh/chart: clickhouse-3.6.3
          app.kubernetes.io/instance: clickhouse
          app.kubernetes.io/managed-by: Helm
          app.kubernetes.io/component: clickhouse
      (...)  
```

After:

```yaml
  (...)
  volumeClaimTemplates:
    - metadata:
        name: data
        annotations:
        labels:
          app.kubernetes.io/name: clickhouse
          app.kubernetes.io/instance: clickhouse
          app.kubernetes.io/component: clickhouse
      (...)  
```

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
