### PR TITLE
[bitnami/redis] expose service binding with correct uri

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 18.0.1
+version: 18.0.2

--- a/bitnami/redis/templates/secret-svcbind.yaml
+++ b/bitnami/redis/templates/secret-svcbind.yaml
@@ -30,7 +30,7 @@ data:
   port: {{ print $port | b64enc | quote }}
   password: {{ print $password | b64enc | quote }}
   {{- if $password }}
-  uri: {{ printf "redis://%s@%s:%s" $password $host $port | b64enc | quote }}
+  uri: {{ printf "redis://:%s@%s:%s" $password $host $port | b64enc | quote }}
   {{- else }}
   uri: {{ printf "redis://%s:%s" $host $port | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

Redis URI format should be like "redis://user:secret@localhost:6379/0?foo=bar&qux=baz"

The "userinfo" part should be "user:secret".

Since user part is empty, the uri will have to leave a colon then concatenate with the secret.

ref: https://www.iana.org/assignments/uri-schemes/prov/redis

### Benefits

Change uri format to match the RFC so that other applications follows the RFC can connect to redis service by the uri directly.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
