### PR TITLE
[bitnami/matomo] Expand configuration with smtpAuth and noreply values

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 2.1.0
+version: 2.2.0

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -112,11 +112,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccountName`                    | Attach serviceAccountName to the pod and sidecars                                                                     | `""`                   |
 | `tolerations`                           | Tolerations for pod assignment                                                                                        | `[]`                   |
 | `existingSecret`                        | Name of a secret with the application password                                                                        | `""`                   |
+| `smtpAuth`                              | SMTP authentication mechanism (options: Plain, Login, Crammd5)                                                        | `""`                   |
 | `smtpHost`                              | SMTP host                                                                                                             | `""`                   |
 | `smtpPort`                              | SMTP port                                                                                                             | `""`                   |
 | `smtpUser`                              | SMTP user                                                                                                             | `""`                   |
 | `smtpPassword`                          | SMTP password                                                                                                         | `""`                   |
 | `smtpProtocol`                          | SMTP Protocol (options: ssl,tls, nil)                                                                                 | `""`                   |
+| `noreplyName`                           | Noreply name                                                                                                          | `""`                   |
+| `noreplyAddress`                        | Noreply address                                                                                                       | `""`                   |
 | `smtpExistingSecret`                    | The name of an existing secret with SMTP credentials                                                                  | `""`                   |
 | `containerPorts`                        | Container ports                                                                                                       | `{}`                   |
 | `persistence.enabled`                   | Enable persistence using PVC                                                                                          | `true`                 |

--- a/bitnami/matomo/templates/deployment.yaml
+++ b/bitnami/matomo/templates/deployment.yaml
@@ -187,6 +187,10 @@ spec:
               value: {{ .Values.matomoWebsiteName | quote }}
             - name: MATOMO_WEBSITE_HOST
               value: {{ .Values.matomoWebsiteHost | quote }}
+            {{- if .Values.smtpAuth -}}
+            - name: MATOMO_SMTP_AUTH
+              value: {{ .Values.smtpAuth | quote }}
+            {{- end }}
             {{- if .Values.smtpHost }}
             - name: MATOMO_SMTP_HOST
               value: {{ .Values.smtpHost | quote }}
@@ -209,6 +213,14 @@ spec:
             {{- if .Values.smtpProtocol }}
             - name: MATOMO_SMTP_PROTOCOL
               value: {{ .Values.smtpProtocol | quote }}
+            {{- end }}
+            {{- if .Values.noreplyAddress }}
+            - name: MATOMO_NOREPLY_ADDRESS
+              value: {{ .Values.noreplyAddress | quote }}
+            {{- end }}
+            {{- if .Values.noreplyName }}
+            - name: MATOMO_NOREPLY_NAME
+              value: {{ .Values.noreplyName | quote }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -197,17 +197,23 @@ tolerations: []
 existingSecret: ""
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo/#smtp-configuration
+## @param smtpAuth SMTP authentication mechanism (options: Plain, Login, Crammd5)
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
 ## @param smtpPassword SMTP password
 ## @param smtpProtocol SMTP Protocol (options: ssl,tls, nil)
+## @param noreplyName Noreply name
+## @param noreplyAddress Noreply address
 ##
+smtpAuth: ""
 smtpHost: ""
 smtpPort: ""
 smtpUser: ""
 smtpPassword: ""
 smtpProtocol: ""
+noreplyName: ""
+noreplyAddress: "" 
 ## @param smtpExistingSecret The name of an existing secret with SMTP credentials
 ## NOTE: Must contain key `smtp-password`
 ## NOTE: When it's set, the `smtpPassword` parameter is ignored


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The changes adds the option to set three environment variables relating to mail configuration:
```
MATOMO_SMTP_AUTH
MATOMO_NOREPLY_ADDRESS
MATOMO_NOREPLY_NAME
```
The values can now be set in the chart by setting the following values respectively:
```
smtpAuth
noreplyAddress
noreplyName
```
### Benefits

<!-- What benefits will be realized by the code change? -->
It allows the configuration of these variables without having to use a workaround.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #18740 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
