### PR TITLE
[bitnami/flux] Update runtime-params to support Openshift

### DIFF
--- a/.vib/flux/runtime-parameters.yaml
+++ b/.vib/flux/runtime-parameters.yaml
@@ -135,6 +135,10 @@ extraDeploy:
         fullnameOverride: vib-dokuwiki
         persistence:
           enabled: false
+        podSecurityContext:
+          enabled: false
+        containerSecurityContext:
+          enabled: false
   # This is for image-notification-controller. We will use the metrics to ensure that it is consumed
   # and therefore RBAC is correct. The values do not need to be correct
   # Source: https://fluxcd.io/flux/components/notification/receiver/

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: flux
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 0.4.0
+version: 0.4.1

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: flux
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 0.4.1
+version: 0.4.0


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR modifies the `HelmRelease` extraDeploy to disable `podSecurityContext/containerSecurityContext` for the `bitnami/dokuwiki` chart. This is done to support internal OpenShift testing and does not change the testing env in any way. 

> Note: Given the `runtime-parameters.yaml` complexity, modifying the runtimes here instead of internally is preferred.

### Benefits

None to GH repo usage

### Possible drawbacks

None

### Applicable issues

None

### Additional information

Successful execution [here](https://github.com/bitnami/charts/actions/runs/6040096071/job/16390381897?pr=18963).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
