### PR TITLE
[bitnami/cert-manager] Add patch permission to cert-manager controller for issuers and clusterissuers

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 name: cert-manager
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.11.11
+version: 0.11.12

--- a/bitnami/cert-manager/templates/controller/rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/rbac.yaml
@@ -71,7 +71,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers"]
     verbs: ["get", "list", "watch"]
@@ -97,7 +97,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change adds `patch` verb to the cluster role for issues and clusterissuers. This has been causing the following error in our logs

> cert-manager/clusterissuers: re-queuing item due to error processing" err="clusterissuers.cert-manager.io \"letsencrypt\" is forbidden: User \"system:serviceaccount:cert-manager:cert-manager-controller\" cannot patch resource \"clusterissuers/status\" in API group \"cert-manager.io\" at the cluster scope" key="letsencrypt

### Benefits

Issuer status will get updated

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

This change has already been made on the [official helm chart](https://github.com/cert-manager/cert-manager/commit/3e23b6fd8a7a4f1200e53f4f17e5496e11813d90)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
