### PR TITLE
[bitnami/consul]: Use merge helper

### DIFF
--- a/bitnami/consul/Chart.lock
+++ b/bitnami/consul/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T13:57:22.424227+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:31:49.603252+02:00"

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -14,22 +14,22 @@ annotations:
 apiVersion: v2
 appVersion: 1.16.1
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: HashiCorp Consul is a tool for discovering and configuring services in your infrastructure.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/consul/img/consul-stack-220x234.png
 keywords:
-- discovering
-- configuring
-- services
+  - discovering
+  - configuring
+  - services
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: consul
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 10.13.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/consul
+version: 10.13.2

--- a/bitnami/consul/templates/consul-headless-service.yaml
+++ b/bitnami/consul/templates/consul-headless-service.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.commonAnnotations .Values.service.headless.annotations }}
-  {{- $annotations := merge .Values.service.headless.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -35,6 +35,6 @@ spec:
     - name: dns-udp
       protocol: UDP
       port: {{ .Values.containerPorts.dns }}
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
   sessionAffinity: None

--- a/bitnami/consul/templates/ingress.yaml
+++ b/bitnami/consul/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/consul/templates/metrics-svc.yaml
+++ b/bitnami/consul/templates/metrics-svc.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,6 +24,6 @@ spec:
     - name: http-metrics
       port: 9107
       targetPort: metrics
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
 {{- end }}

--- a/bitnami/consul/templates/pdb.yaml
+++ b/bitnami/consul/templates/pdb.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
 {{- end }}

--- a/bitnami/consul/templates/service.yaml
+++ b/bitnami/consul/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -44,6 +44,6 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
 {{- end }}

--- a/bitnami/consul/templates/servicemonitor.yaml
+++ b/bitnami/consul/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ printf "%s-metrics" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
