### PR TITLE
[bitnami/keycloak] fix on metadata templating for keycloakConfigCliJob

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 16.1.1
+version: 16.1.2

--- a/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
+++ b/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ printf "%s-keycloak-config-cli" (tpl "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-keycloak-config-cli" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: keycloak-config-cli


### PR DESCRIPTION
### Description of the change

With the version 16.0.3 of the chart, the templating of the metadata.name field of templates/keycloak-config-cli-job.yaml is incorrect:

```yaml
# Source: keycloak/templates/keycloak-config-cli-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: common.names.fullname-keycloak-config-cli
```

The common.names.fullname value is not templated.

### Benefits

The name is correctly templated: 

```yaml
# Source: keycloak/templates/keycloak-config-cli-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-keycloak-keycloak-config-cli
```

With a truncate to 63 characters if we use a name too long, for example:
```yaml
{{- if .Values.keycloakConfigCli.enabled }}
apiVersion: batch/v1
kind: Job
metadata:
  name: {{ printf "%s-keycloak-config-cli-keycloak-config-cli-keycloak-config-cli-keycloak-config-cli" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
```

We get a truncated string:

```yaml
# Source: keycloak/templates/keycloak-config-cli-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-keycloak-keycloak-config-cli-keycloak-config-cli-k
```

### Possible drawbacks

I don't see any regression

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
