### PR TITLE
[bitnami/grafana-loki]: Use merge helper

### DIFF
--- a/bitnami/grafana-loki/Chart.lock
+++ b/bitnami/grafana-loki/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 6.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:1f684708ff56ddbc023a07f4ee4eb5ae2ed599997c2dddc4e3ff94da4005f0c5
-generated: "2023-08-23T09:06:31.159655+02:00"
+  version: 2.10.0
+digest: sha256:fa5d6e7915d1faaa138c017ec4ee7d21afe29486b133cd6c35c14cdab7618440
+generated: "2023-09-05T11:32:41.199206+02:00"

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -18,43 +18,43 @@ annotations:
 apiVersion: v2
 appVersion: 2.8.4
 dependencies:
-- alias: memcachedchunks
-  condition: memcachedchunks.enabled
-  name: memcached
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.x.x
-- alias: memcachedfrontend
-  condition: memcachedfrontend.enabled
-  name: memcached
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.x.x
-- alias: memcachedindexqueries
-  condition: memcachedindexqueries.enabled
-  name: memcached
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.x.x
-- alias: memcachedindexwrites
-  condition: memcachedindexwrites.enabled
-  name: memcached
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - alias: memcachedchunks
+    condition: memcachedchunks.enabled
+    name: memcached
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 6.x.x
+  - alias: memcachedfrontend
+    condition: memcachedfrontend.enabled
+    name: memcached
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 6.x.x
+  - alias: memcachedindexqueries
+    condition: memcachedindexqueries.enabled
+    name: memcached
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 6.x.x
+  - alias: memcachedindexwrites
+    condition: memcachedindexwrites.enabled
+    name: memcached
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 6.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
 keywords:
-- grafana
-- tracing
-- metrics
-- infrastructure
+  - grafana
+  - tracing
+  - metrics
+  - infrastructure
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: grafana-loki
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.11.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
+version: 2.11.1

