### PR TITLE
[bitnami/argo-workflows]: Use merge helper

### DIFF
--- a/bitnami/argo-workflows/Chart.lock
+++ b/bitnami/argo-workflows/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.9.0
+  version: 12.10.0
 - name: mysql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.12.0
+  version: 9.12.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:6a8218b0fef1571a3e7e689fcfeb08e27f3deeb9197d6680b469bccbe684f6a1
-generated: "2023-08-23T12:44:45.248405+02:00"
+  version: 2.10.0
+digest: sha256:b99b67ab21ff5ff634d68e40a42472d512d5786a3cff6c21f0d35436c598ab11
+generated: "2023-09-05T11:31:31.280845+02:00"

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -14,32 +14,32 @@ annotations:
 apiVersion: v2
 appVersion: 3.4.10
 dependencies:
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
-- condition: mysql.enabled
-  name: mysql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.x.x
+  - condition: mysql.enabled
+    name: mysql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 9.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Argo Workflows is meant to orchestrate Kubernetes jobs in parallel. It uses DAG and step-based workflows
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/argo-workflows/img/argo-workflows-stack-220x234.png
 keywords:
-- Devops
-- Kubernetes
-- Jobs
-- Continuous delivery
-- Continous deployment
+  - Devops
+  - Kubernetes
+  - Jobs
+  - Continuous delivery
+  - Continous deployment
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: argo-workflows
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 5.4.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
+version: 5.4.2

--- a/bitnami/argo-workflows/templates/controller/deployment.yaml
+++ b/bitnami/argo-workflows/templates/controller/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.controller.updateStrategy }}
   strategy: {{- toYaml .Values.controller.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.controller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: controller

--- a/bitnami/argo-workflows/templates/controller/pdb.yaml
+++ b/bitnami/argo-workflows/templates/controller/pdb.yaml
@@ -23,7 +23,7 @@ spec:
   {{- else }}
   minAvailable: 0
   {{- end }}
-  {{- $podLabels := merge .Values.controller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: controller

--- a/bitnami/argo-workflows/templates/controller/service-account.yaml
+++ b/bitnami/argo-workflows/templates/controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if or .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-workflows/templates/controller/service.yaml
+++ b/bitnami/argo-workflows/templates/controller/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if or .Values.controller.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.controller.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -56,7 +56,7 @@ spec:
     {{- if .Values.controller.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.controller.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.controller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
   sessionAffinity: None

--- a/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if or $.Values.workflows.serviceAccount.annotations $.Values.commonAnnotations }}
-  {{- $annotations := merge $.Values.workflows.serviceAccount.annotations $.Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.workflows.serviceAccount.annotations $.Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ $.Values.workflows.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-workflows/templates/server/deployment.yaml
+++ b/bitnami/argo-workflows/templates/server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.server.updateStrategy }}
   strategy: {{- toYaml .Values.server.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: server

--- a/bitnami/argo-workflows/templates/server/ingress.yaml
+++ b/bitnami/argo-workflows/templates/server/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.controller.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.controller.service.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.service.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/argo-workflows/templates/server/pdb.yaml
+++ b/bitnami/argo-workflows/templates/server/pdb.yaml
@@ -24,7 +24,7 @@ spec:
   {{- else }}
   minAvailable: 0
   {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: server

--- a/bitnami/argo-workflows/templates/server/service-account.yaml
+++ b/bitnami/argo-workflows/templates/server/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: argo-workflows
   {{- if or .Values.server.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.server.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/argo-workflows/templates/server/service.yaml
+++ b/bitnami/argo-workflows/templates/server/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if or .Values.server.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -41,6 +41,6 @@ spec:
     {{- if .Values.server.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.server.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
