### PR TITLE
[bitnami/kafka] Zookeeper chart update

### DIFF
--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.4.11
+  version: 12.1.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.8.0
-digest: sha256:63d2b26d75270dc04ffaa7ab77c5a066c43fed92a84d381bcaffea0d390081fa
-generated: "2023-08-18T16:20:17.24008372Z"
+  version: 2.9.0
+digest: sha256:a54db8d2946ff889eaa08317cdc9eccbfe55722b08c147ee0799925cd1b43c93
+generated: "2023-08-23T10:11:09.64327+02:00"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
 - condition: zookeeper.enabled
   name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.x.x
+  version: 12.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 24.0.14
+version: 25.0.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -1209,6 +1209,10 @@ kubectl apply -f $NEW_PVC_MANIFEST_FILE
 
 Repeat this process for each replica you had in your Kafka cluster. Once completed, upgrade the cluster and the new Statefulset should reuse the existing PVCs.
 
+### To 25.0.0
+
+This major updates the Zookeeper subchart to it newest major, 12.0.0. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/zookeeper#to-1200).
+
 ### To 23.0.0
 
 This major updates Kafka to its newest version, 3.5.x. For more information, please refer to [kafka upgrade notes](https://kafka.apache.org/35/documentation.html#upgrade).


### PR DESCRIPTION
### Description of the change

This major version updates the Zookeeper subchart to its newest major.

### Benefits

Keep charts up to date.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
