### PR TITLE
[bitnami/grafana-operator]: fix ingress annotations

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.4.0
+version: 3.4.1

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -183,8 +183,8 @@ spec:
     metadata:
       {{- $labels := merge .Values.grafana.ingress.labels .Values.grafana.labels .Values.commonLabels }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 8 }}
-      {{- if or .Values.commonAnnotations .Values.grafana.persistence.annotations }}
-      {{- $annotations := merge .Values.grafana.persistence.annotations .Values.commonAnnotations }}
+      {{- if or .Values.commonAnnotations .Values.grafana.ingress.annotations }}
+      {{- $annotations := merge .Values.grafana.ingress.annotations .Values.commonAnnotations }}
       annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 8 }}
       {{- end }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

This PR ensures we use the correct chart value for rendering the ingress annotations to use for Grafana.

### Benefits

Users can set custom ingress annotations for Grafana.

### Possible drawbacks

None

### Applicable issues

- fixes #18249

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
