### PR TITLE
[bitnami/milvus] Update Kafka subchart 25.0.0

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.2.0
+  version: 9.3.0
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 24.0.8
+  version: 25.0.1
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.6.12
+  version: 12.8.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.8.0
-digest: sha256:314ea46ba8f80ac263a911e0d912fa5348d33db3c4f21f7d4ab362efc66efe55
-generated: "2023-08-09T14:34:20.180647168Z"
+  version: 2.9.0
+digest: sha256:1598ca226145a2c584acda821afeccb7d29c0941eabd3cba28fef0b184a6c786
+generated: "2023-08-24T17:39:38.400078+02:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 24.x.x
+  version: 25.x.x
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 2.0.1
+version: 3.0.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1602,6 +1602,10 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ## Upgrading
 
+### To 3.0.0
+
+This major updates the Kafka subchart to its newest major, 25.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2500).
+
 ### To 2.0.0
 
 This major updates the Kafka subchart to its newest major, 24.0.0. This new version refactors the Kafka chart architecture and requires manual actions during the upgrade. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2400).


### PR DESCRIPTION
### Description of the change

Updates Kafka subchart after its new major #18805 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
