### PR TITLE
[bitnami/argo-cd]: Use merge helper

### DIFF
--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.0.0
+  version: 18.0.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:d848f62f8fc5c5493859943cc8d0eacdb866e98d096d31c1134fc9a79c6adffd
-generated: "2023-08-28T09:11:53.654009859+02:00"
+  version: 2.10.0
+digest: sha256:73725b4e4d355462d60ddd1cf9e558161e69896ee5afec3c39758bf56ef6cac7
+generated: "2023-09-05T11:31:26.979019+02:00"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -16,27 +16,27 @@ annotations:
 apiVersion: v2
 appVersion: 2.8.2
 dependencies:
-- condition: redis.enabled
-  name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: redis.enabled
+    name: redis
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 18.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/argo-cd/img/argo-cd-stack-220x234.png
 keywords:
-- Continuous delivery
-- Continuous deployment
-- Devops
-- Kubernetes
+  - Continuous delivery
+  - Continuous deployment
+  - Devops
+  - Kubernetes
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: argo-cd
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 5.1.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
+version: 5.1.1

--- a/bitnami/argo-cd/templates/application-controller/deployment.yaml
+++ b/bitnami/argo-cd/templates/application-controller/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   {{- if .Values.controller.updateStrategy }}
   strategy: {{- toYaml .Values.controller.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.controller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: controller

--- a/bitnami/argo-cd/templates/application-controller/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/application-controller/metrics-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: controller
   {{- if or .Values.commonAnnotations .Values.controller.metrics.service.annotations }}
-  {{- $annotations := merge .Values.controller.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -45,7 +45,7 @@ spec:
       {{- else if eq .Values.controller.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.controller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
 {{- end }}

--- a/bitnami/argo-cd/templates/application-controller/service-account.yaml
+++ b/bitnami/argo-cd/templates/application-controller/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
   {{- if or .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/application-controller/service.yaml
+++ b/bitnami/argo-cd/templates/application-controller/service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
   {{- if or .Values.commonAnnotations .Values.controller.service.annotations }}
-  {{- $annotations := merge .Values.controller.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,6 +47,6 @@ spec:
     {{- if .Values.controller.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.controller.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.controller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/bitnami/argo-cd/templates/applicationset/deployment.yaml
+++ b/bitnami/argo-cd/templates/applicationset/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   strategy: {{- toYaml .Values.applicationSet.updateStrategy | nindent 4 }}
   {{- end }}
   selector:
-  {{- $podLabels := merge .Values.applicationSet.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: applicationSet

--- a/bitnami/argo-cd/templates/applicationset/ingress-webhook.yaml
+++ b/bitnami/argo-cd/templates/applicationset/ingress-webhook.yaml
@@ -9,7 +9,7 @@ kind: Ingress
 metadata:
   name: {{ include "argocd.applicationSet" . }}
   namespace: {{ .Release.Namespace | quote }}
-  {{- $labels := merge .Values.applicationSet.webhook.ingress.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.webhook.ingress.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: applicationSet
   {{- if or .Values.applicationSet.webhook.ingress.annotations .Values.commonAnnotations .Values.applicationSet.webhook.ingress.certManager }}
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.applicationSet.webhook.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.applicationSet.webhook.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.webhook.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/bitnami/argo-cd/templates/applicationset/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/applicationset/metrics-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: applicationSet
   {{- if or .Values.commonAnnotations .Values.applicationSet.metrics.service.annotations }}
-  {{- $annotations := merge .Values.applicationSet.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -46,7 +46,7 @@ spec:
       {{- else if eq .Values.applicationSet.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.applicationSet.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: applicationSet
 {{- end }}

--- a/bitnami/argo-cd/templates/applicationset/service-account.yaml
+++ b/bitnami/argo-cd/templates/applicationset/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: applicationSet
   {{- if or .Values.applicationSet.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.applicationSet.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.applicationSet.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/applicationset/service.yaml
+++ b/bitnami/argo-cd/templates/applicationset/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: applicationSet
   {{- if or .Values.commonAnnotations .Values.applicationSet.service.annotations }}
-  {{- $annotations := merge .Values.applicationSet.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,7 +47,7 @@ spec:
     {{- if .Values.applicationSet.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.applicationSet.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.applicationSet.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: applicationSet
 {{- end }}

--- a/bitnami/argo-cd/templates/dex/deployment.yaml
+++ b/bitnami/argo-cd/templates/dex/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.dex.updateStrategy }}
   strategy: {{- toYaml .Values.dex.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.dex.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dex.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: dex

--- a/bitnami/argo-cd/templates/dex/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/dex/metrics-svc.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dex
   {{- if or .Values.commonAnnotations .Values.dex.metrics.service.annotations }}
-  {{- $annotations := merge .Values.dex.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dex.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -45,7 +45,7 @@ spec:
       {{- else if eq .Values.dex.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.dex.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dex.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dex
 {{- end }}

--- a/bitnami/argo-cd/templates/dex/service-account.yaml
+++ b/bitnami/argo-cd/templates/dex/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dex
   {{- if or .Values.dex.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dex.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dex.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.dex.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/dex/service.yaml
+++ b/bitnami/argo-cd/templates/dex/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dex
   {{- if or .Values.commonAnnotations .Values.dex.service.annotations }}
-  {{- $annotations := merge .Values.dex.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dex.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -57,7 +57,7 @@ spec:
     {{- if .Values.dex.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.dex.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.dex.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dex.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dex
 {{- end }}

--- a/bitnami/argo-cd/templates/notifications/bots/slack/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
-  {{- $podLabels := merge .Values.bots.slack.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.bots.slack.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: notifications-slack-bot

--- a/bitnami/argo-cd/templates/notifications/bots/slack/service-account.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notifications-slack-bot
   {{- if or .Values.notifications.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.notifications.bots.slack.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notifications.bots.slack.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.notifications.bots.slack.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/notifications/bots/slack/service.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notifications-slack-bot
   {{- if or .Values.commonAnnotations .Values.notifications.bots.slack.service.annotations }}
-  {{- $annotations := merge .Values.notifications.bots.slack.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notifications.bots.slack.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,7 +47,7 @@ spec:
     {{- if .Values.notifications.bots.slack.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.notifications.bots.slack.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.bots.slack.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.bots.slack.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notifications-slack-bot
 {{ end }}

--- a/bitnami/argo-cd/templates/notifications/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
-  {{- $podLabels := merge .Values.notifications.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notifications.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: notifications

--- a/bitnami/argo-cd/templates/notifications/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/notifications/metrics-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: notifications
   {{- if or .Values.commonAnnotations .Values.notifications.metrics.service.annotations }}
-  {{- $annotations := merge .Values.notifications.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notifications.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -46,7 +46,7 @@ spec:
       {{- else if eq .Values.notifications.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.notifications.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notifications.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notifications
 {{- end }}

--- a/bitnami/argo-cd/templates/notifications/service-account.yaml
+++ b/bitnami/argo-cd/templates/notifications/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notifications
   {{- if or .Values.notifications.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.notifications.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notifications.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.notifications.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   {{- if .Values.repoServer.updateStrategy }}
   strategy: {{- toYaml .Values.repoServer.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.repoServer.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.repoServer.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: repo-server

--- a/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: repo-server
   {{- if or .Values.commonAnnotations .Values.repoServer.metrics.service.annotations }}
-  {{- $annotations := merge .Values.repoServer.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.repoServer.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -46,7 +46,7 @@ spec:
       {{- else if eq .Values.repoServer.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.repoServer.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.repoServer.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: repo-server
 {{- end }}

--- a/bitnami/argo-cd/templates/repo-server/service-account.yaml
+++ b/bitnami/argo-cd/templates/repo-server/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: repo-server
   {{- if or .Values.repoServer.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.repoServer.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.repoServer.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.repoServer.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/repo-server/service.yaml
+++ b/bitnami/argo-cd/templates/repo-server/service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: repo-server
   {{- if or .Values.commonAnnotations .Values.repoServer.service.annotations }}
-  {{- $annotations := merge .Values.repoServer.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.repoServer.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,6 +47,6 @@ spec:
     {{- if .Values.repoServer.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.repoServer.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.repoServer.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: repo-server

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   {{- if .Values.server.updateStrategy }}
   strategy: {{- toYaml .Values.server.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: server

--- a/bitnami/argo-cd/templates/server/ingress-grcp.yaml
+++ b/bitnami/argo-cd/templates/server/ingress-grcp.yaml
@@ -17,7 +17,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.server.ingressGrpc.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.server.ingressGrpc.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.ingressGrpc.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/bitnami/argo-cd/templates/server/ingress.yaml
+++ b/bitnami/argo-cd/templates/server/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.server.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.server.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/bitnami/argo-cd/templates/server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/server/metrics-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: server
   {{- if or .Values.commonAnnotations .Values.server.metrics.service.annotations }}
-  {{- $annotations := merge .Values.server.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -46,7 +46,7 @@ spec:
       {{- else if eq .Values.server.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
 {{- end }}

--- a/bitnami/argo-cd/templates/server/service-account.yaml
+++ b/bitnami/argo-cd/templates/server/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
   {{- if or .Values.server.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.server.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-cd/templates/server/service.yaml
+++ b/bitnami/argo-cd/templates/server/service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
   {{- if or .Values.commonAnnotations .Values.server.service.annotations }}
-  {{- $annotations := merge .Values.server.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -57,6 +57,6 @@ spec:
     {{- if .Values.server.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.server.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
