### PR TITLE
[bitnami/contour]: Use merge helper

### DIFF
--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T13:58:07.074757+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:31:52.099258+02:00"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -14,22 +14,22 @@ annotations:
 apiVersion: v2
 appVersion: 1.25.2
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/contour/img/contour-stack-220x234.png
 keywords:
-- ingress
-- envoy
-- contour
+  - ingress
+  - envoy
+  - contour
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: contour
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 12.6.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/contour
+version: 12.6.1

--- a/bitnami/contour/templates/certgen/serviceaccount.yaml
+++ b/bitnami/contour/templates/certgen/serviceaccount.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    {{- $mergedAnnotations := merge .Values.contour.certgen.serviceAccount.annotations .Values.commonAnnotations }}
+    {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.certgen.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- if $mergedAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/contour/templates/certgen/serviceaccount.yaml
+++ b/bitnami/contour/templates/certgen/serviceaccount.yaml
@@ -14,8 +14,8 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if or .Values.contour.certgen.serviceAccount.annotations .Values.commonAnnotations }}
     {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.certgen.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
-    {{- if $mergedAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 automountServiceAccountToken: {{ .Values.contour.certgen.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.contour.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.podLabels .Values.commonLabels ) "context" . ) }}
   replicas: {{ .Values.contour.replicaCount }}
   {{- if .Values.contour.updateStrategy }}
   strategy: {{- toYaml .Values.contour.updateStrategy | nindent 4 }}

--- a/bitnami/contour/templates/contour/service.yaml
+++ b/bitnami/contour/templates/contour/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: contour
   {{- if or .Values.contour.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.contour.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -51,7 +51,7 @@ spec:
     {{- if .Values.contour.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.contour.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.contour.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: contour
 {{- if .Values.metrics.serviceMonitor.enabled }}
@@ -66,7 +66,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
-  {{- $podLabels := merge .Values.contour.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: contour
   ports:

--- a/bitnami/contour/templates/contour/serviceaccount.yaml
+++ b/bitnami/contour/templates/contour/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: contour
-  {{- $mergedAnnotations := merge .Values.contour.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.contour.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   {{- if $mergedAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/contour/templates/contour/servicemonitor.yaml
+++ b/bitnami/contour/templates/contour/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ printf "%s-contour" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: contour
   {{- if .Values.commonAnnotations }}

--- a/bitnami/contour/templates/default-backend/deployment.yaml
+++ b/bitnami/contour/templates/default-backend/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.defaultBackend.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.defaultBackend.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: default-backend
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       {{- if or .Values.defaultBackend.podAnnotations .Values.commonAnnotations }}
-      {{- $podAnnotations := merge .Values.defaultBackend.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.defaultBackend.podAnnotations .Values.commonAnnotations ) "context" . ) }}
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/contour/templates/default-backend/ingress.yaml
+++ b/bitnami/contour/templates/default-backend/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/contour/templates/default-backend/poddisruptionbudget.yaml
+++ b/bitnami/contour/templates/default-backend/poddisruptionbudget.yaml
@@ -24,7 +24,7 @@ spec:
   {{- if .Values.defaultBackend.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.defaultBackend.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.defaultBackend.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.defaultBackend.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: default-backend

--- a/bitnami/contour/templates/default-backend/service.yaml
+++ b/bitnami/contour/templates/default-backend/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: default-backend
   {{- if or .Values.defaultBackend.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.defaultBackend.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.defaultBackend.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -22,7 +22,7 @@ spec:
       port: {{ .Values.defaultBackend.service.ports.http }}
       protocol: TCP
       targetPort: http
-  {{- $podLabels := merge .Values.defaultBackend.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.defaultBackend.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: default-backend
 {{- end }}

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -18,14 +18,14 @@ spec:
   {{- if .Values.envoy.updateStrategy }}
   updateStrategy: {{- toYaml .Values.envoy.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.envoy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: envoy
   template:
     metadata:
       {{- if or .Values.envoy.podAnnotations .Values.commonAnnotations }}
-      {{- $podAnnotations := merge .Values.envoy.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.podAnnotations .Values.commonAnnotations ) "context" . ) }}
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -23,14 +23,14 @@ spec:
   strategy: {{- toYaml .Values.envoy.updateStrategy | nindent 4 }}
   {{- end }}
   minReadySeconds: {{ .Values.envoy.minReadySeconds }}
-  {{- $podLabels := merge .Values.envoy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: envoy
   template:
     metadata:
       {{- if or .Values.envoy.podAnnotations .Values.commonAnnotations }}
-      {{- $podAnnotations := merge .Values.envoy.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.podAnnotations .Values.commonAnnotations ) "context" . ) }}
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/contour/templates/envoy/service.yaml
+++ b/bitnami/contour/templates/envoy/service.yaml
@@ -3,14 +3,14 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $podLabels := merge .Values.envoy.podLabels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.podLabels .Values.commonLabels ) "context" . ) }}
 {{- if .Values.envoy.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ default (printf "%s-envoy" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-") .Values.envoy.service.name }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.envoy.service.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: envoy
   annotations:
@@ -25,7 +25,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     {{- end }}
     {{- if or .Values.envoy.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.envoy.service.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.service.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/contour/templates/envoy/serviceaccount.yaml
+++ b/bitnami/contour/templates/envoy/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: envoy
   {{- if or .Values.envoy.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.envoy.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.envoy.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.envoy.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/contour/templates/envoy/servicemonitor.yaml
+++ b/bitnami/contour/templates/envoy/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ printf "%s-envoy" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: envoy
   {{- if .Values.commonAnnotations }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
