### PR TITLE
[bitnami/deepspeed]: Use merge helper

### DIFF
--- a/bitnami/deepspeed/Chart.lock
+++ b/bitnami/deepspeed/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.2
-digest: sha256:0d1ed3ab5c6a7e3ab3bfaea47851d574aae674797326572c51719718026e1f63
-generated: "2023-08-31T22:26:18.792085344Z"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:31:54.508508+02:00"

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -14,25 +14,25 @@ annotations:
 apiVersion: v2
 appVersion: 0.10.2
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: DeepSpeed is deep learning software suite for empowering ChatGPT-like model training. Features dense or sparse model inference, high throughput and high compression.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/deepspeed/img/deepspeed-stack-220x234.png
 keywords:
-- deepspeed
-- pytorch
-- python
-- machine
-- learning
+  - deepspeed
+  - pytorch
+  - python
+  - machine
+  - learning
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: deepspeed
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
-- https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 1.2.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
+  - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
+version: 1.2.2

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -9,16 +9,16 @@ kind: {{ ternary "Job" "Deployment" .Values.client.useJob }}
 metadata:
   name: {{ include "deepspeed.v0.client.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.client.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: client
   {{- if or .Values.client.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.client.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.client.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: deepspeed
@@ -40,7 +40,7 @@ spec:
         checksum/source: {{ include (print $.Template.BasePath "/client/source-configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- if or .Values.client.podAnnotations .Values.commonAnnotations }}
-        {{- $annotations := merge .Values.client.podAnnotations .Values.commonAnnotations }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.podAnnotations .Values.commonAnnotations ) "context" . ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 8 }}
         {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/deepspeed/templates/client/networkpolicy.yaml
+++ b/bitnami/deepspeed/templates/client/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $clientPodLabels := merge .Values.client.podLabels .Values.commonLabels }}
+  {{- $clientPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $clientPodLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: deepspeed
@@ -36,7 +36,7 @@ spec:
         - port: {{ .Values.worker.containerPorts.ssh }}
         - port: {{ .Values.worker.externalAccess.service.ports.ssh }}
       to:
-        {{- $workerPodLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+        {{- $workerPodLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.podLabels .Values.commonLabels ) "context" . ) }}
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $workerPodLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: deepspeed

--- a/bitnami/deepspeed/templates/client/pvc.yaml
+++ b/bitnami/deepspeed/templates/client/pvc.yaml
@@ -9,12 +9,12 @@ apiVersion: v1
 metadata:
   name: {{ include "deepspeed.v0.client.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.client.persistence.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.persistence.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: client
   {{- if or .Values.client.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.client.persistence.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/deepspeed/templates/client/service-account.yaml
+++ b/bitnami/deepspeed/templates/client/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: client
   {{- if or .Values.client.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.client.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.client.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.client.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/deepspeed/templates/worker/networkpolicy.yaml
+++ b/bitnami/deepspeed/templates/worker/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: deepspeed

--- a/bitnami/deepspeed/templates/worker/service-account.yaml
+++ b/bitnami/deepspeed/templates/worker/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker
   {{- if or .Values.worker.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.worker.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.worker.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/deepspeed/templates/worker/worker-headless-svc.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-headless-svc.yaml
@@ -13,13 +13,13 @@ metadata:
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker
   {{- if or .Values.commonAnnotations .Values.worker.headlessServiceAnnotations }}
-  {{- $annotations := merge .Values.worker.headlessServiceAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.headlessServiceAnnotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None
-  {{- $podLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker

--- a/bitnami/deepspeed/templates/worker/worker-service.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-service.yaml
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   name: {{ printf "%s-%d-external" (include "deepspeed.v0.worker.fullname" $) $i | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" $ | quote }}
-  {{- $labels := merge $root.Values.worker.externalAccess.service.labels $root.Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.externalAccess.service.labels $root.Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker
@@ -26,7 +26,7 @@ metadata:
     {{ include "common.tplvalues.render" (dict "value" (index $root.Values.worker.externalAccess.service.loadBalancerAnnotations $i) "context" $) | nindent 4 }}
     {{- end }}
     {{- if or $root.Values.worker.externalAccess.service.annotations $root.Values.commonAnnotations }}
-    {{- $annotations := merge $root.Values.worker.externalAccess.service.annotations $root.Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.externalAccess.service.annotations $root.Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
@@ -65,7 +65,7 @@ spec:
   {{- if and (eq $root.Values.worker.externalAccess.service.type "NodePort") (le (add $i 1) (len $root.Values.worker.externalAccess.service.externalIPs)) }}
   externalIPs: [{{ index $root.Values.worker.externalAccess.service.externalIPs $i | quote }}]
   {{- end }}
-  {{- $podLabels := merge $root.Values.worker.podLabels $root.Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.podLabels $root.Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker

--- a/bitnami/deepspeed/templates/worker/worker-service.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-service.yaml
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   name: {{ printf "%s-%d-external" (include "deepspeed.v0.worker.fullname" $) $i | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" $ | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.externalAccess.service.labels $root.Values.commonLabels ) "context" . ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.externalAccess.service.labels $root.Values.commonLabels ) "context" $ ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker
@@ -26,7 +26,7 @@ metadata:
     {{ include "common.tplvalues.render" (dict "value" (index $root.Values.worker.externalAccess.service.loadBalancerAnnotations $i) "context" $) | nindent 4 }}
     {{- end }}
     {{- if or $root.Values.worker.externalAccess.service.annotations $root.Values.commonAnnotations }}
-    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.externalAccess.service.annotations $root.Values.commonAnnotations ) "context" . ) }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.externalAccess.service.annotations $root.Values.commonAnnotations ) "context" $ ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
@@ -65,7 +65,7 @@ spec:
   {{- if and (eq $root.Values.worker.externalAccess.service.type "NodePort") (le (add $i 1) (len $root.Values.worker.externalAccess.service.externalIPs)) }}
   externalIPs: [{{ index $root.Values.worker.externalAccess.service.externalIPs $i | quote }}]
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.podLabels $root.Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.worker.podLabels $root.Values.commonLabels ) "context" $ ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker

--- a/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
@@ -9,19 +9,19 @@ kind: StatefulSet
 metadata:
   name: {{ include "deepspeed.v0.worker.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.worker.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: deepspeed
     app.kubernetes.io/component: worker
   {{- if or .Values.worker.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.worker.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.worker.replicaCount }}
   podManagementPolicy: {{ .Values.worker.podManagementPolicy | quote }}
   serviceName: {{ printf "%s-headless" (include "deepspeed.v0.worker.fullname" .) }}
-  {{- $podLabels := merge .Values.worker.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: deepspeed
@@ -38,7 +38,7 @@ spec:
         checksum/source: {{ include (print $.Template.BasePath "/client/source-configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- if or .Values.worker.podAnnotations .Values.commonAnnotations }}
-        {{- $annotations := merge .Values.worker.podAnnotations .Values.commonAnnotations }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.worker.podAnnotations .Values.commonAnnotations ) "context" . ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 8 }}
         {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
