### PR TITLE
[bitnami/kubernetes-event-exporter] add vpa support

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 2.6.0
+version: 2.7.0

--- a/bitnami/kubernetes-event-exporter/README.md
+++ b/bitnami/kubernetes-event-exporter/README.md
@@ -154,6 +154,24 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRule.labels`                   | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                     | `{}`                                |
 | `metrics.prometheusRule.groups`                   | Groups, containing the alert rules.                                                                                       | `[]`                                |
 
+### Autoscaling
+
+| Name                                  | Description                                                                                    | Value   |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------- | ------- |
+| `autoscaling.vpa.enabled`             | Enable VPA                                                                                     | `false` |
+| `autoscaling.vpa.annotations`         | Annotations for VPA resource                                                                   | `{}`    |
+| `autoscaling.vpa.recommenders`        | Recommender responsible for generating recommendation for the object.                          | `[]`    |
+| `autoscaling.vpa.controlledResources` | VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory | `[]`    |
+| `autoscaling.vpa.maxAllowed`          | VPA Max allowed resources for the pod                                                          | `{}`    |
+| `autoscaling.vpa.minAllowed`          | VPA Min allowed resources for the pod                                                          | `{}`    |
+
+### VPA update policy
+
+| Name                                       | Description                                                                                                                                                            | Value  |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `autoscaling.vpa.updatePolicy.minReplicas` | Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction                                                                    | `1`    |
+| `autoscaling.vpa.updatePolicy.updateMode`  | Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod | `Auto` |
+
 ## Configuration and installation details
 
 ### [Rolling vs Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)

--- a/bitnami/kubernetes-event-exporter/templates/vpa.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/vpa.yaml
@@ -1,0 +1,57 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.autoscaling.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/part-of: kubernetes-event-exporter
+   {{- if .Values.commonLabels }}
+   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+   {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.autoscaling.vpa.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.autoscaling.vpa.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.autoscaling.vpa.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: event-exporter
+      {{- with .Values.autoscaling.vpa.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoscaling.vpa.maxAllowed }}
+      maxAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoscaling.vpa.minAllowed }}
+      minAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}
+  {{- if .Values.autoscaling.vpa.updatePolicy }}
+  updatePolicy:
+    {{- with .Values.autoscaling.vpa.updatePolicy.minReplicas }}
+    minReplicas: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.vpa.updatePolicy.updateMode }}
+    updateMode: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/kubernetes-event-exporter/values.yaml
+++ b/bitnami/kubernetes-event-exporter/values.yaml
@@ -411,3 +411,40 @@ metrics:
     ##           labels:
     ##             severity: critical
     groups: []
+
+## @section Autoscaling
+##
+autoscaling:
+  vpa:
+    ## @param autoscaling.vpa.enabled Enable VPA
+    ##
+    enabled: false
+    ## @param autoscaling.vpa.annotations Annotations for VPA resource
+    ##
+    annotations: {}
+    ## @param autoscaling.vpa.recommenders Recommender responsible for generating recommendation for the object.
+    ## List should be empty (then the default recommender will generate the recommendation) or contain exactly one recommender.
+    ## For example:
+    ## recommenders:
+    ## - name: custom-recommender-performance
+    recommenders: []
+    ## @param autoscaling.vpa.controlledResources VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+    ##
+    controlledResources: []
+    ## @param autoscaling.vpa.maxAllowed VPA Max allowed resources for the pod
+    ## cpu: 200m
+    ## memory: 100Mi
+    maxAllowed: {}
+    ## @param autoscaling.vpa.minAllowed VPA Min allowed resources for the pod
+    ## cpu: 200m
+    ## memory: 100Mi
+    minAllowed: {}
+    ## @section VPA update policy
+    ##
+    updatePolicy:
+      ## @param autoscaling.vpa.updatePolicy.minReplicas Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+      minReplicas: 1
+      ## @param autoscaling.vpa.updatePolicy.updateMode Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod
+      ## Possible values are "Off", "Initial", "Recreate", and "Auto".
+      ##
+      updateMode: Auto


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Adds support for Vertical Pod Autoscaler to automatically adjust cpu/memory requests/limits based on the actual usage without user intervention.

### Benefits
Improve cluster resource utilization.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
