### PR TITLE
[bitnami/logstash] fix: add namespace under the kubectl port-forward logstash chart

### DIFF
--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: logstash
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/logstash
-version: 5.5.0
+version: 5.5.1

--- a/bitnami/logstash/templates/NOTES.txt
+++ b/bitnami/logstash/templates/NOTES.txt
@@ -53,7 +53,7 @@ To access Logstash from outside the cluster execute the following commands:
 {{- else if contains "ClusterIP" .Values.service.type }}
 
     export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }})
-    kubectl port-forward svc/{{ include "common.names.fullname" . }} ${SERVICE_PORT}:${SERVICE_PORT} &
+    kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "common.names.fullname" . }} ${SERVICE_PORT}:${SERVICE_PORT} &
     echo "http://127.0.0.1:${SERVICE_PORT}"
 
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add namespace under the kubectl port-forward logstash chart

### Additional information

When you deploy the Logstash helm chart, the `port-forward` in the notes does not take into consideration the namespace the chart has been deployed.

This is the current output:
```bash
Logstash can be accessed through following DNS names from within your cluster:
    Logstash: logstash.logstash.svc.cluster.local
To access Logstash from outside the cluster execute the following commands:
    export SERVICE_PORT=$(kubectl get --namespace logstash -o jsonpath="{.spec.ports[0].port}" services logstash)
    kubectl port-forward svc/logstash ${SERVICE_PORT}:${SERVICE_PORT} &
    echo "http://127.0.0.1:$/{SERVICE_PORT}"
```
   
 Expected output with namespace consideration:
 
```bash
 Logstash can be accessed through following DNS names from within your cluster:
    Logstash: logstash.logstash.svc.cluster.local
To access Logstash from outside the cluster execute the following commands:
    export SERVICE_PORT=$(kubectl get --namespace logstash -o jsonpath="{.spec.ports[0].port}" services logstash)
    kubectl --namespace logstash port-forward svc/logstash ${SERVICE_PORT}:${SERVICE_PORT} &
    echo "http://127.0.0.1:$/{SERVICE_PORT}"
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
