### PR TITLE
[bitnami/kafka] broker pod labels

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 25.1.0
+version: 25.1.1

--- a/bitnami/kafka/templates/broker/pdb.yaml
+++ b/bitnami/kafka/templates/broker/pdb.yaml
@@ -23,7 +23,7 @@ spec:
   {{- if .Values.broker.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.broker.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+  {{- $podLabels := merge .Values.broker.podLabels .Values.commonLabels }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: broker

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   podManagementPolicy: {{ .Values.broker.podManagementPolicy }}
   replicas: {{ .Values.broker.replicaCount }}
-  {{- $podLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+  {{- $podLabels := merge .Values.broker.podLabels .Values.commonLabels }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: broker

--- a/bitnami/kafka/templates/broker/svc-external-access.yaml
+++ b/bitnami/kafka/templates/broker/svc-external-access.yaml
@@ -53,7 +53,7 @@ spec:
   {{- if and (eq $.Values.externalAccess.broker.service.type "NodePort") (le (add $i 1) (len $.Values.externalAccess.broker.service.externalIPs)) }}
   externalIPs: [{{ index $.Values.externalAccess.broker.service.externalIPs $i | quote }}]
   {{- end }}
-  {{- $podLabels := merge $.Values.worker.podLabels $.Values.commonLabels }}
+  {{- $podLabels := merge $.Values.broker.podLabels $.Values.commonLabels }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: kafka
     app.kubernetes.io/component: broker

--- a/bitnami/kafka/templates/broker/svc-headless.yaml
+++ b/bitnami/kafka/templates/broker/svc-headless.yaml
@@ -31,7 +31,7 @@ spec:
       port: {{ .Values.service.ports.client }}
       protocol: TCP
       targetPort: client
-  {{- $podLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+  {{- $podLabels := merge .Values.broker.podLabels .Values.commonLabels }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
       app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: kafka


### PR DESCRIPTION
### Description of the change

This PR fixes an issue introduced at https://github.com/bitnami/charts/pull/18609 since the podLabels values reference for brokers wasn't correct.

### Benefits

Proper broker templates rendering.

### Possible drawbacks

None

### Applicable issues

- fixes #18843

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
