### PR TITLE
[bitnami/elasticsearch]: Use merge helper

### DIFF
--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 10.5.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:5b4f425b55a10777388e1a6c9e3e00e09fe454e20664a36839237b63f9ff0e07
-generated: "2023-08-23T16:03:28.34726+02:00"
+  version: 2.10.0
+digest: sha256:c57e5f83ed9da0763ccd2fbac3089934c6d13198c04f14feff7e425d28104b02
+generated: "2023-09-05T11:32:12.399769+02:00"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -14,24 +14,24 @@ annotations:
 apiVersion: v2
 appVersion: 8.9.1
 dependencies:
-- condition: global.kibanaEnabled
-  name: kibana
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: global.kibanaEnabled
+    name: kibana
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 10.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Elasticsearch is a distributed search and analytics engine. It is used for web search, log monitoring, and real-time analytics. Ideal for Big Data applications.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/elasticsearch/img/elasticsearch-stack-220x234.png
 keywords:
-- elasticsearch
+  - elasticsearch
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: elasticsearch
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 19.11.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
+version: 19.11.1

--- a/bitnami/elasticsearch/templates/coordinating/pdb.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.coordinating.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.coordinating.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: coordinating-only

--- a/bitnami/elasticsearch/templates/coordinating/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: coordinating-only
   {{- if or .Values.coordinating.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.coordinating.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.coordinating.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
@@ -16,14 +16,14 @@ metadata:
     app: coordinating-only
     {{- end }}
   {{- if or .Values.coordinating.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.coordinating.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not .Values.coordinating.autoscaling.enabled }}
   replicas: {{ .Values.coordinating.replicaCount }}
   {{- end }}
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: coordinating-only

--- a/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: coordinating-only
 {{- end }}

--- a/bitnami/elasticsearch/templates/data/pdb.yaml
+++ b/bitnami/elasticsearch/templates/data/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.data.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.data.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: data

--- a/bitnami/elasticsearch/templates/data/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/data/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: data
   {{- if or .Values.data.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.data.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.data.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/elasticsearch/templates/data/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     app: data
     {{- end }}
   {{- if or .Values.data.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.data.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
   replicas: {{ .Values.data.replicaCount }}
   {{- end }}
   podManagementPolicy: {{ .Values.data.podManagementPolicy }}
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: data
@@ -340,7 +340,7 @@ spec:
     - metadata:
         name: "data"
         {{- if or .Values.data.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.data.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 10 }}
         {{- end }}
         {{- if .Values.commonLabels }}

--- a/bitnami/elasticsearch/templates/data/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/data/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: data
 {{- end }}

--- a/bitnami/elasticsearch/templates/ingest/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingest/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/elasticsearch/templates/ingest/pdb.yaml
+++ b/bitnami/elasticsearch/templates/ingest/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.ingest.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.ingest.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: ingest

--- a/bitnami/elasticsearch/templates/ingest/service.yaml
+++ b/bitnami/elasticsearch/templates/ingest/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -54,7 +54,7 @@ spec:
     {{- if .Values.ingest.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingest.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
 {{- end }}

--- a/bitnami/elasticsearch/templates/ingest/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/ingest/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.ingest.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/elasticsearch/templates/ingest/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     app: ingest
     {{- end }}
   {{- if or .Values.ingest.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
   replicas: {{ .Values.ingest.replicaCount }}
   {{- end }}
   podManagementPolicy: {{ .Values.ingest.podManagementPolicy }}
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: ingest

--- a/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
 {{- end }}

--- a/bitnami/elasticsearch/templates/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: elasticsearch
   {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/elasticsearch/templates/master/pdb.yaml
+++ b/bitnami/elasticsearch/templates/master/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.master.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.master.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: master

--- a/bitnami/elasticsearch/templates/master/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/master/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: master
   {{- if or .Values.master.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.master.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.master.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     app: master
     {{- end }}
   {{- if or .Values.master.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.master.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
   replicas: {{ .Values.master.replicaCount }}
   {{- end }}
   podManagementPolicy: {{ .Values.master.podManagementPolicy }}
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: master
@@ -340,7 +340,7 @@ spec:
     - metadata:
         name: "data"
         {{- if or .Values.master.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.master.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 10 }}
         {{- end }}
         {{- if .Values.commonLabels }}

--- a/bitnami/elasticsearch/templates/master/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/master/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: master
 {{- end }}

--- a/bitnami/elasticsearch/templates/metrics/deployment.yaml
+++ b/bitnami/elasticsearch/templates/metrics/deployment.yaml
@@ -16,12 +16,12 @@ metadata:
     app: metrics
     {{- end }}
   {{- if or .Values.metrics.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.metrics.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   replicas: 1
-  {{- $podLabels := merge .Values.metrics.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: metrics

--- a/bitnami/elasticsearch/templates/metrics/service.yaml
+++ b/bitnami/elasticsearch/templates/metrics/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -21,7 +21,7 @@ spec:
     - name: http-metrics
       port: {{ .Values.metrics.service.port }}
       targetPort: metrics
-  {{- $podLabels := merge .Values.metrics.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
 {{- end }}

--- a/bitnami/elasticsearch/templates/metrics/servicemonitor.yaml
+++ b/bitnami/elasticsearch/templates/metrics/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "elasticsearch.metrics.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if .Values.commonAnnotations }}

--- a/bitnami/elasticsearch/templates/service.yaml
+++ b/bitnami/elasticsearch/templates/service.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: master
     {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
