### PR TITLE
[bitnami/clickhouse] Add distibuteReplicasByZone parameter for schedule shard replicas to different AZ

### DIFF
--- a/bitnami/clickhouse/Chart.lock
+++ b/bitnami/clickhouse/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 11.4.11
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:55b494b839c8ea02a7754c61e80794e3bb3de1cb3a1600cf2abe361d7a9156b3
-generated: "2023-08-23T15:56:41.338771+02:00"
+  version: 2.9.1
+digest: sha256:f98087d52bd1405d582f5a01ff6569c43adb1f6e30a1571ef0636b6329643329
+generated: "2023-08-30T13:52:16.779367141+03:00"

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.7.1
+version: 3.7.2

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -98,6 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.debug`                                       | Enable ClickHouse image debug mode                                                                         | `false`               |
 | `shards`                                            | Number of ClickHouse shards to deploy                                                                      | `2`                   |
 | `replicaCount`                                      | Number of ClickHouse replicas per shard to deploy                                                          | `3`                   |
+| `distibuteReplicasByZone`                           | Schedules replicas of the same shard to different availability zones                                       | `false`               |
 | `containerPorts.http`                               | ClickHouse HTTP container port                                                                             | `8123`                |
 | `containerPorts.https`                              | ClickHouse HTTPS container port                                                                            | `8443`                |
 | `containerPorts.tcp`                                | ClickHouse TCP container port                                                                              | `9000`                |

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.podAffinityPreset "component" "clickhouse" "customLabels" $podLabels "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.podAntiAffinityPreset "component" "clickhouse" "customLabels" $podLabels "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.podAntiAffinityPreset "component" "clickhouse" "customLabels" $podLabels "extraPodAffinityTerms" (ternary (list (dict "extraMatchLabels" (dict "shard" $i) "topologyKey" "topology.kubernetes.io/zone")) (list) $.Values.distibuteReplicasByZone) "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $.Values.nodeAffinityPreset.type "key" $.Values.nodeAffinityPreset.key "values" $.Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if $.Values.nodeSelector }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -105,6 +105,10 @@ shards: 2
 ## if keeper enable, same as keeper count, keeper cluster by shards.
 ##
 replicaCount: 3
+
+## @param distibuteReplicasByZone Schedules replicas of the same shard to different availability zones
+##
+distibuteReplicasByZone: false
 ## @param containerPorts.http ClickHouse HTTP container port
 ## @param containerPorts.https ClickHouse HTTPS container port
 ## @param containerPorts.tcp ClickHouse TCP container port


### PR DESCRIPTION
### Description of the change

Adds a distibuteReplicasByZone parameter which allows to create [extraPodAffinityTerms](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_affinities.tpl#L99) 

### Benefits

Allows to create additional podAntiAffinity term for each clickhouse shard (described by statefulset) which schedule each replica of the same shard to separate availability zone. This will increase cluster accessibility in case of AZ failure.
```
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                app.kubernetes.io/component: clickhouse
                app.kubernetes.io/instance: clickhouse-bitnami
                app.kubernetes.io/name: clickhouse
            topologyKey: kubernetes.io/hostname
          - labelSelector:
              matchLabels:
                app.kubernetes.io/component: clickhouse
                app.kubernetes.io/instance: clickhouse-bitnami
                app.kubernetes.io/name: clickhouse
                shard: "0"
            topologyKey: topology.kubernetes.io/zone
```
### Possible drawbacks

--

### Applicable issues

--

### Additional information

--

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
