### PR TITLE
[bitnami/harbor]: Use merge helper

### DIFF
--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.0.0
+  version: 18.0.2
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.10.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:46bd4e57c97682d567cd5666dd8e7dc636ebf89445a26548b6ba8576e173b6f6
-generated: "2023-08-28T09:08:59.2120231+02:00"
+  version: 2.10.0
+digest: sha256:909a1b88eddc7aa1b4f32055f052a679aed3f01b4790830724c09073d99c692b
+generated: "2023-09-05T11:33:02.54248+02:00"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -32,31 +32,31 @@ annotations:
 apiVersion: v2
 appVersion: 2.8.3
 dependencies:
-- condition: redis.enabled
-  name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.x.x
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: redis.enabled
+    name: redis
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 18.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Harbor is an open source trusted cloud-native registry to store, sign, and scan content. It adds functionalities like security, identity, and management to the open source Docker distribution.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/harbor-core/img/harbor-core-stack-220x234.png
 keywords:
-- docker
-- registry
-- vulnerability
-- scan
+  - docker
+  - registry
+  - vulnerability
+  - scan
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: harbor
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 17.1.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/harbor
+version: 17.1.1

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.core.replicaCount }}
-  {{- $podLabels := merge .Values.core.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.core.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: core

--- a/bitnami/harbor/templates/core/core-svc.yaml
+++ b/bitnami/harbor/templates/core/core-svc.yaml
@@ -26,6 +26,6 @@ spec:
       port: {{ .Values.core.service.ports.metrics }}
       targetPort: metrics
     {{- end }}
-  {{- $podLabels := merge .Values.core.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.core.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: core

--- a/bitnami/harbor/templates/exporter/exporter-dpl.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-dpl.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.exporter.replicaCount }}
-  {{- $podLabels := merge .Values.exporter.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.exporter.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: exporter

--- a/bitnami/harbor/templates/exporter/exporter-svc.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-svc.yaml
@@ -19,7 +19,7 @@ spec:
     - name: http-metrics
       port: {{ .Values.exporter.service.ports.metrics }}
       targetPort: metrics
-  {{- $podLabels := merge .Values.exporter.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.exporter.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: exporter
 {{ end }}

--- a/bitnami/harbor/templates/ingress/core-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/core-ingress.yaml
@@ -43,7 +43,7 @@ metadata:
     {{- end }}
   {{- end }}
   {{- if or .Values.ingress.core.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.ingress.core.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.core.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/harbor/templates/ingress/notary-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/notary-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingress.notary.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingress.notary.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.notary.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.jobservice.replicaCount }}
-  {{- $podLabels := merge .Values.jobservice.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobservice.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: jobservice

--- a/bitnami/harbor/templates/jobservice/jobservice-pvc.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-pvc.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     {{- if or .Values.persistence.persistentVolumeClaim.jobservice.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.persistence.persistentVolumeClaim.jobservice.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.persistentVolumeClaim.jobservice.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/harbor/templates/jobservice/jobservice-scandata-pvc.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-scandata-pvc.yaml
@@ -16,7 +16,7 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     {{- if or .Values.persistence.persistentVolumeClaim.jobservice.scanData.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.persistence.persistentVolumeClaim.jobservice.scanData.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.persistentVolumeClaim.jobservice.scanData.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/harbor/templates/jobservice/jobservice-svc.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-svc.yaml
@@ -23,6 +23,6 @@ spec:
       port: {{ .Values.jobservice.service.ports.metrics }}
       targetPort: metrics
     {{- end }}
-  {{- $podLabels := merge .Values.jobservice.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobservice.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: jobservice

--- a/bitnami/harbor/templates/metrics/metrics-svcmonitor.yaml
+++ b/bitnami/harbor/templates/metrics/metrics-svcmonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if .Values.commonAnnotations }}

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.nginx.replicaCount }}
-  {{- $podLabels := merge .Values.nginx.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.nginx.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: nginx

--- a/bitnami/harbor/templates/nginx/service.yaml
+++ b/bitnami/harbor/templates/nginx/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: nginx
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -67,7 +67,7 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.nginx.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.nginx.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: nginx
 {{- end }}

--- a/bitnami/harbor/templates/notary/notary-server.yaml
+++ b/bitnami/harbor/templates/notary/notary-server.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.notary.server.replicaCount }}
-  {{- $podLabels := merge .Values.notary.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notary.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: notary-server

--- a/bitnami/harbor/templates/notary/notary-signer.yaml
+++ b/bitnami/harbor/templates/notary/notary-signer.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.notary.signer.replicaCount }}
-  {{- $podLabels := merge .Values.notary.signer.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notary.signer.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: notary-signer

--- a/bitnami/harbor/templates/notary/notary-svc.yaml
+++ b/bitnami/harbor/templates/notary/notary-svc.yaml
@@ -22,7 +22,7 @@ spec:
     - name: notary-server
       port: {{ .Values.notary.service.ports.server }}
       targetPort: notary-server
-  {{- $serverPodLabels := merge .Values.notary.server.podLabels .Values.commonLabels }}
+  {{- $serverPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notary.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $serverPodLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notary-server
 ---
@@ -40,7 +40,7 @@ spec:
     - name: notary-signer
       port: {{ .Values.notary.service.ports.signer }}
       targetPort: notary-signer
-  {{- $signerPodLabels := merge .Values.notary.signer.podLabels .Values.commonLabels }}
+  {{- $signerPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.notary.signer.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $signerPodLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: notary-signer
 {{- end }}

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.portal.replicaCount }}
-  {{- $podLabels := merge .Values.portal.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.portal.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: portal

--- a/bitnami/harbor/templates/portal/portal-svc.yaml
+++ b/bitnami/harbor/templates/portal/portal-svc.yaml
@@ -21,6 +21,6 @@ spec:
     - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}
       port: {{ ternary .Values.portal.service.ports.https .Values.portal.service.ports.http .Values.internalTLS.enabled }}
       targetPort: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-  {{- $podLabels := merge .Values.portal.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.portal.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: portal

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.registry.replicaCount }}
-  {{- $podLabels := merge .Values.registry.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.registry.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: registry

--- a/bitnami/harbor/templates/registry/registry-pvc.yaml
+++ b/bitnami/harbor/templates/registry/registry-pvc.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     {{- if or .Values.persistence.persistentVolumeClaim.registry.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.persistence.persistentVolumeClaim.registry.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.persistentVolumeClaim.registry.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/harbor/templates/registry/registry-svc.yaml
+++ b/bitnami/harbor/templates/registry/registry-svc.yaml
@@ -24,6 +24,6 @@ spec:
       port: {{ .Values.registry.server.service.ports.metrics }}
       targetPort: metrics
     {{- end }}
-  {{- $podLabels := merge .Values.registry.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.registry.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: registry

--- a/bitnami/harbor/templates/trivy/trivy-sts.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-sts.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: {{ .Values.trivy.replicaCount }}
   serviceName: {{ template "harbor.trivy" . }}
   updateStrategy: {{- toYaml .Values.trivy.updateStrategy | nindent 4 }}
-  {{- $podLabels := merge .Values.trivy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.trivy.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: trivy

--- a/bitnami/harbor/templates/trivy/trivy-svc.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-svc.yaml
@@ -20,7 +20,7 @@ spec:
       protocol: TCP
       port: {{ ternary .Values.trivy.service.ports.https .Values.trivy.service.ports.http .Values.internalTLS.enabled }}
       targetPort: api-server
-  {{- $podLabels := merge .Values.trivy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.trivy.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: trivy
 {{ end }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)