### PR TITLE
[bitnami/aspnet-core] Fix goss tests when running as nonroot

### DIFF
--- a/.vib/aspnet-core/goss/goss.yaml
+++ b/.vib/aspnet-core/goss/goss.yaml
@@ -5,9 +5,13 @@ file:
   /app:
     exists: true
     filetype: directory
+    {{- if .Vars.containerSecurityContext.enabled }}
     mode: "0777"
     owner: root
     group: root
+    {{- else }}
+    mode: "2777"
+    {{- end }}
 command:
   {{ if and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
   check-sa:

--- a/.vib/aspnet-core/runtime-parameters.yaml
+++ b/.vib/aspnet-core/runtime-parameters.yaml
@@ -11,6 +11,8 @@ containerPorts:
 serviceAccount:
   create: true
   automountServiceAccountToken: true
+containerSecurityContext:
+  enabled: true
 service:
   type: LoadBalancer
   ports:

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: aspnet-core
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
-version: 4.4.0
+version: 4.4.1


### PR DESCRIPTION
### Description of the change

Uses different outputs when running in platforms that sets a user different than root.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
