### PR TITLE
[bitnami/contour] Disable hostPort for VIB tests

### DIFF
--- a/.vib/contour/runtime-parameters.yaml
+++ b/.vib/contour/runtime-parameters.yaml
@@ -18,6 +18,7 @@ contour:
     type: ClusterIP
 envoy:
   enabled: true
+  useHostPort: false
   containerPorts:
     http: 8080
     https: 8080

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 12.6.1
+version: 12.6.2


### PR DESCRIPTION
### Description of the change

This PR disables the use of hostPort on Envoy daemonset for VIB tests since it's incompatible with some K8s platforms such as Openshift:

```
Warning  FailedScheduling  52s   default-scheduler  0/1 nodes are available: 1 node(s) didn't have free ports for the requested pod ports. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod..
```

### Benefits

VIB tests successfully executed on Openshift.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

N/A