### PR TITLE
[bitnami/opensearch]: Use merge helper

### DIFF
--- a/.vib/opensearch/ginkgo/opensearch_suite_test.go
+++ b/.vib/opensearch/ginkgo/opensearch_suite_test.go
@@ -27,7 +27,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&releaseName, "name", "", "name of the primary statefulset")
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
-	flag.IntVar(&timeoutSeconds, "timeout", 120, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 240, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/bitnami/opensearch/Chart.lock
+++ b/bitnami/opensearch/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T14:25:45.817348+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:35:18.182244+02:00"

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -14,20 +14,20 @@ annotations:
 apiVersion: v2
 appVersion: 2.9.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: OpenSearch is a scalable open-source solution for search, analytics, and observability. Features full-text queries, natural language processing, custom dictionaries, amongst others.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/opensearch/img/opensearch-stack-220x234.png
 keywords:
-- opensearch
+  - opensearch
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: opensearch
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.2.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
+version: 0.2.2

--- a/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: opensearch

--- a/bitnami/opensearch/templates/coordinating/pdb.yaml
+++ b/bitnami/opensearch/templates/coordinating/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.coordinating.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.coordinating.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: coordinating-only

--- a/bitnami/opensearch/templates/coordinating/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/coordinating/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: coordinating-only
   {{- if or .Values.coordinating.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.coordinating.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.coordinating.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/opensearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/opensearch/templates/coordinating/statefulset.yaml
@@ -16,14 +16,14 @@ metadata:
     app: coordinating-only
     {{- end }}
   {{- if or .Values.coordinating.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.coordinating.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not .Values.coordinating.autoscaling.hpa.enabled }}
   replicas: {{ .Values.coordinating.replicaCount }}
   {{- end }}
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: coordinating-only

--- a/bitnami/opensearch/templates/coordinating/svc-headless.yaml
+++ b/bitnami/opensearch/templates/coordinating/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.coordinating.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: coordinating-only
 {{- end }}

--- a/bitnami/opensearch/templates/coordinating/vpa.yaml
+++ b/bitnami/opensearch/templates/coordinating/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opensearch
     app.kubernetes.io/component: coordinating-only
   {{- if or .Values.coordinating.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.coordinating.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/dashboards/deployment.yaml
+++ b/bitnami/opensearch/templates/dashboards/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.dashboards.updateStrategy }}
   strategy: {{- toYaml .Values.dashboards.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.dashboards.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: dashboards

--- a/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.dashboards.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: opensearch

--- a/bitnami/opensearch/templates/dashboards/pdb.yaml
+++ b/bitnami/opensearch/templates/dashboards/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.dashboards.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.dashboards.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.dashboards.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: dashboards

--- a/bitnami/opensearch/templates/dashboards/service.yaml
+++ b/bitnami/opensearch/templates/dashboards/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dashboards
   {{- if or .Values.dashboards.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboards.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.dashboards.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.dashboards.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.dashboards.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dashboards
 {{- end }}

--- a/bitnami/opensearch/templates/dashboards/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/dashboards/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: dashboards
   {{- if or .Values.dashboards.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboards.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.dashboards.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/opensearch/templates/dashboards/vpa.yaml
+++ b/bitnami/opensearch/templates/dashboards/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opensearch
     app.kubernetes.io/component: dashboards
   {{- if or .Values.dashboards.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.dashboards.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/data/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/data/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: opensearch

--- a/bitnami/opensearch/templates/data/pdb.yaml
+++ b/bitnami/opensearch/templates/data/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.data.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.data.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: data

--- a/bitnami/opensearch/templates/data/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/data/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: data
   {{- if or .Values.data.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.data.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.data.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/opensearch/templates/data/statefulset.yaml
+++ b/bitnami/opensearch/templates/data/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     app: data
     {{- end }}
   {{- if or .Values.data.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.data.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
   replicas: {{ .Values.data.replicaCount }}
   {{- end }}
   podManagementPolicy: {{ .Values.data.podManagementPolicy }}
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: data
@@ -329,7 +329,7 @@ spec:
     - metadata:
         name: "data"
         {{- if or .Values.data.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.data.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 4 }}
         {{- end }}
         {{- if .Values.commonLabels }}

--- a/bitnami/opensearch/templates/data/svc-headless.yaml
+++ b/bitnami/opensearch/templates/data/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.data.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: data
 {{- end }}

--- a/bitnami/opensearch/templates/data/vpa.yaml
+++ b/bitnami/opensearch/templates/data/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opensearch
     app.kubernetes.io/component: data
   {{- if or .Values.data.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.data.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/ingest/ingress.yaml
+++ b/bitnami/opensearch/templates/ingest/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/ingest/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/ingest/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: opensearch

--- a/bitnami/opensearch/templates/ingest/pdb.yaml
+++ b/bitnami/opensearch/templates/ingest/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.ingest.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.ingest.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: ingest

--- a/bitnami/opensearch/templates/ingest/service.yaml
+++ b/bitnami/opensearch/templates/ingest/service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -54,7 +54,7 @@ spec:
     {{- if .Values.ingest.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingest.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
 {{- end }}

--- a/bitnami/opensearch/templates/ingest/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/ingest/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.ingest.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/opensearch/templates/ingest/statefulset.yaml
+++ b/bitnami/opensearch/templates/ingest/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     app: ingest
     {{- end }}
   {{- if or .Values.ingest.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
   replicas: {{ .Values.ingest.replicaCount }}
   {{- end }}
   podManagementPolicy: {{ .Values.ingest.podManagementPolicy }}
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: ingest

--- a/bitnami/opensearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/opensearch/templates/ingest/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.ingest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: ingest
 {{- end }}

--- a/bitnami/opensearch/templates/ingest/vpa.yaml
+++ b/bitnami/opensearch/templates/ingest/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opensearch
     app.kubernetes.io/component: ingest
   {{- if or .Values.ingest.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/ingress.yaml
+++ b/bitnami/opensearch/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: opensearch
   {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/master/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/master/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: opensearch

--- a/bitnami/opensearch/templates/master/pdb.yaml
+++ b/bitnami/opensearch/templates/master/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.master.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.master.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: master

--- a/bitnami/opensearch/templates/master/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/master/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: master
   {{- if or .Values.master.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.master.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.master.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/opensearch/templates/master/statefulset.yaml
+++ b/bitnami/opensearch/templates/master/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     app: master
     {{- end }}
   {{- if or .Values.master.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.master.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -24,7 +24,7 @@ spec:
   replicas: {{ .Values.master.replicaCount }}
   {{- end }}
   podManagementPolicy: {{ .Values.master.podManagementPolicy }}
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: master
@@ -341,7 +341,7 @@ spec:
     - metadata:
         name: "data"
         {{- if or .Values.master.persistence.annotations .Values.commonAnnotations }}
-        {{- $claimAnnotations := merge .Values.master.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 4 }}
         {{- end }}
         {{- if .Values.commonLabels }}

--- a/bitnami/opensearch/templates/master/svc-headless.yaml
+++ b/bitnami/opensearch/templates/master/svc-headless.yaml
@@ -25,7 +25,7 @@ spec:
     - name: tcp-transport
       port: {{ .Values.containerPorts.transport }}
       targetPort: transport
-  {{- $podLabels := merge .Values.master.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: master
 {{- end }}

--- a/bitnami/opensearch/templates/master/vpa.yaml
+++ b/bitnami/opensearch/templates/master/vpa.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opensearch
     app.kubernetes.io/component: master
   {{- if or .Values.ingest.autoscaling.vpa.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.ingest.autoscaling.vpa.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.autoscaling.vpa.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/opensearch/templates/service.yaml
+++ b/bitnami/opensearch/templates/service.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: master
     {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)