### PR TITLE
[bitnami/common]: Compatiblity with Helm 3.2.0+

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.9.2
+appVersion: 2.10.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.10.0
+version: 2.10.1

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -11,16 +11,7 @@ Kubernetes standard labels
 */}}
 {{- define "common.labels.standard" -}}
 {{- if and (hasKey . "customLabels") (hasKey . "context") -}}
-{{ merge
-        (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml)
-        (dict
-            "app.kubernetes.io/name" (include "common.names.name" .context)
-            "helm.sh/chart" (include "common.names.chart" .context)
-            "app.kubernetes.io/instance" .context.Release.Name
-            "app.kubernetes.io/managed-by" .context.Release.Service
-        )
-    | toYaml
-}}
+{{ merge (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml) (dict "app.kubernetes.io/name" (include "common.names.name" .context) "helm.sh/chart" (include "common.names.chart" .context) "app.kubernetes.io/instance" .context.Release.Name "app.kubernetes.io/managed-by" .context.Release.Service) | toYaml }}
 {{- else -}}
 app.kubernetes.io/name: {{ include "common.names.name" . }}
 helm.sh/chart: {{ include "common.names.chart" . }}
@@ -40,14 +31,7 @@ overwrote them on metadata.labels fields.
 */}}
 {{- define "common.labels.matchLabels" -}}
 {{- if and (hasKey . "customLabels") (hasKey . "context") -}}
-{{ merge
-        (pick (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml) "app.kubernetes.io/name" "app.kubernetes.io/instance")
-        (dict
-            "app.kubernetes.io/name" (include "common.names.name" .context)
-            "app.kubernetes.io/instance" .context.Release.Name
-        )
-    | toYaml
-}}
+{{ merge (pick (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml) "app.kubernetes.io/name" "app.kubernetes.io/instance") (dict "app.kubernetes.io/name" (include "common.names.name" .context) "app.kubernetes.io/instance" .context.Release.Name ) | toYaml }}
 {{- else -}}
 app.kubernetes.io/name: {{ include "common.names.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
### Description of the change

This PR attempts to fix an incompatibility introduced at #18154 due to the use of "new line" characters on some `dict` instructions. [This limitation](https://github.com/golang/go/issues/29770) that was fixed in `go1.16` affects Helm < 3.6 versions.

### Benefits

Users can use any Helm 3.2.0+ version with `bitnami/common`.

### Possible drawbacks

None

### Applicable issues

- fixes #19011

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
