### PR TITLE
[bitnami/argo-cd] Provide configmap for rbac configuration

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 4.7.25
+version: 4.8.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -810,6 +810,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `config.existingStylesConfigmap`               | Use an existing styles configmap                                                                      | `""`   |
 | `config.tlsCerts`                              | TLS certificates used to verify the authenticity of the repository servers                            | `{}`   |
 | `config.gpgKeys`                               | GnuPG public keys to add to the keyring                                                               | `{}`   |
+| `config.rbac`                                  | Role-based authentication configuration                                                               | `{}`   |
 | `config.secret.create`                         | Whether to create or not the secret                                                                   | `true` |
 | `config.secret.annotations`                    | General secret extra annotations                                                                      | `{}`   |
 | `config.secret.githubSecret`                   | GitHub secret to configure webhooks                                                                   | `""`   |

--- a/bitnami/argo-cd/templates/applicationset/deployment.yaml
+++ b/bitnami/argo-cd/templates/applicationset/deployment.yaml
@@ -159,6 +159,10 @@ spec:
             - mountPath: /app/config/gpg/source
               name: gpg-keys
             {{- end }}
+            {{- if .Values.config.rbac }}
+            - mountPath: /app/config/rbac
+              name: rbac
+            {{- end }}
             - mountPath: /app/config/gpg/keys
               name: gpg-keyring
             - mountPath: /tmp
@@ -179,6 +183,11 @@ spec:
         - name: gpg-keys
           configMap:
             name: argocd-gpg-keys-cm
+        {{- end }}
+        {{- if .Values.config.rbac }}
+        - name: rbac
+          configMap:
+            name: argocd-rbac-cm
         {{- end }}
         - name: gpg-keyring
           emptyDir: {}

--- a/bitnami/argo-cd/templates/rbac-cm.yaml
+++ b/bitnami/argo-cd/templates/rbac-cm.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # Mandatory hardcoded name.
+  # Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/
+  name: argocd-rbac-cm
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    # Mandatory label
+    # Ref: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#atomic-configuration
+    app.kubernetes.io/part-of: argocd
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  {{- include "common.tplvalues.render" (dict "value" .Values.config.rbac "context" $) | nindent 2 }}

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -3192,6 +3192,16 @@ config:
     #   ...
     #   -----END PGP PUBLIC KEY BLOCK-----
 
+  ## @param config.rbac Role-based authentication configuration
+  ##
+  rbac: {}
+    # policy.default: role:readonly
+    # policy.csv: |
+    #   # Grant all members of the group 'my-org:team-alpha; the ability to sync apps in 'my-project'
+    #   p, my-org:team-alpha, applications, sync, my-project/*, allow
+    #   # Grant all members of 'my-org:team-beta' admins
+    #   g, my-org:team-beta, role:admin
+
   ## Argo CD general secret configuration
   ##
   secret:


### PR DESCRIPTION
### Description of the change

Besides the `gpg-keys` and `tls-certs` configmaps, there is also a `rbac` configmap for role-based authentication configuration.

### Benefits

Configure rbac as part of the chart.

### Possible drawbacks

None

### Additional information

See also:
* https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/
* https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/argocd-rbac-cm.yaml

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
