### PR TITLE
[bitnami/kafka] Provisioning job to use a writable folder for client.properties;

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.9
+version: 24.0.10

--- a/bitnami/kafka/templates/provisioning/job.yaml
+++ b/bitnami/kafka/templates/provisioning/job.yaml
@@ -103,7 +103,7 @@ spec:
             - |
               echo "Configuring environment"
               . /opt/bitnami/scripts/libkafka.sh
-              export CLIENT_CONF="${CLIENT_CONF:-/opt/bitnami/kafka/config/client.properties}"
+              export CLIENT_CONF="${CLIENT_CONF:-/tmp/client.properties}"
               if [ ! -f "$CLIENT_CONF" ]; then
                 touch $CLIENT_CONF
 
@@ -243,6 +243,8 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
             {{- if .Values.provisioning.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -263,6 +265,8 @@ spec:
             defaultMode: 256
         {{- end }}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.provisioning.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.extraVolumes "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### Description of the change

This PR updates default provisioning job `client.properties` location to a writable directory.

### Benefits

Provisioning works with default hardening config (`readOnlyRootFilesystem`)

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #18191

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
