### PR TITLE
[bitnami/flink]: Use merge helper

### DIFF
--- a/bitnami/flink/Chart.lock
+++ b/bitnami/flink/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T14:02:33.667638+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:32:20.556029+02:00"

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -10,22 +10,22 @@ annotations:
 apiVersion: v2
 appVersion: 1.17.1
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Apache Flink is a framework and distributed processing engine for stateful computations over unbounded and bounded data streams.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/flink/img/flink-stack-220x234.png
 keywords:
-- flink
-- stream-processing
-- batch-processing
+  - flink
+  - stream-processing
+  - batch-processing
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: flink
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 0.4.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/flink
+version: 0.4.1

--- a/bitnami/flink/templates/jobmanager/deployment.yaml
+++ b/bitnami/flink/templates/jobmanager/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.jobmanager.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobmanager.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: flink
@@ -30,7 +30,7 @@ spec:
         app.kubernetes.io/part-of: flink
         app.kubernetes.io/component: jobmanager
       {{- if or .Values.jobmanager.podAnnotations .Values.commonAnnotations }}
-      {{- $podAnnotations := merge .Values.jobmanager.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobmanager.podAnnotations .Values.commonAnnotations ) "context" . ) }}
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:

--- a/bitnami/flink/templates/jobmanager/service.yml
+++ b/bitnami/flink/templates/jobmanager/service.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: flink
     app.kubernetes.io/component: jobmanager
   {{- if or .Values.jobmanager.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.jobmanager.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobmanager.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -63,7 +63,7 @@ spec:
     {{- if .Values.jobmanager.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.jobmanager.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.jobmanager.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobmanager.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flink
     app.kubernetes.io/component: jobmanager

--- a/bitnami/flink/templates/jobmanager/serviceaccount.yaml
+++ b/bitnami/flink/templates/jobmanager/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flink
     app.kubernetes.io/component: jobmanager
-  {{- $mergedAnnotations := merge .Values.jobmanager.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobmanager.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   {{- if $mergedAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/flink/templates/taskmanager/deployment.yaml
+++ b/bitnami/flink/templates/taskmanager/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.taskmanager.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.taskmanager.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: flink
@@ -30,7 +30,7 @@ spec:
         app.kubernetes.io/part-of: flink
         app.kubernetes.io/component: taskmanager
       {{- if or .Values.taskmanager.podAnnotations .Values.commonAnnotations }}
-      {{- $podAnnotations := merge .Values.taskmanager.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.taskmanager.podAnnotations .Values.commonAnnotations ) "context" . ) }}
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:

--- a/bitnami/flink/templates/taskmanager/service.yml
+++ b/bitnami/flink/templates/taskmanager/service.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: flink
     app.kubernetes.io/component: taskmanager
   {{- if or .Values.taskmanager.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.taskmanager.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.taskmanager.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -55,7 +55,7 @@ spec:
     {{- if .Values.taskmanager.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.taskmanager.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.taskmanager.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.taskmanager.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flink
     app.kubernetes.io/component: taskmanager

--- a/bitnami/flink/templates/taskmanager/serviceaccount.yaml
+++ b/bitnami/flink/templates/taskmanager/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flink
     app.kubernetes.io/component: taskmanager
-  {{- $mergedAnnotations := merge .Values.taskmanager.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.taskmanager.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   {{- if $mergedAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
