### PR TITLE
[bitnami/sealed-secrest] missing dot

### DIFF
--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: sealed-secrets
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sealed-secrets
-version: 1.5.0
+version: 1.5.1

--- a/bitnami/sealed-secrets/templates/deployment.yaml
+++ b/bitnami/sealed-secrets/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       {{- if or .Values.podAnnotations .Values.commonAnnotations }}
-      {{- $annotations := merge .ValuespodAnnotations .Values.commonAnnotations }}
+      {{- $annotations := merge .Values.podAnnotations .Values.commonAnnotations }}
       annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

This PR fixes an issue introduced at https://github.com/bitnami/charts/pull/18439 since there's a missing dot in `.Values.podAnnotations`.

### Possible drawbacks

None

### Applicable issues

- fixes #18851

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
