### PR TITLE
[bitnami/vault]: Use merge helper

### DIFF
--- a/bitnami/vault/Chart.lock
+++ b/bitnami/vault/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.1
-digest: sha256:1670870388a94ddd4f318012c54370d82edaf406e9fa049f28270154b461aeb2
-generated: "2023-08-30T07:52:54.242579661Z"
+  version: 2.10.0
+digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
+generated: "2023-09-05T11:36:44.601736+02:00"

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -16,23 +16,23 @@ annotations:
 apiVersion: v2
 appVersion: 1.14.2
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Vault is a tool for securely managing and accessing secrets using a unified interface. Features secure storage, dynamic secrets, data encryption and revocation.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/vault/img/vault-stack-220x234.png
 keywords:
-- security
-- secrets
-- injection
-- vault
+  - security
+  - secrets
+  - injection
+  - vault
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+  - name: VMware, Inc.
+    url: https://github.com/bitnami/charts
 name: vault
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 0.3.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/vault
+version: 0.3.2

--- a/bitnami/vault/templates/csi-provider/daemonset.yaml
+++ b/bitnami/vault/templates/csi-provider/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.csiProvider.updateStrategy }}
   updateStrategy: {{- toYaml .Values.csiProvider.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.csiProvider.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.csiProvider.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: vault

--- a/bitnami/vault/templates/csi-provider/service-account.yaml
+++ b/bitnami/vault/templates/csi-provider/service-account.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "vault.csi-provider.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.csiProvider.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.csiProvider.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.csiProvider.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.csiProvider.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/vault/templates/injector/deployment.yaml
+++ b/bitnami/vault/templates/injector/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.injector.updateStrategy }}
   strategy: {{- toYaml .Values.injector.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.injector.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: vault

--- a/bitnami/vault/templates/injector/pdb.yaml
+++ b/bitnami/vault/templates/injector/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.injector.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.injector.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.injector.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: vault

--- a/bitnami/vault/templates/injector/service-account.yaml
+++ b/bitnami/vault/templates/injector/service-account.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.injector.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.injector.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.injector.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/vault/templates/injector/service.yaml
+++ b/bitnami/vault/templates/injector/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: injector
   {{- if or .Values.injector.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.injector.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.injector.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.injector.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.injector.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: injector

--- a/bitnami/vault/templates/server/active-service.yaml
+++ b/bitnami/vault/templates/server/active-service.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- if or .Values.server.service.active.annotations .Values.commonAnnotations }}
   annotations:
     {{- if or .Values.server.service.active.annotations .Values.commonAnnotations (and .Values.server.metrics.enabled .Values.server.metrics.annotations) }}
-    {{- $annotations := merge .Values.server.service.active.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.active.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.server.metrics.enabled .Values.server.metrics.annotations }}
@@ -64,7 +64,7 @@ spec:
     {{- if .Values.server.service.active.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.server.service.active.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.injector.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: vault

--- a/bitnami/vault/templates/server/ingress.yaml
+++ b/bitnami/vault/templates/server/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: server
   {{- if or .Values.server.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/vault/templates/server/pdb.yaml
+++ b/bitnami/vault/templates/server/pdb.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.server.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.server.pdb.maxUnavailable }}
   {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: vault

--- a/bitnami/vault/templates/server/service-account.yaml
+++ b/bitnami/vault/templates/server/service-account.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.server.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.server.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/vault/templates/server/service-headless.yaml
+++ b/bitnami/vault/templates/server/service-headless.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: server
   {{- if or .Values.server.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -27,7 +27,7 @@ spec:
     - name: https-internal
       port: {{ .Values.server.service.general.ports.internal }}
       targetPort: https-internal
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: server

--- a/bitnami/vault/templates/server/service.yaml
+++ b/bitnami/vault/templates/server/service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: server
   {{- if or .Values.server.service.general.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.service.general.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.general.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
@@ -58,7 +58,7 @@ spec:
     {{- if .Values.server.service.general.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.server.service.general.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: server

--- a/bitnami/vault/templates/server/servicemonitor.yaml
+++ b/bitnami/vault/templates/server/servicemonitor.yaml
@@ -9,12 +9,12 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "vault.server.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.server.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := merge .Values.server.metrics.serviceMonitor.labels .Values.commonLabels }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: vault
     app.kubernetes.io/component: server
   {{- if or .Values.server.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
-  {{- $annotations := merge .Values.server.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/vault/templates/server/statefulset.yaml
+++ b/bitnami/vault/templates/server/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
   {{- if .Values.server.updateStrategy }}
   updateStrategy: {{- toYaml .Values.server.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := merge .Values.server.podLabels .Values.commonLabels }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: vault


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/18889 adapting the chart to use the new helper `common.tplvalues.merge` donated by @jouve to merge annotations & labels.

### Benefits

Chart to be compatible with values with string templates & dicts, so both the formats below can be used:

```yaml
podLabels:
  foo: "bar"
  app.kubernetes.io/name: "{{ join \"-\" (list \"prefix\" .Release.Name)  }}"
```

```yaml
podLabels: |
  {{ include "XXX.labels" . }}
```

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)