### PR TITLE
[bitnami/jupyterhub]: Use merge helper

### DIFF
--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.10.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.1
-digest: sha256:090b1fd2db71ad49e1a438b4e7fe1993516bc85048133222cae14d6717a86974
-generated: "2023-08-30T12:09:49.925212511Z"
+  version: 2.10.0
+digest: sha256:d1b11fe318591fb8b98acbdcdb1469c3f6730c47bf64834bb5af3fda6626c69b
+generated: "2023-09-05T11:33:22.644667+02:00"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -16,25 +16,25 @@ annotations:
 apiVersion: v2
 appVersion: 4.0.2
 dependencies:
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: JupyterHub brings the power of notebooks to groups of users. It gives users access to computational environments and resources without burdening the users with installation and maintenance tasks.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/jupyterhub/img/jupyterhub-stack-220x234.png
 keywords:
-- python
-- scientific
+  - python
+  - scientific
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: jupyterhub
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 4.2.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
+version: 4.2.2

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   {{- if .Values.hub.updateStrategy }}
   strategy: {{- toYaml .Values.hub.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.hub.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: hub

--- a/bitnami/jupyterhub/templates/hub/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/hub/networkpolicy.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $hubPodLabels := merge .Values.hub.podLabels .Values.commonLabels }}
+  {{- $hubPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $hubPodLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: hub
@@ -53,7 +53,7 @@ spec:
     - ports:
         - port: {{ .Values.proxy.containerPort.api }}
       to:
-        {{- $proxyPodLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+        {{- $proxyPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $proxyPodLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/hub/pdb.yaml
+++ b/bitnami/jupyterhub/templates/hub/pdb.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   minAvailable: {{ .Values.hub.pdb.minAvailable }}
   maxUnavailable: {{ .Values.hub.pdb.maxUnavailable }}
-  {{- $podLabels := merge .Values.hub.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: hub

--- a/bitnami/jupyterhub/templates/hub/service-account.yaml
+++ b/bitnami/jupyterhub/templates/hub/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: hub
   {{- if or .Values.hub.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.hub.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.hub.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/jupyterhub/templates/hub/service.yaml
+++ b/bitnami/jupyterhub/templates/hub/service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: hub
   {{- if or .Values.hub.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.hub.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,6 +47,6 @@ spec:
     {{- if .Values.hub.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.hub.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.hub.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: hub

--- a/bitnami/jupyterhub/templates/hub/servicemonitor.yaml
+++ b/bitnami/jupyterhub/templates/hub/servicemonitor.yaml
@@ -10,7 +10,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "jupyterhub.hub.name" . }}
   namespace: {{ default .Release.Namespace .Values.hub.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.hub.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: hub
   {{- if .Values.commonAnnotations }}

--- a/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
@@ -18,7 +18,7 @@ spec:
   {{- if .Values.imagePuller.updateStrategy }}
   updateStrategy: {{- toYaml .Values.imagePuller.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.imagePuller.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.imagePuller.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: image-puller

--- a/bitnami/jupyterhub/templates/proxy/deployment.yaml
+++ b/bitnami/jupyterhub/templates/proxy/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   {{- if .Values.proxy.updateStrategy }}
   strategy: {{- toYaml .Values.proxy.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/proxy/ingress.yaml
+++ b/bitnami/jupyterhub/templates/proxy/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.proxy.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.proxy.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/jupyterhub/templates/proxy/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/proxy/networkpolicy.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $proxyPodLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+  {{- $proxyPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $proxyPodLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: proxy
@@ -45,7 +45,7 @@ spec:
     - ports:
         - port: {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
       to:
-        {{- $hubPodLabels := merge .Values.hub.podLabels .Values.commonLabels }}
+        {{- $hubPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.podLabels .Values.commonLabels ) "context" . ) }}
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $hubPodLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/component: hub

--- a/bitnami/jupyterhub/templates/proxy/pdb.yaml
+++ b/bitnami/jupyterhub/templates/proxy/pdb.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   minAvailable: {{ .Values.proxy.pdb.minAvailable }}
   maxUnavailable: {{ .Values.proxy.pdb.maxUnavailable }}
-  {{- $podLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/proxy/service-account.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy
   {{- if or .Values.proxy.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.proxy.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.proxy.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/jupyterhub/templates/proxy/service-api.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-api.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy
   {{- if or .Values.proxy.service.api.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.proxy.service.api.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.service.api.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,6 +47,6 @@ spec:
     {{- if .Values.proxy.service.api.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.api.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
@@ -13,7 +13,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy
   {{- if or .Values.proxy.service.metrics.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.proxy.service.metrics.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.service.metrics.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.proxy.service.metrics.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.metrics.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy
 {{- end }}

--- a/bitnami/jupyterhub/templates/proxy/service-public.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-public.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy
   {{- if or .Values.proxy.service.public.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.proxy.service.public.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.service.public.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,6 +47,6 @@ spec:
     {{- if .Values.proxy.service.public.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.public.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.proxy.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/proxy/servicemonitor.yaml
+++ b/bitnami/jupyterhub/templates/proxy/servicemonitor.yaml
@@ -10,7 +10,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ printf "%s-proxy-api" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ default .Release.Namespace .Values.proxy.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.proxy.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.proxy.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: proxy
   {{- if .Values.commonAnnotations }}

--- a/bitnami/jupyterhub/templates/singleuser/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/singleuser/networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
     - ports:
         - port: {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
       to:
-        {{- $hubPodLabels := merge .Values.hub.podLabels .Values.commonLabels }}
+        {{- $hubPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.hub.podLabels .Values.commonLabels ) "context" . ) }}
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $hubPodLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/component: hub

--- a/bitnami/jupyterhub/templates/singleuser/service-account.yaml
+++ b/bitnami/jupyterhub/templates/singleuser/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: singleuser
   {{- if or .Values.singleuser.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.singleuser.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.singleuser.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.singleuser.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)