### PR TITLE
[bitnami/spring-cloud-dataflow]: Use merge helper

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.1.2
+  version: 12.1.3
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.1.1
+  version: 13.1.2
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 25.1.0
+  version: 25.1.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:413b30633d200fb766200c5687565249962e3c137c200e99a3e377e1c7661762
-generated: "2023-08-25T09:45:58.358204+02:00"
+  version: 2.10.0
+digest: sha256:26891a01daefc2b53ae5eefebcc06548ce3467a8db367e081dab9c9b1766bf1f
+generated: "2023-09-05T11:36:22.997409+02:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -20,37 +20,37 @@ annotations:
 apiVersion: v2
 appVersion: 2.10.3
 dependencies:
-- condition: rabbitmq.enabled
-  name: rabbitmq
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
-- condition: mariadb.enabled
-  name: mariadb
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - dataflow-database
-  version: 13.x.x
-- condition: kafka.enabled
-  name: kafka
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 25.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: rabbitmq.enabled
+    name: rabbitmq
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - dataflow-database
+    version: 13.x.x
+  - condition: kafka.enabled
+    name: kafka
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 25.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/spring-cloud-dataflow/img/spring-cloud-dataflow-stack-220x234.png
 keywords:
-- spring-cloud
-- dataflow
-- skipper
-- spring
+  - spring-cloud
+  - dataflow
+  - skipper
+  - spring
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: spring-cloud-dataflow
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 23.1.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
+version: 23.1.1

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.metrics.updateStrategy }}
   strategy: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.metrics.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: prometheus-proxy

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.metrics.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.metrics.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.metrics.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: prometheus-proxy

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: prometheus-proxy
   namespace: {{ .Release.Namespace }}
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -54,7 +54,7 @@ spec:
       {{- else }}
       nodePort: null
       {{- end }}
-  {{- $podLabels := merge .Values.metrics.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "scdf.fullname" . }}-prometheus-proxy
-  {{- $labels := merge .Values.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
   namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: server

--- a/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.server.ingress.annotations .Values.commonAnnotations }}
-    {{- $annotations := merge .Values.server.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:

--- a/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.server.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.server.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: server

--- a/bitnami/spring-cloud-dataflow/templates/server/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/service.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
   namespace: {{ .Release.Namespace }}
   {{- if or .Values.server.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -46,6 +46,6 @@ spec:
     {{- if .Values.server.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.server.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.skipper.replicaCount }}
-  {{- $podLabels := merge .Values.skipper.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: skipper

--- a/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.skipper.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.skipper.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.skipper.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: skipper

--- a/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: skipper
   namespace: {{ .Release.Namespace }}
   {{- if or .Values.skipper.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.skipper.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -47,7 +47,7 @@ spec:
     {{- if .Values.skipper.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.skipper.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.skipper.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: skipper
 {{- end }}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)