### PR TITLE
[bitnami/kube-prometheus] Skip check-no-capabilities test when securityContext disabled

### DIFF
--- a/.vib/kube-prometheus/goss/goss.yaml
+++ b/.vib/kube-prometheus/goss/goss.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 command:
+  {{- if .Vars.operator.containerSecurityContext.enabled }}
   check-no-capabilities:
     exec: cat /proc/1/status
     exit-status: 0
@@ -11,6 +12,7 @@ command:
     - "CapEff:	0000000000000000"
     - "CapBnd:	0000000000000000"
     - "CapAmb:	0000000000000000"
+  {{- end }}
   {{- $uid := .Vars.operator.podSecurityContext.runAsUser }}
   {{- $gid := .Vars.operator.podSecurityContext.fsGroup }}
   check-user-info:


### PR DESCRIPTION
### Description of the change

Skips test 'check-no-capabilities' when securityContext is not enabled, as capabilities drop is not configured.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
