### PR TITLE
[bitnami/grafana-operator] Add functionality to pass the env list as implemented in CRD

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.4.0
+version: 3.5.0

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -220,6 +220,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.affinity`                                          | Affinity for controller pod assignment                                                                  | `{}`                     |
 | `grafana.nodeSelector`                                      | Node labels for controller pod assignment                                                               | `{}`                     |
 | `grafana.tolerations`                                       | Tolerations for controller pod assignment                                                               | `[]`                     |
+| `grafana.env`                                               | it is environment variable to pass to the running container                                             | `[]`                     |
 | `grafana.envFrom`                                           | Extra environment variable to pass to the running container                                             | `[]`                     |
 | `grafana.client.timeout`                                    | The timeout in seconds for the Grafana Rest API on that instance                                        | `5`                      |
 | `grafana.labels`                                            | Add additional labels to the grafana deployment, service and ingress resources                          | `{}`                     |

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -113,6 +113,9 @@ spec:
             - name: grafana
               image: {{ include "common.images.image" (dict "imageRoot" .Values.grafana.image "global" .Values.global) }}
               imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+              {{- if .Values.grafana.env }}
+              env: {{- toYaml .Values.grafana.env | nindent 16 }}
+              {{- end }}
               {{- if .Values.grafana.envFrom }}
               envFrom: {{- toYaml .Values.grafana.envFrom | nindent 16 }}
               {{- end }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -552,6 +552,21 @@ grafana:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
+  ## @param grafana.env it is environment variable to pass to the running container
+  ## e.g:
+  ## env:
+  ##   - name: GF_SECURITY_ADMIN_USER
+  ##     valueFrom:
+  ##       secretKeyRef:
+  ##         key: GF_SECURITY_ADMIN_USER
+  ##         name: credentials
+  ##   - name: GF_SECURITY_ADMIN_PASSWORD
+  ##     valueFrom:
+  ##       secretKeyRef:
+  ##         key: GF_SECURITY_ADMIN_PASSWORD
+  ##         name: credentials
+  ##
+  env: []
   ## @param grafana.envFrom Extra environment variable to pass to the running container
   ## Ref: https://github.com/integr8ly/grafana-operator/blob/master/documentation/deploy_grafana.md#configuring-the-deployment
   ## e.g:


### PR DESCRIPTION
### Description of the change

Introduced the capability to pass custom environment variables to the Grafana container via `values.yaml` and made corresponding updates in `grafana.yaml` to apply these environment variables.

### Benefits

Users can now specify custom environment variables for the Grafana container. This can be useful for configuring and tweaking various aspects of Grafana, such as setting the admin credentials via Kubernetes secrets.

### Possible drawbacks

No known drawbacks or limitations for this feature at this time.

### Applicable issues

N/A

### Additional information

New parameters have been added to `values.yaml` to configure environment variables for the Grafana container, along with the logic to apply them in `grafana.yaml`.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)