### PR TITLE
 [bitnami/kafka] Fix multiline custom config incorrectly rendered

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.6
+version: 24.0.7

--- a/bitnami/kafka/templates/controller-eligible/configmap.yaml
+++ b/bitnami/kafka/templates/controller-eligible/configmap.yaml
@@ -21,7 +21,8 @@ metadata:
   {{- end }}
 data:
   {{- if or .Values.config .Values.controller.config }}
-  server.properties: {{- include "common.tplvalues.render" ( dict "value" (coalesce .Values.controller.config .Values.config) "context" $ ) | nindent 4 }}
+  server.properties: | 
+  {{- include "common.tplvalues.render" ( dict "value" (coalesce .Values.controller.config .Values.config) "context" $ ) | nindent 4 }}
   {{- else }}
   server.properties: |-
     # Listeners configuration


### PR DESCRIPTION
### Description of the change

In the kafka chart, when you assign a multiline string to .config it is not rendered as a multiline string under server.properties in the kafka configuration configmap. Leading to deployment errors.

### Benefits

Ability to inject a custom server.properties as multiline string without deployment errors.

### Possible drawbacks

### Applicable issues

- fixes #18280 

### Additional information



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
