### PR TITLE
[bitnami/fluentd]: Use merge helper

### DIFF
--- a/bitnami/fluentd/Chart.lock
+++ b/bitnami/fluentd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.2
-digest: sha256:0d1ed3ab5c6a7e3ab3bfaea47851d574aae674797326572c51719718026e1f63
-generated: "2023-09-01T10:50:09.357387285Z"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:32:25.367564+02:00"

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -10,24 +10,24 @@ annotations:
 apiVersion: v2
 appVersion: 1.16.2
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Fluentd collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/fluentd/img/fluentd-stack-220x234.png
 keywords:
-- fluentd
-- logging
-- logs
-- data
-- collector
+  - fluentd
+  - logging
+  - logs
+  - data
+  - collector
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: fluentd
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 5.9.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
+version: 5.9.2

--- a/bitnami/fluentd/templates/aggregator-hpa.yaml
+++ b/bitnami/fluentd/templates/aggregator-hpa.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: aggregator
   {{- if or .Values.aggregator.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.aggregator.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -14,11 +14,11 @@ metadata:
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: aggregator
   {{- if or .Values.aggregator.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.aggregator.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.aggregator.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: aggregator

--- a/bitnami/fluentd/templates/aggregator-svc-headless.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc-headless.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: aggregator
     app: aggregator
   {{- if or .Values.commonAnnotations .Values.aggregator.service.headless.annotations .Values.aggregator.service.annotationsHeadless }}
-  {{- $annotations := merge .Values.aggregator.service.headless.annotations .Values.aggregator.service.annotationsHeadless .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.service.headless.annotations .Values.aggregator.service.annotationsHeadless .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
     - name: {{ $key }}
       {{ omit $value "nodePort" | toYaml | nindent 6 }}
   {{- end }}
-  {{- $podLabels := merge .Values.aggregator.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: aggregator
 {{- end -}}

--- a/bitnami/fluentd/templates/aggregator-svc.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: aggregator
     app: aggregator
   {{- if or .Values.commonAnnotations .Values.aggregator.service.annotations }}
-  {{- $annotations := merge .Values.aggregator.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -41,7 +41,7 @@ spec:
     - name: {{ $key }}
       {{ toYaml $value | nindent 6 }}
   {{- end }}
-  {{- $podLabels := merge .Values.aggregator.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: aggregator
 {{- end -}}

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -14,11 +14,11 @@ metadata:
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
     app: forwarder
   {{- if or .Values.forwarder.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.forwarder.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.forwarder.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.forwarder.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.forwarder.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: forwarder

--- a/bitnami/fluentd/templates/forwarder-svc.yaml
+++ b/bitnami/fluentd/templates/forwarder-svc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: forwarder
     app: forwarder
   {{- if or .Values.commonAnnotations .Values.forwarder.service.annotations }}
-  {{- $annotations := merge .Values.forwarder.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.forwarder.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -41,7 +41,7 @@ spec:
     - name: {{ $key }}
       {{ toYaml $value | nindent 6 }}
   {{- end }}
-  {{- $podLabels := merge .Values.forwarder.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.forwarder.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: forwarder
 {{- end }}

--- a/bitnami/fluentd/templates/ingress.yaml
+++ b/bitnami/fluentd/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.aggregator.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.aggregator.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/fluentd/templates/metrics-svc.yaml
+++ b/bitnami/fluentd/templates/metrics-svc.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app: metrics
   {{- if or .Values.commonAnnotations .Values.metrics.service.annotations }}
-  {{- $annotations := merge .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/fluentd/templates/serviceaccount.yaml
+++ b/bitnami/fluentd/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: forwarder
   {{- if or .Values.forwarder.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.forwarder.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.forwarder.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.forwarder.serviceAccount.automountServiceAccountToken }}
@@ -27,7 +27,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: aggregator
   {{- if or .Values.aggregator.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.aggregator.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.aggregator.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.aggregator.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/fluentd/templates/servicemonitor.yaml
+++ b/bitnami/fluentd/templates/servicemonitor.yaml
@@ -9,10 +9,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
