### PR TITLE
[bitnami/spring-cloud-dataflow] Update Kafka subchart 25.0.0

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.0.13
+  version: 12.1.2
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.0.5
+  version: 13.1.1
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 24.0.14
+  version: 25.1.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.8.0
-digest: sha256:d8fc17b909f5d21017ee20e693651999f054bfb47cc52de707a3b36485a08bf8
-generated: "2023-08-21T03:28:41.786898552Z"
+  version: 2.9.0
+digest: sha256:413b30633d200fb766200c5687565249962e3c137c200e99a3e377e1c7661762
+generated: "2023-08-25T09:45:58.358204+02:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 24.x.x
+  version: 25.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 22.0.3
+version: 23.0.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -662,6 +662,10 @@ Find more information about how to deal with common errors related to Bitnami He
 
 If you enabled RabbitMQ chart to be used as the messaging solution for Skipper to manage streaming content, then it's necessary to set the `rabbitmq.auth.password` and `rabbitmq.auth.erlangCookie` parameters when upgrading for readiness/liveness probes to work properly. Inspect the RabbitMQ secret to obtain the password and the Erlang cookie, then you can upgrade your chart using the command below:
 
+### To 23.0.0
+
+This major updates the Kafka subchart to its newest major, 25.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2500).
+
 ### To 22.0.0
 
 This major updates the Kafka subchart to its newest major, 24.0.0. This new version refactors the Kafka chart architecture and requires manual actions during the upgrade. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2400).

--- a/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
@@ -46,7 +46,12 @@ data:
     {{- if .Values.rabbitmq.enabled }}
     k8s_wait_for_statefulset {{ $releaseNamespace }} {{ $rabbitmqFullname }}
     {{- else if .Values.kafka.enabled }}
-    k8s_wait_for_statefulset {{ $releaseNamespace }} {{ $kafkaFullname }}
+    {{- if gt (int .Values.kafka.controller.replicaCount) 0 }}
+    k8s_wait_for_statefulset {{ $releaseNamespace }} {{ $kafkaFullname }}-controller
+    {{- end }}
+    {{- if gt (int .Values.kafka.broker.replicaCount) 0 }}
+    k8s_wait_for_statefulset {{ $releaseNamespace }} {{ $kafkaFullname }}-broker
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Updates Kafka subchart after its new major #18805 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
