### PR TITLE
[bitnami/grafana]: Use merge helper

### DIFF
--- a/bitnami/grafana/Chart.lock
+++ b/bitnami/grafana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.2
-digest: sha256:0d1ed3ab5c6a7e3ab3bfaea47851d574aae674797326572c51719718026e1f63
-generated: "2023-09-01T03:32:03.321524921Z"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:32:37.595674+02:00"

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -14,23 +14,23 @@ annotations:
 apiVersion: v2
 appVersion: 10.1.1
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Grafana is an open source metric analytics and visualization suite for visualizing time series data that supports various types of data sources.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
 keywords:
-- analytics
-- monitoring
-- metrics
-- logs
+  - analytics
+  - monitoring
+  - metrics
+  - logs
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: grafana
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 9.1.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/grafana
+version: 9.1.2

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.grafana.replicaCount }}
-  {{- $podLabels := merge .Values.grafana.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.grafana.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: grafana

--- a/bitnami/grafana/templates/image-renderer-deployment.yaml
+++ b/bitnami/grafana/templates/image-renderer-deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.imageRenderer.updateStrategy }}
   strategy: {{- toYaml .Values.imageRenderer.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.imageRenderer.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageRenderer.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: image-renderer

--- a/bitnami/grafana/templates/image-renderer-service.yaml
+++ b/bitnami/grafana/templates/image-renderer-service.yaml
@@ -51,7 +51,7 @@ spec:
     {{- if .Values.imageRenderer.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.imageRenderer.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.imageRenderer.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageRenderer.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: image-renderer
 {{- end }}

--- a/bitnami/grafana/templates/image-renderer-servicemonitor.yaml
+++ b/bitnami/grafana/templates/image-renderer-servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}-image-renderer
   namespace: {{ default .Release.Namespace .Values.imageRenderer.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.imageRenderer.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imageRenderer.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: image-renderer
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/ingress.yaml
+++ b/bitnami/grafana/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/grafana/templates/pvc.yaml
+++ b/bitnami/grafana/templates/pvc.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/grafana/templates/service.yaml
+++ b/bitnami/grafana/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- if or (and .Values.metrics.enabled .Values.metrics.service.annotations) .Values.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if or .Values.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.metrics.enabled .Values.metrics.service.annotations }}
@@ -53,6 +53,6 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.grafana.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.grafana.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana

--- a/bitnami/grafana/templates/serviceaccount.yaml
+++ b/bitnami/grafana/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 secrets:

--- a/bitnami/grafana/templates/servicemonitor.yaml
+++ b/bitnami/grafana/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)