### PR TITLE
[bitnami/contour]: VIB test envoy's container port

### DIFF
--- a/.vib/contour/runtime-parameters.yaml
+++ b/.vib/contour/runtime-parameters.yaml
@@ -20,7 +20,7 @@ envoy:
   enabled: true
   containerPorts:
     http: 8080
-    https: 8080
+    https: 8443
   service:
     type: LoadBalancer
     externalTrafficPolicy: Local


### PR DESCRIPTION
### Description of the change

This PR fixes the `values.yaml` used to install Contour chart since we're setting the same container port for both HTTP & HTTPS .

### Benefits

Testing Contour with a reasonable configuration.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
