### PR TITLE
[bitnami/grafana-tempo] Fixed incorrect indent in servicemonitor labels

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-tempo
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 2.4.0
+version: 2.4.1

--- a/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: compactor
+    app.kubernetes.io/component: compactor
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: distributor
+    app.kubernetes.io/component: distributor
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: ingester
+    app.kubernetes.io/component: ingester
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/metrics-generator/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: metrics-generator
+    app.kubernetes.io/component: metrics-generator
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: querier
+    app.kubernetes.io/component: querier
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/component: query-frontend
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
-     app.kubernetes.io/component: vulture
+    app.kubernetes.io/component: vulture
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes an indent issue introduced in the PR https://github.com/bitnami/charts/pull/18509 which prevents servicemonitors being deployed for Grafana Tempo

### Benefits

N/A

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

Issue only occurs if `metrics.serviceMonitor.enabled: true`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
