### PR TITLE
[bitnami/nginx-ingress-controller] Replace kuard with dokuwiki

### DIFF
--- a/.vib/nginx-ingress-controller/ginkgo/integration_suite_test.go
+++ b/.vib/nginx-ingress-controller/ginkgo/integration_suite_test.go
@@ -33,8 +33,8 @@ const APP_NAME = "NGINX Ingress Controller"
 
 var kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 var namespace = flag.String("namespace", "", "namespace where the resources are deployed")
-var svcName = flag.String("service-name", "", "service name used to serve the kuard deployment")
-var svcPort = flag.String("service-port", "", "service port used to serve the kuard deployment")
+var svcName = flag.String("service-name", "", "service name used to serve the dokuwiki deployment")
+var svcPort = flag.String("service-port", "", "service port used to serve the dokuwiki deployment")
 
 func clusterConfigOrDie() *rest.Config {
 	var config *rest.Config
@@ -207,10 +207,10 @@ func CheckRequirements() {
 		panic(fmt.Sprintf("The namespace where %s is deployed must be provided. Use the '--namespace' flag", APP_NAME))
 	}
 	if *svcName == "" {
-		panic(fmt.Sprintln("The testing service name used to serve the kuard deployment must be provided. Use the '--service-name' flag"))
+		panic(fmt.Sprintln("The testing service name used to serve the dokuwiki deployment must be provided. Use the '--service-name' flag"))
 	}
 	if *svcPort == "" {
-		panic(fmt.Sprintln("The testing service port used to serve the kuard deployment must be provided. Use the '--service-port' flag"))
+		panic(fmt.Sprintln("The testing service port used to serve the dokuwiki deployment must be provided. Use the '--service-port' flag"))
 	}
 }
 

--- a/.vib/nginx-ingress-controller/ginkgo/nginx_ingress_controller_test.go
+++ b/.vib/nginx-ingress-controller/ginkgo/nginx_ingress_controller_test.go
@@ -69,7 +69,7 @@ var _ = Describe("NGINX Ingress Controller:", func() {
 
 		It("the host resolves to the testing deployment", func() {
 			responseBody := getResponseBodyOrDie(ctx, "http://"+ingressHost)
-			Expect(containsString(responseBody, "kuard")).To(BeTrue())
+			Expect(containsString(responseBody, "dokuwiki")).To(BeTrue())
 		})
 	})
 })

--- a/.vib/nginx-ingress-controller/runtime-parameters.yaml
+++ b/.vib/nginx-ingress-controller/runtime-parameters.yaml
@@ -41,27 +41,27 @@ extraDeploy:
   kind: Deployment
   metadata:
     labels:
-      app: kuard
-    name: kuard
+      app: dokuwiki
+    name: dokuwiki
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: kuard
+        app: dokuwiki
     template:
       metadata:
         labels:
-          app: kuard
+          app: dokuwiki
       spec:
         containers:
-        - image: gcr.io/kuar-demo/kuard-amd64:1
-          name: kuard
+        - image: docker.io/bitnami/dokuwiki:latest
+          name: dokuwiki
 - apiVersion: v1
   kind: Service
   metadata:
     labels:
-      app: kuard
-    name: kuard-vib
+      app: dokuwiki
+    name: dokuwiki-vib
   spec:
     ports:
     - port: 80
@@ -73,6 +73,6 @@ extraDeploy:
       targetPort: 443
       name: https
     selector:
-      app: kuard
+      app: dokuwiki
     sessionAffinity: None
     type: ClusterIP

--- a/.vib/nginx-ingress-controller/vib-publish.json
+++ b/.vib/nginx-ingress-controller/vib-publish.json
@@ -61,7 +61,7 @@
             "params": {
               "kubeconfig": "{{kubeconfig}}",
               "namespace": "{{namespace}}",
-              "service-name": "kuard-vib",
+              "service-name": "dokuwiki-vib",
               "service-port": "80"
             }
           }

--- a/.vib/nginx-ingress-controller/vib-verify.json
+++ b/.vib/nginx-ingress-controller/vib-verify.json
@@ -61,7 +61,7 @@
             "params": {
               "kubeconfig": "{{kubeconfig}}",
               "namespace": "{{namespace}}",
-              "service-name": "kuard-vib",
+              "service-name": "dokuwiki-vib",
               "service-port": "80"
             }
           }

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 9.8.1
+version: 9.8.2

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 9.8.2
+version: 9.8.1


### PR DESCRIPTION
### Description of the change

This PR replaces the [kuard image](https://github.com/kubernetes-up-and-running/kuard) used as demo web app for NGINX Ingress Controller ginkgo tests. Instead, we'll use Bitnami Dokuwiki since it's compatible with multi-arch environments.

### Benefits

VIB tests pass on different arch clusters.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
