### PR TITLE
[bitnami/clickhouse] Set Zookeeper 3.8.x as subchart

### DIFF
--- a/.vib/clickhouse/ginkgo/clickhouse_suite_test.go
+++ b/.vib/clickhouse/ginkgo/clickhouse_suite_test.go
@@ -32,7 +32,7 @@ func init() {
 	flag.StringVar(&username, "username", "", "database user")
 	flag.StringVar(&password, "password", "", "database password for username")
 	flag.IntVar(&shards, "shards", 2, "number of shards")
-	flag.IntVar(&timeoutSeconds, "timeout", 120, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 180, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.8.0
+version: 3.9.0

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 3.9.0
+version: 3.8.1

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -342,11 +342,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Zookeeper subchart parameters
 
-| Name                             | Description                   | Value  |
-| -------------------------------- | ----------------------------- | ------ |
-| `zookeeper.enabled`              | Deploy Zookeeper subchart     | `true` |
-| `zookeeper.replicaCount`         | Number of Zookeeper instances | `3`    |
-| `zookeeper.service.ports.client` | Zookeeper client port         | `2181` |
+| Name                             | Description                                          | Value                 |
+| -------------------------------- | ---------------------------------------------------- | --------------------- |
+| `zookeeper.enabled`              | Deploy Zookeeper subchart                            | `true`                |
+| `zookeeper.replicaCount`         | Number of Zookeeper instances                        | `3`                   |
+| `zookeeper.service.ports.client` | Zookeeper client port                                | `2181`                |
+| `zookeeper.image.registry`       | Zookeeper image registry                             | `docker.io`           |
+| `zookeeper.image.repository`     | Zookeeper image repository                           | `bitnami/zookeeper`   |
+| `zookeeper.image.tag`            | Zookeeper image tag (immutable tags are recommended) | `3.8.2-debian-11-r40` |
+| `zookeeper.image.pullPolicy`     | Zookeeper image pull policy                          | `IfNotPresent`        |
 
 See <https://github.com/bitnami-labs/readme-generator-for-helm> to create the table.
 

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -1110,6 +1110,17 @@ externalZookeeper:
 ##
 zookeeper:
   enabled: true
+  ## Override zookeeper default image as 3.9 is not supported https://github.com/ClickHouse/ClickHouse/issues/53749
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/zookeeper
+  ## @param zookeeper.image.registry Zookeeper image registry
+  ## @param zookeeper.image.repository Zookeeper image repository
+  ## @param zookeeper.image.tag Zookeeper image tag (immutable tags are recommended)
+  ## @param zookeeper.image.pullPolicy Zookeeper image pull policy
+  image:
+    registry: docker.io
+    repository: bitnami/zookeeper
+    tag: 3.8.2-debian-11-r40
+    pullPolicy: IfNotPresent
   replicaCount: 3
   service:
     ports:


### PR DESCRIPTION
### Description of the change

Set zookeeper 3.8 image because there is an incompatibility with Zookeeper 3.9.x, see: https://github.com/ClickHouse/ClickHouse/issues/53749

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
