### PR TITLE
[bitnami/kube-state-metrics] add thanosrulers/status subresource for prometheus-operator

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -46,4 +46,4 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 8.17.1
+version: 8.17.2

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
@@ -50,6 +50,7 @@ rules:
       - prometheuses/status
       - prometheuses/finalizers
       - thanosrulers
+      - thanosrulers/status
       - thanosrulers/finalizers
       - servicemonitors
       - podmonitors


### PR DESCRIPTION

### Description of the change

This MR adds the /status subresource for thanosrulers
### Benefits

This allows the operator to set the status correctly
### Possible drawbacks

n/a
### Applicable issues


### Additional information


### Checklist


- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
