### PR TITLE
[bitnami/mongodb-sharded]: Use merge helper

### DIFF
--- a/bitnami/mongodb-sharded/Chart.lock
+++ b/bitnami/mongodb-sharded/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T14:21:20.663407+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:34:44.76822+02:00"

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -14,25 +14,25 @@ annotations:
 apiVersion: v2
 appVersion: 6.0.9
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: MongoDB(R) is an open source NoSQL database that uses JSON for data storage. MongoDB(TM) Sharded improves scalability and reliability for large datasets by distributing data across multiple machines.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:
-- mongodb
-- database
-- nosql
-- cluster
-- replicaset
-- replication
+  - mongodb
+  - database
+  - nosql
+  - cluster
+  - replicaset
+  - replication
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: mongodb-sharded
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 6.6.2
+  - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
+version: 6.6.3

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.configsvr.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.configsvr.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: configsvr

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-podmonitor.yaml
@@ -30,7 +30,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-  {{- $podLabels := merge .Values.configsvr.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.configsvr.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: configsvr

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.configsvr.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.configsvr.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: configsvr
@@ -30,7 +30,7 @@ spec:
       {{- if or .Values.common.podAnnotations .Values.configsvr.podAnnotations .Values.metrics.enabled }}
       annotations:
         {{- if or .Values.common.podAnnotations .Values.configsvr.podAnnotations }}
-        {{- $annotations := merge .Values.configsvr.podAnnotations .Values.common.podAnnotations }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.configsvr.podAnnotations .Values.common.podAnnotations ) "context" . ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations  "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if .Values.metrics.enabled }}

--- a/bitnami/mongodb-sharded/templates/headless-service.yaml
+++ b/bitnami/mongodb-sharded/templates/headless-service.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.commonAnnotations .Values.service.headless.annotations }}
-  {{- $annotations := merge .Values.service.headless.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -22,5 +22,5 @@ spec:
     {{- if .Values.service.extraPorts }}
       {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
     {{- toYaml .Values.mongos.updateStrategy | nindent 4 }}
   replicas: {{ .Values.mongos.replicaCount }}
-  {{- $podLabels := merge .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: mongos
@@ -34,7 +34,7 @@ spec:
       {{- if or .Values.common.podAnnotations .Values.mongos.podAnnotations .Values.metrics.enabled }}
       annotations:
         {{- if or .Values.common.podAnnotations .Values.mongos.podAnnotations }}
-        {{- $annotations := merge .Values.mongos.podAnnotations .Values.common.podAnnotations }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.mongos.podAnnotations .Values.common.podAnnotations ) "context" . ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations  "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if .Values.metrics.enabled }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: mongos

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-podmonitor.yaml
@@ -30,7 +30,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-  {{- $podLabels := merge .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: mongos

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
@@ -14,7 +14,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongos
   {{- if or $.Values.commonAnnotations $.Values.mongos.servicePerReplica.annotations }}
-  {{- $annotations := merge $.Values.mongos.servicePerReplica.annotations $.Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.mongos.servicePerReplica.annotations $.Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if $.Values.mongos.servicePerReplica.extraPorts }}
       {{- include "common.tplvalues.render" (dict "value" $.Values.mongos.servicePerReplica.extraPorts "context" $context) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge $.Values.mongos.podLabels $.Values.common.podLabels $.Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.mongos.podLabels $.Values.common.podLabels $.Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongos
     statefulset.kubernetes.io/pod-name: {{ printf "%s-mongos-%d" (include "common.names.fullname" $) $i }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
@@ -14,7 +14,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongos
   {{- if or $.Values.commonAnnotations $.Values.mongos.servicePerReplica.annotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.mongos.servicePerReplica.annotations $.Values.commonAnnotations ) "context" . ) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.mongos.servicePerReplica.annotations $.Values.commonAnnotations ) "context" $ ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if $.Values.mongos.servicePerReplica.extraPorts }}
       {{- include "common.tplvalues.render" (dict "value" $.Values.mongos.servicePerReplica.extraPorts "context" $context) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.mongos.podLabels $.Values.common.podLabels $.Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.mongos.podLabels $.Values.common.podLabels $.Values.commonLabels ) "context" $ ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongos
     statefulset.kubernetes.io/pod-name: {{ printf "%s-mongos-%d" (include "common.names.fullname" $) $i }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongos
   {{- if or .Values.commonAnnotations .Values.service.annotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.service.extraPorts }}
       {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.mongos.podLabels .Values.common.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongos
   sessionAffinity: {{ default "None" .Values.service.sessionAffinity }}

--- a/bitnami/mongodb-sharded/templates/serviceaccount.yaml
+++ b/bitnami/mongodb-sharded/templates/serviceaccount.yaml
@@ -13,7 +13,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: {{ $component }}
   {{- if or $serviceAccount.annotations $.Values.commonAnnotations }}
-  {{- $annotations := merge $serviceAccount.annotations $.Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $serviceAccount.annotations $.Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ $serviceAccount.automountServiceAccountToken }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" $ ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr-arbiter
@@ -33,7 +33,7 @@ spec:
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.arbiter.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if or $.Values.common.podAnnotations $.Values.shardsvr.arbiter.podAnnotations }}
-        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podAnnotations $.Values.common.podAnnotations ) "context" . ) }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podAnnotations $.Values.common.podAnnotations ) "context" $ ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations  "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr-arbiter
@@ -33,7 +33,7 @@ spec:
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.arbiter.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if or $.Values.common.podAnnotations $.Values.shardsvr.arbiter.podAnnotations }}
-        {{- $annotations := merge $.Values.shardsvr.arbiter.podAnnotations $.Values.common.podAnnotations }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podAnnotations $.Values.common.podAnnotations ) "context" . ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations  "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" $ ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-podmonitor.yaml
@@ -32,7 +32,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ $.Release.Namespace }}
-  {{- $podLabels := merge $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-podmonitor.yaml
@@ -32,7 +32,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ $.Release.Namespace }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.arbiter.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" $ ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge $.Values.shardsvr.dataNode.podLabels $.Values.common.podLabels $.Values.common.podLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.dataNode.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr
@@ -33,7 +33,7 @@ spec:
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.dataNode.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if or $.Values.common.podAnnotations $.Values.shardsvr.dataNode.podAnnotations }}
-        {{- $annotations := merge $.Values.shardsvr.dataNode.podAnnotations $.Values.common.podAnnotations }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.dataNode.podAnnotations $.Values.common.podAnnotations ) "context" . ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations  "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.dataNode.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.dataNode.podLabels $.Values.common.podLabels $.Values.common.podLabels ) "context" $ ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: shardsvr
@@ -33,7 +33,7 @@ spec:
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.dataNode.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if or $.Values.common.podAnnotations $.Values.shardsvr.dataNode.podAnnotations }}
-        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.dataNode.podAnnotations $.Values.common.podAnnotations ) "context" . ) }}
+        {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.shardsvr.dataNode.podAnnotations $.Values.common.podAnnotations ) "context" $ ) }}
         {{- include "common.tplvalues.render" ( dict "value" $annotations  "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)