### PR TITLE
[bitnami/minio] Add `disableVersioning` flag for provisioning unversioned buckets

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: minio
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 12.8.1
+version: 12.8.2

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -194,9 +194,11 @@ spec:
               {{- end }}
 
               {{- if $isDistributedMode }}
+              {{- if not $bucket.disableVersioning }}
               {{- if (or ((empty $bucket.withLock)) (not $bucket.withLock)) }}
               {{- $versioning := ternary ("enable") ("suspend") (and (not (empty $bucket.versioning)) $bucket.versioning) }}
               mc version {{ $versioning }} {{ $minioAlias }}/{{ $bucket.name }};
+              {{- end }}
               {{- end }}
               {{- end }}
 

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -351,7 +351,12 @@ provisioning:
   ##     region: us-east-1
   ##     # Only when mode is 'distributed'
   ##     # ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+  ##     # `versioning: false` corresponds to "suspended" versioning, not to be confused with "unversioned"
   ##     versioning: false
+  ##     # Set `disableVersioning` to `true` to leave the provisioned bucket unversioned.
+  ##     # This will have no effect if the bucket had previously been provisioned with
+  ##     # versioning enabled or suspended, as versioning cannot be disabled once enabled.
+  ##     disableVersioning: false
   ##     # Versioning is automatically enabled if withLock is true
   ##     # ref: https://docs.min.io/docs/minio-bucket-versioning-guide.html
   ##     withLock: true


### PR DESCRIPTION
### Description of the change

It isn't currently possible to provision unversioned buckets from the Helm chart. In MinIO, bucket versioning can be in three states: `versioned`, `suspended`, and `unversioned`. The Helm chart's existing `bucket.versioning` field is a boolean, and so it only allows buckets to be provisioned with `suspended` or `versioned` versioning statuses. It's desirable to be able to provision unversioned buckets, as otherwise, folders/prefixes are not automatically deleted when their contents are deleted.

This PR adds a `disableVersioning` flag to the MinIO bucket provisioning logic. If set to `true`, provisioned buckets will be left unversioned.

I verified the following by deploying to Minikube:
- With `disableVersioning: false` and `versioning: false`, provisioned buckets have a "suspended" versioning status. This is the same behavior as before.
- With `disableVersioning` not specified at all in the bucket configuration and `versioning: false`, provisioned buckets have a "suspended" versioning status. This is the same behavior as before, and verifies that this won't be a breaking change.
- With `disableVersioning: true`, `mc version info myminio/bucket-name` reports an "unversioned" versioning status, as desired.


### Benefits

Clients will be able to provision unversioned buckets.

### Possible drawbacks

It's confusing to have two similarly named parameters, `disableVersioning` and `versioning`, which at face value should be doing the same thing. In a perfect world, `versioning` would be an enum with three possible values (`unversioned`, `suspended`, and `versioned`), but changing it now would constitute a breaking change. I tried to add comments to help clear this up. I'm open to suggestions!

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
