### PR TITLE
[bitnami/kafka] Change selector labels of kafka JMX metrics exporter

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 25.0.0
+version: 25.0.1

--- a/bitnami/kafka/templates/metrics/jmx-svc.yaml
+++ b/bitnami/kafka/templates/metrics/jmx-svc.yaml
@@ -35,5 +35,5 @@ spec:
       protocol: TCP
       targetPort: metrics
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: kafka
+    app.kubernetes.io/part-of: kafka
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Current selector labels of **`jmx-exporter`** service are not up-to-date, so prometheus metrics services discovery cannot scrape metrics from **`jmx-exporter`** container

<img width="1151" alt="image" src="https://github.com/bitnami/charts/assets/48898401/519bd539-8525-484c-a49c-d4ce04857c26">

### Benefits

Prometheus will able to discovery metrics from jmx-exporter (if enable).

### Possible drawbacks

### Applicable issues

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
