### PR TITLE
[bitnami/grafana-loki] Add existingConfigmap option for Gateway component

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.11.0
+version: 2.11.1

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -203,6 +203,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.command`                               | Override default container command (useful when using custom images)                                  | `[]`                  |
 | `gateway.args`                                  | Override default container args (useful when using custom images)                                     | `[]`                  |
 | `gateway.extraArgs`                             | Additional container args (will be concatenated to args, unless diagnosticMode is enabled)            | `[]`                  |
+| `gateway.existingConfigmap`                     | Name of a ConfigMap with the NGINX configuration                                                      | `""`                  |
 | `gateway.verboseLogging`                        | Show the gateway access_log                                                                           | `false`               |
 | `gateway.replicaCount`                          | Number of Gateway replicas to deploy                                                                  | `1`                   |
 | `gateway.auth.enabled`                          | Enable basic auth                                                                                     | `false`               |

--- a/bitnami/grafana-loki/templates/_helpers.tpl
+++ b/bitnami/grafana-loki/templates/_helpers.tpl
@@ -155,6 +155,17 @@ Get the promtail configuration configmap.
 {{- end -}}
 
 {{/*
+Get the NGINX configuration configmap.
+*/}}
+{{- define "grafana-loki.gateway.configmapName" -}}
+{{- if .Values.gateway.existingConfigmap -}}
+    {{- .Values.gateway.existingConfigmap -}}
+{{- else }}
+    {{- include "grafana-loki.gateway.fullname" .  -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the promtail configuration configmap.
 */}}
 {{- define "grafana-loki.gateway.secretName" -}}

--- a/bitnami/grafana-loki/templates/gateway/configmap-http.yaml
+++ b/bitnami/grafana-loki/templates/gateway/configmap-http.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.gateway.enabled }}
+{{- if and .Values.gateway.enabled (not .Values.gateway.existingConfigmap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/grafana-loki/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-loki/templates/gateway/deployment.yaml
@@ -163,7 +163,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "grafana-loki.gateway.fullname" . }}
+            name: {{ include "grafana-loki.gateway.configmapName" . }}
       {{- if .Values.gateway.auth.enabled }}
         - name: htpasswd
           secret:

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -634,6 +634,11 @@ gateway:
   ## @param gateway.extraArgs Additional container args (will be concatenated to args, unless diagnosticMode is enabled)
   ##
   extraArgs: []
+  ##
+  ## @param gateway.existingConfigmap Name of a ConfigMap with the NGINX configuration
+  ##
+  existingConfigmap: ""
+  ##
   ## @param gateway.verboseLogging Show the gateway access_log
   ##
   verboseLogging: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Adds the ability to use an existing configMap for the Gateway component

### Benefits

<!-- What benefits will be realized by the code change? -->
Able to adjust NGINX configurations without worry of overwriting the next time the HELM chart is deployed

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/18846

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
