### PR TITLE
[bitnami/kube-prometheus]: Use merge helper

### DIFF
--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 3.7.0
 - name: kube-state-metrics
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.6.0
+  version: 3.6.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:09a14f8c30bd4c0b69877cbaabdc9a8d609aed9f9d638d879fefcaf81e2f9194
-generated: "2023-08-24T16:05:36.849597996Z"
+  version: 2.10.0
+digest: sha256:bafc5899ecc9bb76c62bee8f8a88191f000f69e20c4a167600a664d818822dcd
+generated: "2023-09-05T11:33:44.304197+02:00"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -18,32 +18,32 @@ annotations:
 apiVersion: v2
 appVersion: 0.67.1
 dependencies:
-- condition: exporters.enabled,exporters.node-exporter.enabled
-  name: node-exporter
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.x.x
-- condition: exporters.enabled,exporters.kube-state-metrics.enabled
-  name: kube-state-metrics
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: exporters.enabled,exporters.node-exporter.enabled
+    name: node-exporter
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 3.x.x
+  - condition: exporters.enabled,exporters.kube-state-metrics.enabled
+    name: kube-state-metrics
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 3.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
 keywords:
-- prometheus
-- alertmanager
-- operator
-- monitoring
+  - prometheus
+  - alertmanager
+  - operator
+  - monitoring
 kubeVersion: '>= 1.16.0-0'
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: kube-prometheus
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 8.18.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
+version: 8.18.1

--- a/bitnami/kube-prometheus/templates/_helpers.tpl
+++ b/bitnami/kube-prometheus/templates/_helpers.tpl
@@ -111,7 +111,7 @@ app.kubernetes.io/component: blackbox-exporter
 Labels for operator pods
 */}}
 {{- define "kube-prometheus.operator.podLabels" -}}
-{{- $podLabels := merge .Values.operator.podLabels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.operator.podLabels .Values.commonLabels ) "context" . ) }}
 {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) }}
 app.kubernetes.io/component: operator
 {{- end -}}
@@ -120,7 +120,7 @@ app.kubernetes.io/component: operator
 Labels for blackbox-exporter pods
 */}}
 {{- define "kube-prometheus.blackboxExporter.podLabels" -}}
-{{- $podLabels := merge .Values.blackboxExporter.podLabels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.blackboxExporter.podLabels .Values.commonLabels ) "context" . ) }}
 {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) }}
 app.kubernetes.io/component: blackbox-exporter
 {{- end -}}
@@ -129,7 +129,7 @@ app.kubernetes.io/component: blackbox-exporter
 matchLabels for operator
 */}}
 {{- define "kube-prometheus.operator.matchLabels" -}}
-{{- $podLabels := merge .Values.operator.podLabels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.operator.podLabels .Values.commonLabels ) "context" . ) }}
 {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) }}
 app.kubernetes.io/component: operator
 {{- end -}}
@@ -139,7 +139,7 @@ matchLabels for prometheus
 */}}
 {{- define "kube-prometheus.prometheus.matchLabels" -}}
 {{- if or .Values.prometheus.podMetadata.labels .Values.commonLabels }}
-{{- $podLabels := merge .Values.prometheus.podMetadata.labels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.podMetadata.labels .Values.commonLabels ) "context" . ) }}
 {{- include "common.tplvalues.render" ( dict "value" $podLabels "context" $ ) }}
 {{- end -}}
 app.kubernetes.io/name: prometheus
@@ -152,7 +152,7 @@ matchLabels for alertmanager
 */}}
 {{- define "kube-prometheus.alertmanager.matchLabels" -}}
 {{- if or .Values.alertmanager.podMetadata.labels .Values.commonLabels }}
-{{- $podLabels := merge .Values.alertmanager.podMetadata.labels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.podMetadata.labels .Values.commonLabels ) "context" . ) }}
 {{- include "common.tplvalues.render" ( dict "value" $podLabels "context" $ ) }}
 {{- end -}}
 app.kubernetes.io/name: alertmanager
@@ -164,7 +164,7 @@ alertmanager: {{ template "kube-prometheus.alertmanager.fullname" . }}
 matchLabels for blackbox-exporter
 */}}
 {{- define "kube-prometheus.blackboxExporter.matchLabels" -}}
-{{- $podLabels := merge .Values.blackboxExporter.podLabels .Values.commonLabels }}
+{{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.blackboxExporter.podLabels .Values.commonLabels ) "context" . ) }}
 {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) }}
 app.kubernetes.io/component: blackbox-exporter
 {{- end -}}

--- a/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
@@ -51,7 +51,7 @@ spec:
     volumeClaimTemplate:
       metadata:
         {{- if or .Values.alertmanager.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.alertmanager.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $ ) | nindent 10 }}
         {{- end }}
         {{- if .Values.commonLabels }}