--- a/bitnami/grafana-loki/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/compactor/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.compactor.updateStrategy }}
   strategy: {{- toYaml .Values.compactor.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.compactor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.compactor.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/compactor/pvc.yaml
+++ b/bitnami/grafana-loki/templates/compactor/pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.compactor.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.compactor.persistence.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.compactor.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/grafana-loki/templates/compactor/service.yaml
+++ b/bitnami/grafana-loki/templates/compactor/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: compactor
   {{- if or .Values.commonAnnotations .Values.compactor.service.annotations }}
-  {{- $annotations := merge .Values.compactor.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.compactor.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.compactor.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.compactor.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.compactor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.compactor.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: compactor

--- a/bitnami/grafana-loki/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/compactor/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.compactor.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: compactor

--- a/bitnami/grafana-loki/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/distributor/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.distributor.updateStrategy }}
   strategy: {{- toYaml .Values.distributor.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.distributor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.distributor.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/distributor/service.yaml
+++ b/bitnami/grafana-loki/templates/distributor/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: distributor
   {{- if or .Values.commonAnnotations .Values.distributor.service.annotations }}
-  {{- $annotations := merge .Values.distributor.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.distributor.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -57,7 +57,7 @@ spec:
     {{- if .Values.distributor.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.distributor.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.distributor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.distributor.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: distributor

--- a/bitnami/grafana-loki/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/distributor/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.distributor.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: distributor

--- a/bitnami/grafana-loki/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-loki/templates/gateway/deployment.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.gateway.replicaCount }}
-  {{- $podLabels := merge .Values.gateway.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.gateway.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/gateway/ingress.yaml
+++ b/bitnami/grafana-loki/templates/gateway/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.gateway.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.gateway.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.gateway.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/grafana-loki/templates/gateway/service.yaml
+++ b/bitnami/grafana-loki/templates/gateway/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: gateway
   {{- if or .Values.commonAnnotations .Values.gateway.service.annotations }}
-  {{- $annotations := merge .Values.gateway.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.gateway.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -50,7 +50,7 @@ spec:
     {{- if .Values.gateway.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.gateway.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.gateway.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.gateway.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: gateway

--- a/bitnami/grafana-loki/templates/gossip-ring-headless-service.yaml
+++ b/bitnami/grafana-loki/templates/gossip-ring-headless-service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: loki
   {{- if or .Values.commonAnnotations .Values.loki.gossipRing.service.annotations }}
-  {{- $annotations := merge .Values.loki.gossipRing.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.loki.gossipRing.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/grafana-loki/templates/index-gateway/service.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: index-gateway
   {{- if or .Values.commonAnnotations .Values.indexGateway.service.annotations }}
-  {{- $annotations := merge .Values.indexGateway.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.indexGateway.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if .Values.indexGateway.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.indexGateway.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.indexGateway.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: index-gateway

--- a/bitnami/grafana-loki/templates/index-gateway/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.index-gateway.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: index-gateway

--- a/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   podManagementPolicy: {{ .Values.indexGateway.podManagementPolicy }}
   serviceName: {{ template "grafana-loki.index-gateway.fullname" . }}
-  {{- $podLabels := merge .Values.indexGateway.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.indexGateway.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/ingester/service.yaml
+++ b/bitnami/grafana-loki/templates/ingester/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ingester
   {{- if or .Values.commonAnnotations .Values.ingester.service.annotations }}
-  {{- $annotations := merge .Values.ingester.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingester.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -57,7 +57,7 @@ spec:
     {{- if .Values.ingester.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingester.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.ingester.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingester.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ingester

--- a/bitnami/grafana-loki/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/ingester/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.ingester.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ingester

--- a/bitnami/grafana-loki/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ingester/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.ingester.updateStrategy }}
   updateStrategy: {{- toYaml .Values.ingester.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.ingester.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingester.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki
@@ -202,7 +202,7 @@ spec:
         labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
         {{- if or .Values.ingester.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.ingester.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingester.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 10 }}
         {{- end }}
       spec:

--- a/bitnami/grafana-loki/templates/promtail/daemonset.yaml
+++ b/bitnami/grafana-loki/templates/promtail/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.promtail.updateStrategy }}
   updateStrategy: {{- toYaml .Values.promtail.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.promtail.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.promtail.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/promtail/service-account.yaml
+++ b/bitnami/grafana-loki/templates/promtail/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: loki
   {{- if or .Values.promtail.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.promtail.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.promtail.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.promtail.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/grafana-loki/templates/promtail/service.yaml
+++ b/bitnami/grafana-loki/templates/promtail/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: promtail
   {{- if or .Values.commonAnnotations .Values.promtail.service.annotations }}
-  {{- $annotations := merge .Values.promtail.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.promtail.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.promtail.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.promtail.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.promtail.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.promtail.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: promtail

--- a/bitnami/grafana-loki/templates/promtail/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/promtail/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.promtail.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: promtail

--- a/bitnami/grafana-loki/templates/querier/service.yaml
+++ b/bitnami/grafana-loki/templates/querier/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: querier
   {{- if or .Values.commonAnnotations .Values.querier.service.annotations }}
-  {{- $annotations := merge .Values.querier.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.querier.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -57,7 +57,7 @@ spec:
     {{- if .Values.querier.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.querier.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.querier.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.querier.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: querier

--- a/bitnami/grafana-loki/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/querier/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.querier.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: querier

--- a/bitnami/grafana-loki/templates/querier/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/querier/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
   updateStrategy: {{- toYaml .Values.querier.updateStrategy | nindent 4 }}
   {{- end }}
   podManagementPolicy: {{ .Values.querier.podManagementPolicy }}
-  {{- $podLabels := merge .Values.querier.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.querier.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki
@@ -207,7 +207,7 @@ spec:
         labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
         {{- if or .Values.querier.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.querier.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.querier.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 10 }}
         {{- end }}
       spec:

--- a/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.queryFrontend.updateStrategy }}
   strategy: {{- toYaml .Values.queryFrontend.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.queryFrontend.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/headless-service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-frontend
   {{- if or .Values.commonAnnotations .Values.queryFrontend.service.headless.annotations }}
-  {{- $annotations := merge .Values.queryFrontend.service.headless.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -32,7 +32,7 @@ spec:
     {{- if .Values.queryFrontend.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.queryFrontend.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-frontend

--- a/bitnami/grafana-loki/templates/query-frontend/service.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-frontend
   {{- if or .Values.commonAnnotations .Values.queryFrontend.service.annotations }}
-  {{- $annotations := merge .Values.queryFrontend.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if .Values.queryFrontend.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.queryFrontend.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-frontend

--- a/bitnami/grafana-loki/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.query-frontend.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-frontend

--- a/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.queryScheduler.updateStrategy }}
   strategy: {{- toYaml .Values.queryScheduler.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.queryScheduler.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryScheduler.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/query-scheduler/service.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-scheduler
   {{- if or .Values.commonAnnotations .Values.queryScheduler.service.annotations }}
-  {{- $annotations := merge .Values.queryScheduler.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryScheduler.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -59,7 +59,7 @@ spec:
     {{- if .Values.queryScheduler.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.queryScheduler.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryScheduler.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-scheduler

--- a/bitnami/grafana-loki/templates/ruler/service.yaml
+++ b/bitnami/grafana-loki/templates/ruler/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ruler
   {{- if or .Values.commonAnnotations .Values.ruler.service.annotations }}
-  {{- $annotations := merge .Values.ruler.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ruler.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if .Values.ruler.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ruler.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.ruler.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ruler.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ruler

--- a/bitnami/grafana-loki/templates/ruler/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/ruler/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.ruler.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ruler

--- a/bitnami/grafana-loki/templates/ruler/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ruler/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
   updateStrategy: {{- toYaml .Values.ruler.updateStrategy | nindent 4 }}
   {{- end }}
   podManagementPolicy: {{ .Values.ruler.podManagementPolicy }}
-  {{- $podLabels := merge .Values.ruler.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ruler.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/service-account.yaml
+++ b/bitnami/grafana-loki/templates/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: loki
   {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
-  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/grafana-loki/templates/table-manager/deployment.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.tableManager.updateStrategy }}
   strategy: {{- toYaml .Values.tableManager.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.tableManager.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.tableManager.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: grafana-loki

--- a/bitnami/grafana-loki/templates/table-manager/service.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: table-manager
   {{- if or .Values.commonAnnotations .Values.tableManager.service.annotations }}
-  {{- $annotations := merge .Values.tableManager.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.tableManager.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if .Values.tableManager.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.tableManager.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.tableManager.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: table-manager

--- a/bitnami/grafana-loki/templates/table-manager/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.table-manager.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: table-manager


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)