### PR TITLE
[bitnami/pinniped]: fix ingress annotations

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.3.0
+version: 1.3.1

--- a/bitnami/pinniped/templates/supervisor/ingress.yaml
+++ b/bitnami/pinniped/templates/supervisor/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.supervisor.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.supervisor.seringressviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := merge .Values.supervisor.ingress.annotations .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR fixes a bug introduced at https://github.com/bitnami/charts/pull/18406 on ingress annotations.

### Benefits

Proper rendering of ingress manifest.

### Possible drawbacks

None

### Applicable issues

- fixes #18790

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