--- a/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   {{- if or .Values.alertmanager.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.alertmanager.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/alertmanager/service.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/service.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   {{- if or .Values.alertmanager.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.alertmanager.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/alertmanager/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   {{- if or .Values.alertmanager.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.alertmanager.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.alertmanager.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/kube-prometheus/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.alertmanager.serviceMonitor.labels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.commonAnnotations .Values.alertmanager.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.alertmanager.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.blackboxExporter.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        {{- $podLabels := merge .Values.blackboxExporter.podLabels .Values.commonLabels }}
+        {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.blackboxExporter.podLabels .Values.commonLabels ) "context" . ) }}
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.blackboxExporter.podAffinityPreset "component" "blackbox-exporter" "customLabels" $podLabels "context" $) | nindent 10 }}
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.blackboxExporter.podAntiAffinityPreset "component" "blackbox-exporter" "customLabels" $podLabels "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.blackboxExporter.nodeAffinityPreset.type "key" .Values.blackboxExporter.nodeAffinityPreset.key "values" .Values.blackboxExporter.nodeAffinityPreset.values) | nindent 10 }}

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/service.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/service.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.blackboxExporter.labels" . | nindent 4 }}
   {{- if or .Values.commonAnnotations .Values.blackboxExporter.service.annotations }}
-  {{- $annotations := merge .Values.blackboxExporter.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.blackboxExporter.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.blackboxExporter.labels" . | nindent 4 }}
   {{- if or .Values.blackboxExporter.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.blackboxExporter.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.blackboxExporter.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.blackboxExporter.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/service.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-coredns
   namespace: {{ .Values.coreDns.namespace }}
-  {{- $labels := merge .Values.coreDns.service.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coreDns.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-coredns
   {{- if .Values.commonAnnotations }}

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-coredns
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.coreDns.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coreDns.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-coredns
   {{- if or .Values.commonAnnotations .Values.coreDns.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.coreDns.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.coreDns.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-apiserver
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.kubeApiServer.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeApiServer.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: apiserver
   {{- if or .Values.commonAnnotations .Values.kubeApiServer.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.kubeApiServer.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeApiServer.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/service.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
   namespace: {{ .Values.kubeControllerManager.namespace }}
-  {{- $labels := merge .Values.kubeControllerManager.service.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeControllerManager.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kube-controller-manager
   {{- if .Values.commonAnnotations }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.kubeControllerManager.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeControllerManager.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kube-controller-manager
   {{- if or .Values.commonAnnotations .Values.kubeControllerManager.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.kubeControllerManager.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeControllerManager.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/service.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-proxy
   namespace: {{ .Values.kubeProxy.namespace }}
-  {{- $labels := merge .Values.kubeProxy.service.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeProxy.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kube-proxy
   {{- if .Values.commonAnnotations }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-proxy
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.kubeProxy.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeProxy.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kube-proxy
   {{- if or .Values.commonAnnotations .Values.kubeProxy.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.kubeProxy.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeProxy.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/service.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
   namespace: {{ .Values.kubeScheduler.namespace }}
-  {{- $labels := merge .Values.kubeScheduler.service.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeScheduler.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kube-scheduler
   {{- if .Values.commonAnnotations }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.kubeScheduler.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeScheduler.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kube-scheduler
   {{- if or .Values.commonAnnotations .Values.kubeScheduler.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.kubeScheduler.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubeScheduler.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
@@ -9,11 +9,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kubelet
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.kubelet.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubelet.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kubelet
   {{- if or .Values.commonAnnotations .Values.kubelet.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.kubelet.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.kubelet.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.operator.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        {{- $podLabels := merge .Values.operator.podLabels .Values.commonLabels }}
+        {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.operator.podLabels .Values.commonLabels ) "context" . ) }}
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.operator.podAffinityPreset "component" "operator" "customLabels" $podLabels "context" $) | nindent 10 }}
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.operator.podAntiAffinityPreset "component" "operator" "customLabels" $podLabels "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.operator.nodeAffinityPreset.type "key" .Values.operator.nodeAffinityPreset.key "values" .Values.operator.nodeAffinityPreset.values) | nindent 10 }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/service.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.operator.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.commonAnnotations .Values.operator.service.annotations }}
-  {{- $annotations := merge .Values.operator.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.operator.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus-operator/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
   {{- if or .Values.operator.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.operator.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.operator.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.operator.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.operator.serviceMonitor.labels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.commonAnnotations .Values.operator.serviceMonitor.annotations }}
-  {{- $annotations := merge .Values.operator.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.operator.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus/config-reloader-service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/config-reloader-service.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.configReloader.service.labels "context" $) | nindent 4 }}
     {{- end }}
   {{- if or .Values.prometheus.configReloader.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.prometheus.configReloader.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.configReloader.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
   {{- if or .Values.prometheus.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.prometheus.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -169,7 +169,7 @@ spec:
     volumeClaimTemplate:
       metadata:
         {{- if or .Values.prometheus.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.prometheus.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $ ) | nindent 10 }}
         {{- end }}
         {{- if .Values.commonLabels }}

--- a/bitnami/kube-prometheus/templates/prometheus/service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/service.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.prometheus.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.prometheus.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.prometheus.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
   {{- if or .Values.prometheus.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.prometheus.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.prometheus.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/subcomponent: thanos
   {{- if or .Values.prometheus.thanos.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.prometheus.thanos.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.thanos.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.prometheus.thanos.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.prometheus.thanos.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.prometheus.thanos.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.thanos.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)