### PR TITLE
[bitnami/flux]: Use merge helper

### DIFF
--- a/bitnami/flux/Chart.lock
+++ b/bitnami/flux/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T14:07:35.963547+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:32:27.787365+02:00"

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -22,25 +22,25 @@ annotations:
 apiVersion: v2
 appVersion: 0.36.1
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Flux is a tool for keeping Kubernetes clusters in sync with sources of configuration
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/fluxcd-kustomize-controller/img/fluxcd-kustomize-controller-stack-220x234.png
 keywords:
-- deployment
-- gitops
-- cd
-- continuous-delivery
-- helm
-- kustomize
+  - deployment
+  - gitops
+  - cd
+  - continuous-delivery
+  - helm
+  - kustomize
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: flux
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 0.4.0
+version: 0.4.1

--- a/bitnami/flux/templates/helm-controller/deployment.yaml
+++ b/bitnami/flux/templates/helm-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.helmController.updateStrategy }}
   strategy: {{- toYaml .Values.helmController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.helmController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: helm-controller

--- a/bitnami/flux/templates/helm-controller/pdb.yaml
+++ b/bitnami/flux/templates/helm-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.helmController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.helmController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.helmController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: helm-controller

--- a/bitnami/flux/templates/helm-controller/service-account.yaml
+++ b/bitnami/flux/templates/helm-controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller
   {{- if or .Values.helmController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.helmController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.helmController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/flux/templates/helm-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/helm-controller/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller
   {{- if or .Values.helmController.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.helmController.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.helmController.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.helmController.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.helmController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: helm-controller
 {{- end }}

--- a/bitnami/flux/templates/helm-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/helm-controller/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "flux.helm-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.helmController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.helmController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller
   {{- if or .Values.helmController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.helmController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.helmController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/flux/templates/image-automation-controller/deployment.yaml
+++ b/bitnami/flux/templates/image-automation-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.imageAutomationController.updateStrategy }}
   strategy: {{- toYaml .Values.imageAutomationController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.imageAutomationController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: image-automation-controller

--- a/bitnami/flux/templates/image-automation-controller/pdb.yaml
+++ b/bitnami/flux/templates/image-automation-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.imageAutomationController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.imageAutomationController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.imageAutomationController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: image-automation-controller

--- a/bitnami/flux/templates/image-automation-controller/service-account.yaml
+++ b/bitnami/flux/templates/image-automation-controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-automation-controller
   {{- if or .Values.imageAutomationController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.imageAutomationController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.imageAutomationController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/flux/templates/image-automation-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/image-automation-controller/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-automation-controller
   {{- if or .Values.imageAutomationController.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.imageAutomationController.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.imageAutomationController.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.imageAutomationController.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.imageAutomationController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: image-automation-controller
 {{- end }}

--- a/bitnami/flux/templates/image-automation-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/image-automation-controller/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "flux.image-automation-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.imageAutomationController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.imageAutomationController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: helm-controller
   {{- if or .Values.imageAutomationController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.imageAutomationController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageAutomationController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/flux/templates/image-reflector-controller/deployment.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.imageReflectorController.updateStrategy }}
   strategy: {{- toYaml .Values.imageReflectorController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.imageReflectorController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: image-reflector-controller

--- a/bitnami/flux/templates/image-reflector-controller/pdb.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.imageReflectorController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.imageReflectorController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.imageReflectorController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: image-reflector-controller

--- a/bitnami/flux/templates/image-reflector-controller/pvc.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/pvc.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/resource-policy: {{ .Values.imageReflectorController.persistence.resourcePolicy | quote }}
     {{- end }}
     {{- if or .Values.imageReflectorController.serviceAccount.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.imageReflectorController.serviceAccount.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/flux/templates/image-reflector-controller/service-account.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
   {{- if or .Values.imageReflectorController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.imageReflectorController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.imageReflectorController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/flux/templates/image-reflector-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
   {{- if or .Values.imageReflectorController.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.imageReflectorController.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.imageReflectorController.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.imageReflectorController.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.imageReflectorController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: image-reflector-controller
 {{- end }}

--- a/bitnami/flux/templates/image-reflector-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "flux.image-reflector-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.imageReflectorController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.imageReflectorController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: image-reflector-controller
   {{- if or .Values.imageReflectorController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.imageReflectorController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageReflectorController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/flux/templates/kustomize-controller/deployment.yaml
+++ b/bitnami/flux/templates/kustomize-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.kustomizeController.updateStrategy }}
   strategy: {{- toYaml .Values.kustomizeController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.kustomizeController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: kustomize-controller

--- a/bitnami/flux/templates/kustomize-controller/pdb.yaml
+++ b/bitnami/flux/templates/kustomize-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.kustomizeController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.kustomizeController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.kustomizeController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: kustomize-controller

--- a/bitnami/flux/templates/kustomize-controller/service-account.yaml
+++ b/bitnami/flux/templates/kustomize-controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: kustomize-controller
   {{- if or .Values.kustomizeController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.kustomizeController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.kustomizeController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/flux/templates/kustomize-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/kustomize-controller/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: kustomize-controller
   {{- if or .Values.kustomizeController.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.kustomizeController.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.kustomizeController.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.kustomizeController.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.kustomizeController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kustomize-controller
 {{- end }}

--- a/bitnami/flux/templates/kustomize-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/kustomize-controller/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "flux.kustomize-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.kustomizeController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.kustomizeController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: kustomize-controller
   {{- if or .Values.kustomizeController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.kustomizeController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kustomizeController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/flux/templates/notification-controller/deployment.yaml
+++ b/bitnami/flux/templates/notification-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.notificationController.updateStrategy }}
   strategy: {{- toYaml .Values.notificationController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.notificationController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: notification-controller

--- a/bitnami/flux/templates/notification-controller/pdb.yaml
+++ b/bitnami/flux/templates/notification-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.notificationController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.notificationController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.notificationController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: notification-controller

--- a/bitnami/flux/templates/notification-controller/service-account.yaml
+++ b/bitnami/flux/templates/notification-controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
   {{- if or .Values.notificationController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.notificationController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.notificationController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/flux/templates/notification-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/notification-controller/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
   {{- if or .Values.notificationController.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.notificationController.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.notificationController.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.notificationController.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.notificationController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notification-controller
 {{- end }}

--- a/bitnami/flux/templates/notification-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/notification-controller/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "flux.notification-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.notificationController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.notificationController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: notification-controller
   {{- if or .Values.notificationController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.notificationController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.notificationController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/flux/templates/source-controller/deployment.yaml
+++ b/bitnami/flux/templates/source-controller/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.sourceController.updateStrategy }}
   strategy: {{- toYaml .Values.sourceController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.sourceController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: source-controller

--- a/bitnami/flux/templates/source-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/source-controller/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.sourceController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: source-controller

--- a/bitnami/flux/templates/source-controller/pdb.yaml
+++ b/bitnami/flux/templates/source-controller/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.sourceController.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.sourceController.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.sourceController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: source-controller

--- a/bitnami/flux/templates/source-controller/pvc.yaml
+++ b/bitnami/flux/templates/source-controller/pvc.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/resource-policy: {{ .Values.sourceController.persistence.resourcePolicy | quote }}
     {{- end }}
     {{- if or .Values.sourceController.serviceAccount.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.sourceController.serviceAccount.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/flux/templates/source-controller/service-account.yaml
+++ b/bitnami/flux/templates/source-controller/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
   {{- if or .Values.sourceController.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.sourceController.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.sourceController.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/flux/templates/source-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/source-controller/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
   {{- if or .Values.sourceController.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.sourceController.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.sourceController.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.sourceController.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.sourceController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: source-controller
 {{- end }}

--- a/bitnami/flux/templates/source-controller/service.yaml
+++ b/bitnami/flux/templates/source-controller/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
   {{- if or .Values.sourceController.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.sourceController.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.sourceController.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.sourceController.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.sourceController.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: source-controller
 {{- end }}

--- a/bitnami/flux/templates/source-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/source-controller/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "flux.source-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.sourceController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.sourceController.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}    app.kubernetes.io/part-of: flux
     app.kubernetes.io/component: source-controller
   {{- if or .Values.sourceController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.sourceController.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.sourceController.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
