### PR TITLE
[bitnami/common] Fix HPA and VPA capabilities templates

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.8.0
+appVersion: 2.8.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.8.0
+version: 2.8.1

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -146,7 +146,7 @@ Return the appropriate apiVersion for APIService.
 Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 */}}
 {{- define "common.capabilities.hpa.apiVersion" -}}
-{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- if .beta2 -}}
 {{- print "autoscaling/v2beta2" -}}
 {{- else -}}
@@ -161,7 +161,7 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 Return the appropriate apiVersion for Vertical Pod Autoscaler.
 */}}
 {{- define "common.capabilities.vpa.apiVersion" -}}
-{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- if .beta2 -}}
 {{- print "autoscaling/v2beta2" -}}
 {{- else -}}


### PR DESCRIPTION
### Description of the change

This PR fixes the templates to fetch the correct apiVersion for HPA and VPA:
- `common.capabilities.hpa.apiVersion`
- `common.capabilities.vpa.apiVersion`

### Benefits
Bug fix. At the moment using the above two listed templates, causes helm to throw error

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
