### PR TITLE
[bitnami/cert-manager]: Use merge helper

### DIFF
--- a/bitnami/cert-manager/Chart.lock
+++ b/bitnami/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.2
-digest: sha256:0d1ed3ab5c6a7e3ab3bfaea47851d574aae674797326572c51719718026e1f63
-generated: "2023-09-02T03:27:22.211796126Z"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:31:39.719042+02:00"

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -16,23 +16,23 @@ annotations:
 apiVersion: v2
 appVersion: 1.12.4
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/cert-manager/img/cert-manager-stack-220x234.png
 keywords:
-- go
-- security
-- tls
-- certificate
+  - go
+  - security
+  - tls
+  - certificate
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: cert-manager
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.12.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
+version: 0.12.2

--- a/bitnami/cert-manager/templates/cainjector/deployment.yaml
+++ b/bitnami/cert-manager/templates/cainjector/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.webhook.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.webhook.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: cainjector

--- a/bitnami/cert-manager/templates/cainjector/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/cainjector/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "certmanager.cainjector.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: cainjector
-  {{- $mergedAnnotations := merge .Values.cainjector.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.cainjector.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   {{- if $mergedAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.webhook.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.webhook.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: controller

--- a/bitnami/cert-manager/templates/controller/service.yaml
+++ b/bitnami/cert-manager/templates/controller/service.yaml
@@ -18,7 +18,7 @@ spec:
       port: {{ .Values.controller.containerPort }}
       protocol: TCP
       targetPort: {{ .Values.metrics.serviceMonitor.targetPort }}
-  {{- $podLabels := merge .Values.webhook.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.webhook.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
 {{- end }}

--- a/bitnami/cert-manager/templates/controller/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/controller/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "certmanager.controller.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
-  {{- $mergedAnnotations := merge .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   {{- if $mergedAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/cert-manager/templates/controller/servicemonitor.yaml
+++ b/bitnami/cert-manager/templates/controller/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "certmanager.controller.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}

--- a/bitnami/cert-manager/templates/webhook/deployment.yaml
+++ b/bitnami/cert-manager/templates/webhook/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.webhook.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.webhook.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: webhook

--- a/bitnami/cert-manager/templates/webhook/service.yaml
+++ b/bitnami/cert-manager/templates/webhook/service.yaml
@@ -16,6 +16,6 @@ spec:
     - name: https
       port: {{ .Values.webhook.httpsPort }}
       targetPort: {{ .Values.webhook.containerPort }}
-  {{- $podLabels := merge .Values.webhook.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.webhook.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: webhook

--- a/bitnami/cert-manager/templates/webhook/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/webhook/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "certmanager.webhook.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: webhook
-  {{- $mergedAnnotations := merge .Values.webhook.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.webhook.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   {{- if $mergedAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
