### PR TITLE
[bitnami/opensearch] Skip check-no-capabilities test when securityContext disabled

### DIFF
--- a/.vib/opensearch/goss/goss.yaml
+++ b/.vib/opensearch/goss/goss.yaml
@@ -18,6 +18,7 @@ addr:
   tcp://opensearch-dashboards:{{ .Vars.dashboards.service.ports.http }}:
     reachable: true
     timeout: 180000
+{{- if .Vars.master.containerSecurityContext.enabled }}
 command:
   check-no-capabilities:
     exec: cat /proc/1/status
@@ -28,3 +29,4 @@ command:
       - "CapEff:	0000000000000000"
       - "CapBnd:	0000000000000000"
       - "CapAmb:	0000000000000000"
+{{- end }}

--- a/.vib/opensearch/runtime-parameters.yaml
+++ b/.vib/opensearch/runtime-parameters.yaml
@@ -1,5 +1,11 @@
 master:
   replicaCount: 1
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1002
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1002
 coordinating:
   replicaCount: 1
 data:


### PR DESCRIPTION
### Description of the change

Skips test 'check-no-capabilities' when securityContext is not enabled, as capabilities drop is not configured.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
