### PR TITLE
[bitnami/pinniped]: Use merge helper

### DIFF
--- a/bitnami/pinniped/Chart.lock
+++ b/bitnami/pinniped/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:416ad278a896f0e9b51d5305bef5d875c7cca6fbb64b75e1f131b04763e2aff9
-generated: "2023-08-22T14:26:54.612823+02:00"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:35:35.449789+02:00"

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -10,21 +10,21 @@ annotations:
 apiVersion: v2
 appVersion: 0.25.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Pinniped is an identity service provider for Kubernetes. It supplies a consistent and unified login experience across all your clusters. Pinniped is securely integrated with enterprise IDP protocols.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/pinniped/img/pinniped-stack-220x234.png
 keywords:
-- identity
-- infrastructure
+  - identity
+  - infrastructure
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: pinniped
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.3.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
+version: 1.3.2

--- a/bitnami/pinniped/templates/concierge/deployment.yaml
+++ b/bitnami/pinniped/templates/concierge/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.concierge.updateStrategy }}
   strategy: {{- toYaml .Values.concierge.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.concierge.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: concierge

--- a/bitnami/pinniped/templates/concierge/impersonation-proxy-service-account.yaml
+++ b/bitnami/pinniped/templates/concierge/impersonation-proxy-service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
   {{- if or .Values.concierge.serviceAccount.impersonationProxy.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.concierge.serviceAccount.impersonationProxy.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.serviceAccount.impersonationProxy.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.concierge.serviceAccount.impersonationProxy.automountServiceAccountToken }}

--- a/bitnami/pinniped/templates/concierge/kube-cert-agent-service-account.yaml
+++ b/bitnami/pinniped/templates/concierge/kube-cert-agent-service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
   {{- if or .Values.concierge.serviceAccount.kubeCertAgentService.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.concierge.serviceAccount.kubeCertAgentService.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.serviceAccount.kubeCertAgentService.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.concierge.serviceAccount.kubeCertAgentService.automountServiceAccountToken }}

--- a/bitnami/pinniped/templates/concierge/service-account.yaml
+++ b/bitnami/pinniped/templates/concierge/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
   {{- if or .Values.concierge.serviceAccount.concierge.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.concierge.serviceAccount.concierge.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.serviceAccount.concierge.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.concierge.serviceAccount.concierge.automountServiceAccountToken }}

--- a/bitnami/pinniped/templates/concierge/service-api.yaml
+++ b/bitnami/pinniped/templates/concierge/service-api.yaml
@@ -22,7 +22,7 @@ spec:
     - protocol: TCP
       port: 443
       targetPort: https-api
-  {{- $podLabels := merge .Values.concierge.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: concierge
 {{- end }}

--- a/bitnami/pinniped/templates/concierge/service-proxy.yaml
+++ b/bitnami/pinniped/templates/concierge/service-proxy.yaml
@@ -9,12 +9,12 @@ kind: Service
 metadata:
   name: {{ template "pinniped.concierge.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.concierge.service.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: concierge
   {{- if or .Values.concierge.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.concierge.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -50,7 +50,7 @@ spec:
     {{- if .Values.concierge.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.concierge.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.concierge.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.concierge.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: concierge
 {{- end }}

--- a/bitnami/pinniped/templates/supervisor/deployment.yaml
+++ b/bitnami/pinniped/templates/supervisor/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.supervisor.updateStrategy }}
   strategy: {{- toYaml .Values.supervisor.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.supervisor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: supervisor

--- a/bitnami/pinniped/templates/supervisor/ingress.yaml
+++ b/bitnami/pinniped/templates/supervisor/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.supervisor.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.supervisor.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/pinniped/templates/supervisor/service-account.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
   {{- if or .Values.supervisor.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.supervisor.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.supervisor.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/pinniped/templates/supervisor/service-api.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-api.yaml
@@ -9,12 +9,12 @@ kind: Service
 metadata:
   name: {{ template "pinniped.supervisor.api.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.supervisor.service.api.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.service.api.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
   {{- if or .Values.supervisor.service.api.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.supervisor.service.api.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.service.api.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -52,7 +52,7 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .extraPorts "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- $podLabels := merge .Values.supervisor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: supervisor
 {{- end }}

--- a/bitnami/pinniped/templates/supervisor/service.yaml
+++ b/bitnami/pinniped/templates/supervisor/service.yaml
@@ -9,12 +9,12 @@ kind: Service
 metadata:
   name: {{ template "pinniped.supervisor.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := merge .Values.supervisor.service.public.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.service.public.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
   {{- if or .Values.supervisor.service.public.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.supervisor.service.public.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.service.public.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -52,7 +52,7 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .extraPorts "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- $podLabels := merge .Values.supervisor.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.supervisor.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: supervisor
 {{- end }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)