### PR TITLE
[bitnami/kafka] Fixed the issue of Helm deployment failure caused by errors in kafka/template/broker/svc-headless.yaml when enabling Kafka broker-only mode.

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 25.1.1
+version: 25.1.2

--- a/bitnami/kafka/templates/broker/svc-headless.yaml
+++ b/bitnami/kafka/templates/broker/svc-headless.yaml
@@ -33,6 +33,6 @@ spec:
       targetPort: client
   {{- $podLabels := merge .Values.broker.podLabels .Values.commonLabels }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
-      app.kubernetes.io/component: broker
+    app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: kafka
 {{- end }}


### PR DESCRIPTION
### Description of the change

- Delete a tab in bitnami/kafka/templates/broker/svc-headless.yaml,line 36.

### Benefits

- It enables Kafka broker-only mode to be enabled successfully instead of encountering an error: the conversion of svc-headless.yaml from YAML to JSON fails.

### Possible drawbacks

- Unknown

### Applicable issues

- Fixes 

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
