### PR TITLE
[bitnami/argo-cd] Skip check-no-capabilities test when securityContext disabled

### DIFF
--- a/.vib/argo-cd/goss/goss.yaml
+++ b/.vib/argo-cd/goss/goss.yaml
@@ -26,6 +26,7 @@ command:
   check-argocd-cli:
     exec: argocd login argo-cd-server --insecure --username admin --password {{ $password }}
     exit-status: 0
+  {{- if .Vars.server.containerSecurityContext.enabled }}
   check-no-capabilities:
     exec: cat /proc/1/status
     exit-status: 0
@@ -35,6 +36,7 @@ command:
     - "CapEff:	0000000000000000"
     - "CapBnd:	0000000000000000"
     - "CapAmb:	0000000000000000"
+  {{- end }}
   {{- $uid := .Vars.server.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.server.podSecurityContext.fsGroup }}
   check-user-info:


### PR DESCRIPTION
### Description of the change

Skips test 'check-no-capabilities' when securityContext is not enabled, as capabilities drop is not configured.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
