### PR TITLE
[bitnami/kubeapps] Update Redis' subchart

### DIFF
--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.17.0
+  version: 18.0.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.10.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.9.0
-digest: sha256:3ba5f8102fb2dc78f8f8548a6b94be3a092339dd2c2dc9e371af246f90c8a1a5
-generated: "2023-08-25T16:43:04.357891808Z"
+digest: sha256:54c3d9f9665fe6dfc9a5b6e550c8d17b50fcc2cfbe24c4fb7ba4e236ff5f2b70
+generated: "2023-08-28T10:09:06.019122255+02:00"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
 - condition: packaging.flux.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.x.x
+  version: 18.x.x
 - condition: packaging.helm.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -50,4 +50,4 @@ maintainers:
 name: kubeapps
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 12.4.12
+version: 13.0.0

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -658,6 +658,12 @@ helm upgrade $RELEASE_NAME oci://registry-1.docker.io/bitnamicharts/kubeapps
 
 If you find issues upgrading Kubeapps, check the [troubleshooting](#error-while-upgrading-the-chart) section.
 
+### To 13.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 18.0.0. [Here](https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1800) you can find more information about the changes introduced in that version.
+
+NOTE: Due to an error in our release process, Redis&reg;' chart versions higher or equal than 17.15.4 already use Redis&reg; 7.2 by default.
+
 ### To 12.0.0
 
 This major updates the PostgreSQL subchart to its newest major, 12.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#to-1200) you can find more information about the changes introduced in that version.


### PR DESCRIPTION
### Description of the change

Update Redis' subchart.

### Benefits

Update Redis subchart, and notify about an issue in the release process with the previous version of this subchart.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
