### PR TITLE
[bitnami/keycloak] - Fixing external database connection issue (password authentication failed for user "bn_keycloak")

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: keycloak
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 16.0.3
+version: 16.0.4

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -385,7 +385,7 @@ Sometimes, you may want to have Keycloak connect to an external PostgreSQL datab
 
 Refer to the [chart documentation on using an external database](https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/use-external-database) for more details and an example.
 
-If you are using external database, provide an extra KC_DB_PASSWORD env variable
+If you are using external database, provide an extra KC_DB_PASSWORD env variable:
 
 ```yaml
 externalDatabase:

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -385,6 +385,23 @@ Sometimes, you may want to have Keycloak connect to an external PostgreSQL datab
 
 Refer to the [chart documentation on using an external database](https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/use-external-database) for more details and an example.
 
+If you are using external database, provide an extra KC_DB_PASSWORD env variable
+
+```yaml
+externalDatabase:
+  host: "postgresql.externaldb.com"
+  port: 5432
+  user: bn_keycloak
+  database: bn_keycloak
+  existingSecret: passwords
+extraEnvVars:
+  - name: KC_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: postgres-secrets
+        key: postgres-password
+```
+
 > NOTE: Only PostgreSQL database server is supported as external database
 
 It is not supported but possible to run Keycloak with an external MSSQL database with the following settings:

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1055,6 +1055,15 @@ externalDatabase:
   existingSecretUserKey: ""
   existingSecretDatabaseKey: ""
   existingSecretPasswordKey: ""
+## If you are using external database, provide extra KC_DB_PASSWORD env variable to get rid of error with database password:
+# Example:
+# extraEnvVars:
+#   - name: KC_DB_PASSWORD
+#     valueFrom:
+#       secretKeyRef:
+#         name: postgres-secrets
+#         key: postgres-password
+
 
 ## @section Keycloak Cache parameters
 


### PR DESCRIPTION
Values commented from str. 1058

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Change consists fix for the external database password, KC_DB_PASSWORD fixes the issue with chart installing.
Keycloak helm chart with external database fails with error: "[org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator] (JPA Startup Thread: keycloak-default) HHH000342: Could not obtain connection to query metadata: org.postgresql.util.PSQLException: FATAL: password authentication failed for user "bn_keycloak""
Even if database and password sent as an values.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

All code is commented on, has a description, no drawbacks.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes # ERROR: [org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator] (JPA Startup Thread: keycloak-default) HHH000342: Could not obtain connection to query metadata: org.postgresql.util.PSQLException: FATAL: password authentication failed for user "bn_keycloak"

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
