### PR TITLE
[bitnami/redis-cluster] Allow use 0 value for cluster.update.currentNumberOfReplicas

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 9.0.1
+version: 9.0.2

--- a/bitnami/redis-cluster/templates/_helpers.tpl
+++ b/bitnami/redis-cluster/templates/_helpers.tpl
@@ -218,7 +218,7 @@ redis-cluster: newExternalIPs
 redis-cluster: currentNumberOfNodes
     You must provide the currentNumberOfNodes to perform an upgrade when not using external access.
     {{- end -}}
-    {{- if not .Values.cluster.update.currentNumberOfReplicas -}}
+    {{- if kindIs "invalid" .Values.cluster.update.currentNumberOfReplicas -}}
 redis-cluster: currentNumberOfReplicas
     You must provide the currentNumberOfReplicas to perform an upgrade when not using external access.
     {{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Allow use 0 value for `cluster.update.currentNumberOfReplicas`.

### Benefits

This will allow resizing multimaster cluster (which doesn't have replicas, master nodes only) as expected.

### Possible drawbacks

N/A

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/18960

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
