### PR TITLE
[bitnami/discourse]: Use merge helper

### DIFF
--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.0.0
+  version: 18.0.2
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.10.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:df0e86075c4659dc218427bb19b64c7a406c8b1f78cdfe14720c9cf6b2dabb69
-generated: "2023-08-28T08:56:26.056118313+02:00"
+  version: 2.10.0
+digest: sha256:6e21bbca5f89823993c4986bdfa92aeb7e4ba20a5b3f57ddbdf67067bec735e7
+generated: "2023-09-05T11:31:58.200381+02:00"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -12,33 +12,33 @@ annotations:
 apiVersion: v2
 appVersion: 3.0.6
 dependencies:
-- condition: redis.enabled
-  name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.X.X
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.X.X
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: redis.enabled
+    name: redis
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 18.X.X
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.X.X
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/discourse/img/discourse-stack-220x234.png
 keywords:
-- community
-- forum
+  - community
+  - forum
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
-- email: username.taken@gmail.com
-  name: paulczar
-- email: preteluca@gmail.com
-  name: lucaprete
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
+  - email: username.taken@gmail.com
+    name: paulczar
+  - email: preteluca@gmail.com
+    name: lucaprete
 name: discourse
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 11.0.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/discourse
+version: 11.0.1

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   {{- if .Values.updateStrategy }}

--- a/bitnami/discourse/templates/ingress.yaml
+++ b/bitnami/discourse/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/discourse/templates/networkpolicy-backend-ingress.yaml
+++ b/bitnami/discourse/templates/networkpolicy-backend-ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
 {{- if and .Values.networkPolicy.enabled .Values.postgresql.enabled .Values.networkPolicy.ingressRules.backendOnlyAccessibleByFrontend }}
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy

--- a/bitnami/discourse/templates/networkpolicy-ingress.yaml
+++ b/bitnami/discourse/templates/networkpolicy-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   ingress:

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/discourse/templates/service.yaml
+++ b/bitnami/discourse/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -46,5 +46,5 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/bitnami/discourse/templates/serviceaccount.yaml
+++ b/bitnami/discourse/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
