### PR TITLE
[bitnami/contour]: Fix typo in goss tests

### DIFF
--- a/.vib/contour/goss/goss.yaml
+++ b/.vib/contour/goss/goss.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 http:
-  http://contour-envoy:{{ .Vars.envoy.service.ports.https }}:
+  http://contour-envoy:{{ .Vars.envoy.service.ports.http }}:
     status: 200
 addr:
   tcp://contour:{{ .Vars.contour.service.ports.xds }}:

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 12.6.2
+version: 12.6.1

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 12.6.1
+version: 12.6.2


### PR DESCRIPTION
### Description of the change

This PR fixes a typo in contour goss tests since we're accessing to Envoy UI using http protocol but https port.

### Benefits

Fix test suite.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
