### PR TITLE
[bitnami/nats] Fix issue with goss tests 'running_user'

### DIFF
--- a/.vib/nats/goss/goss.yaml
+++ b/.vib/nats/goss/goss.yaml
@@ -8,7 +8,6 @@ file:
     exists: true
     owner: root
 command:
-  {{- $running_user := printf "%d" .Vars.containerSecurityContext.runAsUser }}
   {{- $auth := printf "--user=%s --password=%s" .Vars.auth.user .Vars.auth.password }}
   {{- $client_port := printf "%d" .Vars.service.ports.client }}
   {{- $lb_endpoint := printf "-s nats://nats:%s" $client_port }}
@@ -18,7 +17,7 @@ command:
     ## We need to have the subscriber process running at the same time the publishing is done
     ## The sleep is needed to avoid a race condition where the publishing is done before the subscriber is ready
     ## The subscriber process needs to be timed out so there is no dangling process making goss timeout
-    exec: ( USER={{ $running_user }} timeout 10 ./nats/goss/testfiles/nats {{ $auth }} {{ $lb_endpoint }} sub {{ $subject }}; ) & sleep 3 && USER={{ $running_user }} ./nats/goss/testfiles/nats {{ $auth }} {{ $lb_endpoint }} pub {{ $subject }} {{ $msg }}
+    exec: ( USER=$(id -u) timeout 10 ./nats/goss/testfiles/nats {{ $auth }} {{ $lb_endpoint }} sub {{ $subject }}; ) & sleep 3 && USER=$(id -u) ./nats/goss/testfiles/nats {{ $auth }} {{ $lb_endpoint }} pub {{ $subject }} {{ $msg }}
     exit-status: 0
     stdout:
     - /Received on.*{{ $subject }}/
@@ -29,7 +28,7 @@ command:
     {{- $subject := printf "subj_%s" (randAlpha 5) }}
     {{- $msg := printf "msg_%s" (randAlpha 5) }}
     {{- $pod_endpoint := printf "-s nats://nats-%d.nats-headless:%s" $i $client_port }}
-    exec: ( USER={{ $running_user }} timeout 10 ./nats/goss/testfiles/nats {{ $auth }} {{ $pod_endpoint }} sub {{ $subject }}; ) & sleep 3 && USER={{ $running_user }} ./nats/goss/testfiles/nats {{ $auth }} {{ $lb_endpoint }} pub {{ $subject }} {{ $msg }}
+    exec: ( USER=$(id -u) timeout 10 ./nats/goss/testfiles/nats {{ $auth }} {{ $pod_endpoint }} sub {{ $subject }}; ) & sleep 3 && USER=$(id -u) ./nats/goss/testfiles/nats {{ $auth }} {{ $lb_endpoint }} pub {{ $subject }} {{ $msg }}
     exit-status: 0
     stdout:
     - /Received on.*{{ $subject }}/


### PR DESCRIPTION
### Description of the change

Fixes an issue with NATS goss tests, where tests would fail in Openshift as the variable '$running_user' will not match the real running user, causing the tests to fail.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
