### PR TITLE
[bitnami/apisix]: Use merge helper

### DIFF
--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.4.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.2
-digest: sha256:2ad6c4f68129212d2e43f390dadd53e4c24c8fc7678a16d5477bd863de62bf22
-generated: "2023-09-01T22:23:54.962896305Z"
+  version: 2.10.0
+digest: sha256:c100ca0d7b1dc2763ae55f09ec1d4d708a5cccde81bb9989691811687df80308
+generated: "2023-09-05T11:31:18.260047+02:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -16,33 +16,33 @@ annotations:
 apiVersion: v2
 appVersion: 3.5.0
 dependencies:
-- name: etcd
-  repository: oci://registry-1.docker.io/bitnamicharts
-  condition: etcd.enabled
-  version: 9.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: etcd
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: etcd.enabled
+    version: 9.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Apache APISIX is high-performance, real-time API Gateway. Features load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, amongst others.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/apisix/img/apisix-stack-220x234.png
 keywords:
-- apisix
-- ingress
-- openresty
-- controller
-- http
-- web
-- www
-- reverse proxy
+  - apisix
+  - ingress
+  - openresty
+  - controller
+  - http
+  - web
+  - www
+  - reverse proxy
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: apisix
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/apisix
-- https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
-- https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 2.1.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/apisix
+  - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
+  - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
+version: 2.1.2

--- a/bitnami/apisix/templates/control-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/control-plane/dep-ds.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.controlPlane.updateStrategy }}
   {{ ternary "updateStrategy" "strategy" .Values.controlPlane.useDaemonSet }}: {{- toYaml .Values.controlPlane.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.controlPlane.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/control-plane/ingress.yaml
+++ b/bitnami/apisix/templates/control-plane/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: control-plane
   {{- if or .Values.controlPlane.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controlPlane.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/control-plane/pdb.yaml
+++ b/bitnami/apisix/templates/control-plane/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.controlPlane.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.controlPlane.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.controlPlane.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/control-plane/service-account.yaml
+++ b/bitnami/apisix/templates/control-plane/service-account.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.controlPlane.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controlPlane.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.controlPlane.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/apisix/templates/control-plane/service.yaml
+++ b/bitnami/apisix/templates/control-plane/service.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- if or .Values.controlPlane.service.annotations .Values.commonAnnotations (and .Values.controlPlane.metrics.enabled .Values.controlPlane.metrics.annotations) }}
   annotations:
     {{- if or .Values.controlPlane.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.controlPlane.service.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.service.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.controlPlane.metrics.enabled .Values.controlPlane.metrics.annotations }}
@@ -75,7 +75,7 @@ spec:
     {{- if .Values.controlPlane.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.controlPlane.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.controlPlane.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: control-plane

--- a/bitnami/apisix/templates/control-plane/servicemonitor.yaml
+++ b/bitnami/apisix/templates/control-plane/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "apisix.control-plane.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.controlPlane.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.controlPlane.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: control-plane
   {{- if or .Values.controlPlane.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controlPlane.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/control-plane/vpa.yaml
+++ b/bitnami/apisix/templates/control-plane/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: control-plane
   {{- if or .Values.controlPlane.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controlPlane.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/dashboard/deployment.yaml
+++ b/bitnami/apisix/templates/dashboard/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if not .Values.dashboard.autoscaling.hpa.enabled }}
   replicas: {{ .Values.dashboard.replicaCount }}
   {{- end }}
-  {{- $podLabels := merge .Values.dashboard.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/dashboard/ingress.yaml
+++ b/bitnami/apisix/templates/dashboard/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if or .Values.dashboard.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboard.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/dashboard/pdb.yaml
+++ b/bitnami/apisix/templates/dashboard/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.dashboard.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.dashboard.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.dashboard.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/dashboard/service-account.yaml
+++ b/bitnami/apisix/templates/dashboard/service-account.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.dashboard.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboard.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.dashboard.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/apisix/templates/dashboard/service.yaml
+++ b/bitnami/apisix/templates/dashboard/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if or .Values.dashboard.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboard.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -60,7 +60,7 @@ spec:
     {{- if .Values.dashboard.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.dashboard.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard

--- a/bitnami/apisix/templates/dashboard/vpa.yaml
+++ b/bitnami/apisix/templates/dashboard/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if or .Values.dashboard.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboard.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.dataPlane.updateStrategy }}
   {{ ternary "updateStrategy" "strategy" .Values.dataPlane.useDaemonSet }}: {{- toYaml .Values.dataPlane.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.dataPlane.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/data-plane/ingress.yaml
+++ b/bitnami/apisix/templates/data-plane/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: data-plane
   {{- if or .Values.dataPlane.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dataPlane.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/data-plane/pdb.yaml
+++ b/bitnami/apisix/templates/data-plane/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.dataPlane.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.dataPlane.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.dataPlane.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/data-plane/service-account.yaml
+++ b/bitnami/apisix/templates/data-plane/service-account.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.dataPlane.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dataPlane.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.dataPlane.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/apisix/templates/data-plane/service.yaml
+++ b/bitnami/apisix/templates/data-plane/service.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- if or .Values.dataPlane.service.annotations .Values.commonAnnotations (and .Values.dataPlane.metrics.enabled .Values.dataPlane.metrics.annotations) }}
   annotations:
     {{- if or .Values.dataPlane.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.dataPlane.service.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.service.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.dataPlane.metrics.enabled .Values.dataPlane.metrics.annotations }}
@@ -77,7 +77,7 @@ spec:
     {{- if .Values.dataPlane.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.dataPlane.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.dataPlane.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: data-plane

--- a/bitnami/apisix/templates/data-plane/servicemonitor.yaml
+++ b/bitnami/apisix/templates/data-plane/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "apisix.data-plane.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.dataPlane.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.dataPlane.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: data-plane
   {{- if or .Values.dataPlane.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dataPlane.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/data-plane/vpa.yaml
+++ b/bitnami/apisix/templates/data-plane/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: data-plane
   {{- if or .Values.dataPlane.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dataPlane.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/ingress-controller/deployment.yaml
+++ b/bitnami/apisix/templates/ingress-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.ingressController.updateStrategy }}
   strategy: {{- toYaml .Values.ingressController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.ingressController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/ingress-controller/ingress.yaml
+++ b/bitnami/apisix/templates/ingress-controller/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if or .Values.ingressController.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingressController.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/ingress-controller/pdb.yaml
+++ b/bitnami/apisix/templates/ingress-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.ingressController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.ingressController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.ingressController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/ingress-controller/service-account.yaml
+++ b/bitnami/apisix/templates/ingress-controller/service-account.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingressController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingressController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.ingressController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/apisix/templates/ingress-controller/service.yaml
+++ b/bitnami/apisix/templates/ingress-controller/service.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- if or .Values.ingressController.service.annotations .Values.commonAnnotations (and .Values.ingressController.metrics.enabled .Values.ingressController.metrics.annotations) }}
   annotations:
     {{- if or .Values.ingressController.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.ingressController.service.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.service.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.ingressController.metrics.enabled .Values.ingressController.metrics.annotations }}
@@ -64,7 +64,7 @@ spec:
     {{- if .Values.ingressController.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.ingressController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller

--- a/bitnami/apisix/templates/ingress-controller/servicemonitor.yaml
+++ b/bitnami/apisix/templates/ingress-controller/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "apisix.ingress-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.ingressController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.ingressController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if or .Values.ingressController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingressController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/apisix/templates/ingress-controller/vpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if or .Values.ingressController.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingressController.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
