### PR TITLE
[bitnami/spring-cloud-dataflow] Remove 'runAsUser' goss test

### DIFF
--- a/.vib/spring-cloud-dataflow/goss/goss.yaml
+++ b/.vib/spring-cloud-dataflow/goss/goss.yaml
@@ -12,7 +12,6 @@ file:
     owner: root
     contains:
     - {{ .Vars.server.configuration.accountName }}
-    - /runAsUser.*{{ .Vars.deployer.podSecurityContext.runAsUser }}/
     - /url.*jdbc:mariadb.*{{ .Vars.mariadb.auth.database }}/
     - /username.*{{ .Vars.mariadb.auth.username }}/
   /etc/secrets/database:


### PR DESCRIPTION
### Description of the change

Removes the 'runAsUser' test from Spring Cloud Dataflow goss tests as it is not compatible with all platforms.

When deployed in platforms such as Openshift that does not use 'securityContext' the goss tests will fail.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
