### PR TITLE
[bitnami/supabse]: fix studio ingress annotations

### DIFF
--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: supabase
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 0.4.0
+version: 0.4.1

--- a/bitnami/supabase/templates/studio/ingress.yaml
+++ b/bitnami/supabase/templates/studio/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: studio
   {{- if or .Values.studio.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.auth.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := merge .Values.studio.ingress.annotations .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR fixes a but introduced at https://github.com/bitnami/charts/pull/18751 on the Studio ingress annotations.

### Benefits

Users can properly customize studio ingress annotations.

### Possible drawbacks

None

### Applicable issues

- fixes #18921

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
