### PR TITLE
[bitnami/supabase]: Use merge helper

### DIFF
--- a/bitnami/supabase/Chart.lock
+++ b/bitnami/supabase/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 9.5.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:40e5210825d22791f03bfce46b05f9d323e363325ef2632116eceb3323afcf83
-generated: "2023-08-28T08:26:40.168478+02:00"
+  version: 2.10.0
+digest: sha256:2a9e2303797603ab4c48c4637c03892423eb8246655e029470a097cacc8cdfd4
+generated: "2023-09-05T11:36:32.082015+02:00"

--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -28,29 +28,29 @@ annotations:
 apiVersion: v2
 appVersion: 0.23.6
 dependencies:
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
-- condition: kong.enabled
-  name: kong
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.x.x
+  - condition: kong.enabled
+    name: kong
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 9.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Supabase is an open source Firebase alternative. Provides all the necessary backend features to build your application in a scalable way. Uses PostgreSQL as datastore.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/supabase/img/supabase-stack-220x234.png
 keywords:
-- development
-- dashboards
+  - development
+  - dashboards
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: supabase
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 0.4.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/supabase
+version: 0.4.2

--- a/bitnami/supabase/templates/auth/deployment.yaml
+++ b/bitnami/supabase/templates/auth/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.auth.updateStrategy }}
   strategy: {{- toYaml .Values.auth.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.auth.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.auth.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: auth

--- a/bitnami/supabase/templates/auth/service.yaml
+++ b/bitnami/supabase/templates/auth/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: auth
   {{- if or .Values.auth.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.auth.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.auth.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.auth.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.auth.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.auth.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.auth.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: auth

--- a/bitnami/supabase/templates/jwt-init-job.yaml
+++ b/bitnami/supabase/templates/jwt-init-job.yaml
@@ -12,14 +12,14 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: supabase
   {{- if or .Values.jwt.autoGenerate.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.jwt.autoGenerate.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.jwt.autoGenerate.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   backoffLimit: {{ .Values.jwt.autoGenerate.backoffLimit }}
   template:
     metadata:
-      {{- $podLabels := merge .Values.jwt.autoGenerate.podLabels .Values.commonLabels }}
+      {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.jwt.autoGenerate.podLabels .Values.commonLabels ) "context" . ) }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: init
       {{- if .Values.jwt.autoGenerate.podAnnotations }}

--- a/bitnami/supabase/templates/meta/deployment.yaml
+++ b/bitnami/supabase/templates/meta/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.meta.updateStrategy }}
   strategy: {{- toYaml .Values.meta.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.meta.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.meta.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: meta

--- a/bitnami/supabase/templates/meta/service.yaml
+++ b/bitnami/supabase/templates/meta/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: meta
   {{- if or .Values.meta.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.meta.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.meta.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.meta.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.meta.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.meta.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.meta.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: meta

--- a/bitnami/supabase/templates/realtime/deployment.yaml
+++ b/bitnami/supabase/templates/realtime/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.realtime.updateStrategy }}
   strategy: {{- toYaml .Values.realtime.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.realtime.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.realtime.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: realtime

--- a/bitnami/supabase/templates/realtime/service.yaml
+++ b/bitnami/supabase/templates/realtime/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: realtime
   {{- if or .Values.realtime.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.realtime.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.realtime.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.realtime.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.realtime.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.realtime.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.realtime.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: realtime

--- a/bitnami/supabase/templates/rest/deployment.yaml
+++ b/bitnami/supabase/templates/rest/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.rest.updateStrategy }}
   strategy: {{- toYaml .Values.rest.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.rest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.rest.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: rest

--- a/bitnami/supabase/templates/rest/service.yaml
+++ b/bitnami/supabase/templates/rest/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: rest
   {{- if or .Values.rest.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.rest.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.rest.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.rest.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.rest.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.rest.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.rest.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: rest

--- a/bitnami/supabase/templates/service-account.yaml
+++ b/bitnami/supabase/templates/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: supabase
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/supabase/templates/storage/deployment.yaml
+++ b/bitnami/supabase/templates/storage/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.storage.updateStrategy }}
   strategy: {{- toYaml .Values.storage.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.storage.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.storage.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: storage

--- a/bitnami/supabase/templates/storage/pvc.yaml
+++ b/bitnami/supabase/templates/storage/pvc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: storage
   {{- if or .Values.storage.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.storage.persistence.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.storage.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/supabase/templates/storage/service.yaml
+++ b/bitnami/supabase/templates/storage/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: storage
   {{- if or .Values.storage.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.storage.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.storage.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.storage.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.storage.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.storage.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.storage.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: storage

--- a/bitnami/supabase/templates/studio/deployment.yaml
+++ b/bitnami/supabase/templates/studio/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.studio.updateStrategy }}
   strategy: {{- toYaml .Values.studio.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.studio.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.studio.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: studio

--- a/bitnami/supabase/templates/studio/ingress.yaml
+++ b/bitnami/supabase/templates/studio/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: studio
   {{- if or .Values.studio.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.studio.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.studio.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/supabase/templates/studio/service.yaml
+++ b/bitnami/supabase/templates/studio/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: supabase
     app.kubernetes.io/component: studio
   {{- if or .Values.studio.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.studio.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.studio.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.studio.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.studio.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.studio.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.studio.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: studio


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)