### PR TITLE
[bitnami/mediawiki]: Use merge helper

### DIFF
--- a/bitnami/mediawiki/Chart.lock
+++ b/bitnami/mediawiki/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.1.0
+  version: 13.1.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:3b5a2c8004cc5af67a93971c0ba916099a0896434624e6b24f0d7b0249cb13d7
-generated: "2023-08-23T11:47:10.664947+02:00"
+  version: 2.10.0
+digest: sha256:c3bd0e2ee9a712e8a0c1a0cdc372c07e5d1a81753ce270b7c0d5e3f92c3dc4f8
+generated: "2023-09-05T11:34:23.771614+02:00"

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -12,31 +12,31 @@ annotations:
 apiVersion: v2
 appVersion: 1.40.0
 dependencies:
-- condition: mariadb.enabled
-  name: mariadb
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - mediawiki-database
-  version: 13.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - mediawiki-database
+    version: 13.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: MediaWiki is the free and open source wiki software that powers Wikipedia. Used by thousands of organizations, it is extremely powerful, scalable software and a feature-rich wiki implementation.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/mediawiki/img/mediawiki-stack-220x234.png
 keywords:
-- mediawiki
-- wiki
-- http
-- web
-- application
-- php
+  - mediawiki
+  - wiki
+  - http
+  - web
+  - application
+  - php
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: mediawiki
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
-version: 16.1.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
+version: 16.1.1

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}            
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}            
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}

--- a/bitnami/mediawiki/templates/ingress.yaml
+++ b/bitnami/mediawiki/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/bitnami/mediawiki/templates/mediawiki-pvc.yaml
+++ b/bitnami/mediawiki/templates/mediawiki-pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/mediawiki/templates/metrics-svc.yaml
+++ b/bitnami/mediawiki/templates/metrics-svc.yaml
@@ -21,6 +21,6 @@ spec:
       port: {{ .Values.metrics.port }}
       protocol: TCP
       targetPort: metrics
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
 {{- end }}

--- a/bitnami/mediawiki/templates/networkpolicy-backend-ingress.yaml
+++ b/bitnami/mediawiki/templates/networkpolicy-backend-ingress.yaml
@@ -25,6 +25,6 @@ spec:
   ingress:
     - from:
         - podSelector:
-            {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+            {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
 {{- end }}

--- a/bitnami/mediawiki/templates/networkpolicy-ingress.yaml
+++ b/bitnami/mediawiki/templates/networkpolicy-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}            
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}            
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   ingress:

--- a/bitnami/mediawiki/templates/servicemonitor.yaml
+++ b/bitnami/mediawiki/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if .Values.commonAnnotations }}

--- a/bitnami/mediawiki/templates/svc.yaml
+++ b/bitnami/mediawiki/templates/svc.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -51,5 +51,5 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)