### PR TITLE
 [bitnami/*] Autogenerate json-schema files for all the charts

### DIFF
--- a/bitnami/airflow/values.schema.json
+++ b/bitnami/airflow/values.schema.json
@@ -1,0 +1,2339 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Extra objects to deploy (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "description": "Username to access web UI",
+                    "default": "user"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to access web UI",
+                    "default": ""
+                },
+                "fernetKey": {
+                    "type": "string",
+                    "description": "Fernet key to secure connections",
+                    "default": ""
+                },
+                "secretKey": {
+                    "type": "string",
+                    "description": "Secret key to run your flask app",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret to use for Airflow credentials",
+                    "default": ""
+                }
+            }
+        },
+        "executor": {
+            "type": "string",
+            "description": "Airflow executor. Allowed values: `SequentialExecutor`, `LocalExecutor`, `CeleryExecutor`, `KubernetesExecutor`, `CeleryKubernetesExecutor` and `LocalKubernetesExecutor`",
+            "default": "CeleryExecutor"
+        },
+        "loadExamples": {
+            "type": "boolean",
+            "description": "Switch to load some Airflow examples",
+            "default": false
+        },
+        "configuration": {
+            "type": "string",
+            "description": "Specify content for Airflow config file (auto-generated based on other env. vars otherwise)",
+            "default": ""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "Name of an existing ConfigMap with the Airflow config file",
+            "default": ""
+        },
+        "dags": {
+            "type": "object",
+            "properties": {
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing ConfigMap with all the DAGs files you want to load in Airflow",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container load-dags image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container load-dags image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container load-dags image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container load-dags image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container load-dags image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container load-dags image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Add extra environment variables for all the Airflow pods",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables for all the Airflow pods",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables for all the Airflow pods",
+            "default": ""
+        },
+        "extraEnvVarsSecrets": {
+            "type": "array",
+            "description": "List of secrets with extra environment variables for all the Airflow pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to all the Airflow pods",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to all the Airflow pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for all the Airflow pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the all the Airflow pods",
+            "default": [],
+            "items": {}
+        },
+        "web": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Airflow image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Airflow image repository",
+                            "default": "bitnami/airflow"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Airflow image tag (immutable tags are recommended)",
+                            "default": "2.7.1-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Airflow image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Airflow image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Airflow image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "baseUrl": {
+                    "type": "string",
+                    "description": "URL used to access to Airflow web ui",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing config map containing the Airflow web config file",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Airflow web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Airflow web pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Airflow web pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecrets": {
+                    "type": "array",
+                    "description": "List of secrets with extra environment variables for Airflow web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Airflow web HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Airflow web replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Airflow web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Airflow web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Airflow web containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Airflow web containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Airflow web containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Airflow web pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Airflow web pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Airflow web containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Airflow web containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Airflow web containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Airflow web container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add extra labels to the Airflow web pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Add extra annotations to the Airflow web pods",
+                    "default": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Airflow web pods assignment (evaluated as a template)",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `web.affinity` is set.",
+                            "default": ""
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `web.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Airflow web pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.",
+                    "default": "soft"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Airflow web pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Airflow web pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Airflow web deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Airflow web deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Airflow web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Airflow web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Airflow web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Airflow web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy a pdb object for the Airflow web pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Maximum number/percentage of unavailable Airflow web replicas",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of unavailable Airflow web replicas",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "scheduler": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Airflow Scheduler image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Airflow Scheduler image repository",
+                            "default": "bitnami/airflow-scheduler"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Airflow Scheduler image tag (immutable tags are recommended)",
+                            "default": "2.7.1-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Airflow Schefuler image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Airflow Scheduler image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Airflow Scheduler image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of scheduler replicas",
+                    "default": 1
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override cmd",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override args",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecrets": {
+                    "type": "array",
+                    "description": "List of secrets with extra environment variables for Airflow scheduler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Airflow scheduler containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Airflow scheduler containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Airflow scheduler pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Airflow scheduler pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Airflow scheduler containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Airflow scheduler containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Airflow scheduler containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Airflow scheduler container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add extra labels to the Airflow scheduler pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Add extra annotations to the Airflow scheduler pods",
+                    "default": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Airflow scheduler pods assignment (evaluated as a template)",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `scheduler.affinity` is set.",
+                            "default": ""
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `scheduler.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Airflow scheduler pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`.",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`.",
+                    "default": "soft"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Airflow scheduler pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Airflow scheduler pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Airflow scheduler deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Airflow scheduler deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Airflow scheduler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Airflow scheduler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Airflow scheduler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Airflow scheduler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy a pdb object for the Airflow scheduler pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Maximum number/percentage of unavailable Airflow scheduler replicas",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of unavailable Airflow scheduler replicas",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "worker": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Airflow Worker image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Airflow Worker image repository",
+                            "default": "bitnami/airflow-worker"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Airflow Worker image tag (immutable tags are recommended)",
+                            "default": "2.7.1-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Airflow Worker image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Airflow Worker image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Airflow Worker image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Airflow worker pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Airflow worker pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Airflow worker pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecrets": {
+                    "type": "array",
+                    "description": "List of secrets with extra environment variables for Airflow worker pods",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Airflow worker HTTP container port",
+                            "default": 8793
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Airflow worker replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Airflow worker containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Airflow worker containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Airflow worker containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Airflow worker containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Airflow worker containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Airflow worker pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Airflow worker pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Airflow worker containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Airflow worker containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Airflow worker containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Airflow worker container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add extra labels to the Airflow worker pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Add extra annotations to the Airflow worker pods",
+                    "default": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Airflow worker pods assignment (evaluated as a template)",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `worker.affinity` is set.",
+                            "default": ""
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `worker.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Airflow worker pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`.",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`.",
+                    "default": "soft"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Airflow worker pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Airflow worker pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Airflow worker deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Airflow worker deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Airflow worker pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Airflow worker pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Airflow worker pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Airflow worker pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeClaimTemplates": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of volumesClaimTemplates for the Airflow worker statefulset",
+                    "default": [],
+                    "items": {}
+                },
+                "podTemplate": {
+                    "type": "object",
+                    "description": "Template to replace the default one to be use when `executor=KubernetesExecutor` to create Airflow worker pods",
+                    "default": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy a pdb object for the Airflow worker pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Maximum number/percentage of unavailable Airflow worker replicas",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of unavailable Airflow worker replicas",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether enable horizontal pod autoscaler",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Configure a minimum amount of pods",
+                            "default": 1
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Configure a maximum amount of pods",
+                            "default": 3
+                        },
+                        "targetCPU": {
+                            "type": "number",
+                            "description": "Define the CPU target to trigger the scaling actions (utilization percentage)",
+                            "default": 80
+                        },
+                        "targetMemory": {
+                            "type": "number",
+                            "description": "Define the memory target to trigger the scaling actions (utilization percentage)",
+                            "default": 80
+                        }
+                    }
+                }
+            }
+        },
+        "git": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Git image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Git image repository",
+                            "default": "bitnami/git"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Git image tag (immutable tags are recommended)",
+                            "default": "2.42.0-debian-11-r14"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Git image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Git image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "dags": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable in order to download DAG files from git repositories.",
+                            "default": false
+                        },
+                        "repositories": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "repository": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "branch": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "plugins": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable in order to download Plugins files from git repositories.",
+                            "default": false
+                        },
+                        "repositories": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "repository": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "branch": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "clone": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "array",
+                            "description": "Override cmd",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override args",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Add extra volume mounts",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Add extra environment variables",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap with extra environment variables",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret with extra environment variables",
+                            "default": ""
+                        },
+                        "resources": {
+                            "type": "object",
+                            "description": "Clone init container resource requests and limits",
+                            "default": {}
+                        }
+                    }
+                },
+                "sync": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "number",
+                            "description": "Interval in seconds to pull the git repository containing the plugins and/or DAG files",
+                            "default": 60
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override cmd",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override args",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Add extra volume mounts",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Add extra environment variables",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap with extra environment variables",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret with extra environment variables",
+                            "default": ""
+                        },
+                        "resources": {
+                            "type": "object",
+                            "description": "Sync sidecar container resource requests and limits",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP authentication",
+                    "default": false
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "Server URI, eg. ldap://ldap_server:389",
+                    "default": "ldap://ldap_server:389"
+                },
+                "basedn": {
+                    "type": "string",
+                    "description": "Base of the search, eg. ou=example,o=org.",
+                    "default": "dc=example,dc=org"
+                },
+                "searchAttribute": {
+                    "type": "string",
+                    "description": "if doing an indirect bind to ldap, this is the field that matches the username when searching for the account to bind to",
+                    "default": "cn"
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "DN of the account used to search in the LDAP server.",
+                    "default": "cn=admin,dc=example,dc=org"
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "Bind Password",
+                    "default": ""
+                },
+                "userRegistration": {
+                    "type": "string",
+                    "description": "Set to True to enable user self registration",
+                    "default": "True"
+                },
+                "userRegistrationRole": {
+                    "type": "string",
+                    "description": "Set role name to be assign when a user registers himself. This role must already exist. Mandatory when using ldap.userRegistration",
+                    "default": "Public"
+                },
+                "rolesMapping": {
+                    "type": "string",
+                    "description": "mapping from LDAP DN to a list of roles",
+                    "default": "{ \"cn=All,ou=Groups,dc=example,dc=org\": [\"User\"], \"cn=Admins,ou=Groups,dc=example,dc=org\": [\"Admin\"], }"
+                },
+                "rolesSyncAtLogin": {
+                    "type": "string",
+                    "description": "replace ALL the user's roles each login, or only on registration",
+                    "default": "True"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled TLS/SSL for LDAP, you must include the CA file.",
+                            "default": false
+                        },
+                        "allowSelfSigned": {
+                            "type": "boolean",
+                            "description": "Allow to use self signed certificates",
+                            "default": true
+                        },
+                        "certificatesSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the certificate CA file that will be used by ldap client",
+                            "default": ""
+                        },
+                        "certificatesMountPath": {
+                            "type": "string",
+                            "description": "Where LDAP certifcates are mounted.",
+                            "default": "/opt/bitnami/airflow/conf/certs"
+                        },
+                        "CAFilename": {
+                            "type": "string",
+                            "description": "LDAP CA cert filename",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Airflow service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Airflow service HTTP port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Airflow service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Airflow service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Airflow service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Airflow service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Airflow service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Airflow service",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Airflow",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "airflow.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Airflow pods",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create Role and RoleBinding",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether or not to create a standalone Airflow exporter to expose Airflow metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Airflow exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Airflow exporter image repository",
+                            "default": "bitnami/airflow-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Airflow exporter image tag (immutable tags are recommended)",
+                            "default": "0.20220314.0-debian-11-r407"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Airflow exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Airflow exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Airflow exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Airflow exporter pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Airflow exporter pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Airflow exporter pods",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Airflow exporter metrics container port",
+                            "default": 9112
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Airflow exporter pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Airflow exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Airflow exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Airflow exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Airflow exporter container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Airflow exporter pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Airflow exporter pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Extra annotations for Airflow exporter pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match Ignored if `metrics.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `metrics.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Airflow exporter",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Airflow exporter metrics service port",
+                                    "default": 9112
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.http }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enablePostgresUser": {
+                            "type": "boolean",
+                            "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                            "default": true
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_airflow"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_airflow"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Airflow",
+                    "default": "bn_airflow"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Airflow",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Airflow database name",
+                    "default": "bitnami_airflow"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": ""
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the Redis&reg; helm",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable password authentication",
+                            "default": true
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Redis&reg; password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "The name of an existing secret with Redis&reg; credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Redis&reg; architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Redis&reg; host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Redis&reg; port number",
+                    "default": 6379
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Redis&reg; username",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Redis&reg; password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the Redis&trade credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the Redis&trade credentials",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/apache/values.schema.json
+++ b/bitnami/apache/values.schema.json
@@ -1,56 +1,982 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress Configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the Apache installation."
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
         },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Apache image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Apache image repository",
+                    "default": "bitnami/apache"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Apache image tag (immutable tags are recommended)",
+                    "default": "2.4.57-debian-11-r134"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Apache image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Apache image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Apache image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "git": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Git image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Git image name",
+                    "default": "bitnami/git"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Git image tag (immutable tags are recommended)",
+                    "default": "2.41.0-debian-11-r74"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Git image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas of the Apache deployment",
+            "default": 1
+        },
+        "revisionHistoryLimit": {
+            "type": "number",
+            "description": "The number of old history to retain to allow rollback",
+            "default": 10
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "extraPodSpec": {
+            "type": "object",
+            "description": "Optionally specify extra PodSpec",
+            "default": {}
+        },
+        "cloneHtdocsFromGit": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Get the server static content from a git repository",
+                    "default": false
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Repository to clone static content from",
+                    "default": ""
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch inside the git repository",
+                    "default": ""
+                },
+                "enableAutoRefresh": {
+                    "type": "boolean",
+                    "description": "Enables an automatic git pull with a sidecar container",
+                    "default": true
+                },
+                "interval": {
+                    "type": "number",
+                    "description": "Interval for sidecar container pull from the repository",
+                    "default": 60
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Init container git resource requests",
+                    "default": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Add extra volume mounts for the GIT containers",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "htdocsConfigMap": {
+            "type": "string",
+            "description": "Name of a config map with the server static content",
+            "default": ""
+        },
+        "htdocsPVC": {
+            "type": "string",
+            "description": "Name of a PVC with the server static content",
+            "default": ""
+        },
+        "vhostsConfigMap": {
+            "type": "string",
+            "description": "Name of a config map with the virtual hosts content",
+            "default": ""
+        },
+        "httpdConfConfigMap": {
+            "type": "string",
+            "description": "Name of a config map with the httpd.conf file contents",
+            "default": ""
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Apache pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Apache Server pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Apache Server pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Apache Server pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Apache Server containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Apache Server containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Controller container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Apache server container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to access on the HTTP server",
+                    "default": "/"
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port for startupProbe",
+                    "default": "http"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 180
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable liveness probe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to access on the HTTP server",
+                    "default": "/"
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port for livenessProbe",
+                    "default": "http"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 180
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readiness probe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to access on the HTTP server",
+                    "default": "/"
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port for readinessProbe",
+                    "default": "http"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom rediness probe for the Web component",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array to add extra volumes (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array to add extra mounts (normally used with extraVolumes, evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array to add extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for Apache server nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for Apache server nodes",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Apache server HTTP container port",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Apache server HTTPS container port",
+                    "default": 8443
+                }
+            }
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Apache pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Apache pods",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Apache Server deployment strategy type.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for Apache",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of Apache replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of Apache replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Apache Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Apache service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Apache service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Apache service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Apache service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Apache service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Apache service",
+                    "default": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Apache service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Apache",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "example.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a sidecar prometheus exporter to expose Apache metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache Exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache Exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Apache Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Apache Exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Apache Exporter image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Metrics service port",
+                            "default": 9117
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PodMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PodMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels that can be used so PodMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
         }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\""
-        }
-      }
-    },
-    "replicaCount": {
-      "type": "integer",
-      "form": true,
-      "title": "Number of Replicas"
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Configure metrics exporter",
-          "form": true
-        }
-      }
     }
-  }
 }

--- a/bitnami/apisix/values.schema.json
+++ b/bitnami/apisix/values.schema.json
@@ -110,7 +110,7 @@
                 "tag": {
                     "type": "string",
                     "description": "APISIX image tag (immutable tags are recommended)",
-                    "default": "3.3.0-debian-11-r3"
+                    "default": "3.5.0-debian-11-r0"
                 },
                 "digest": {
                     "type": "string",
@@ -1943,7 +1943,7 @@
                         "tag": {
                             "type": "string",
                             "description": "APISIX Dashboard image tag (immutable tags are recommended)",
-                            "default": "3.0.1-debian-11-r2"
+                            "default": "3.0.1-debian-11-r98"
                         },
                         "digest": {
                             "type": "string",
@@ -1991,7 +1991,7 @@
                 "defaultConfig": {
                     "type": "string",
                     "description": "APISIX Dashboard configuration (evaluated as a template)",
-                    "default": "conf:\n  listen:\n    host: 0.0.0.0\n    port: {{ .Values.dashboard.containerPorts.http }}\n  {{- if .Values.dashboard.tls.enabled }}\n  ssl:\n    host: 0.0.0.0\n    port: {{ .Values.dashboard.containerPorts.https }}\n    cert: /bitnami/certs/{{ .Values.dashboard.tls.certFilename }}\n    key: /bitnami/certs/{{ .Values.dashboard.tls.certKeyFilename }}\n  {{- end }}\n  etcd:\n    prefix: \"/apisix\"\n    endpoints:\n      {{- if .Values.etcd.enabled  }}\n        {{- $replicas := $.Values.etcd.replicaCount | int }}\n        {{- range $i, $_e := until $replicas }}\n      - {{ printf \"%s://%s-%d.%s:%v\" (ternary \"https\" \"http\" $.Values.etcd.auth.client.secureTransport) (include \"apisix.etcd.fullname\" $ ) $i (include \"apisix.etcd.headlessServiceName\" $) ( include \"apisix.etcd.port\" $ ) }}          {{- end }}\n      {{- else }}\n      {{- range $node :=.Values.externalEtcd.servers }}\n      - {{ printf \"%s:%v\" $node (include \"apisix.etcd.port\" $) }}\n      {{- end }}\n      {{- end }}\n    {{- if (include \"apisix.etcd.authEnabled\" .) }}\n    username: \"{{ print \"{{ APISIX_ETCD_USER }}\" }}\"\n    password: \"{{ print \"{{ APISIX_ETCD_PASSWORD }}\" }}\"\n    {{- end }}\n  log:\n    error_log:\n      level: warn\n      file_path: /dev/stderr\n    access_log:\n      file_path: /dev/stdout\nauthentication:\n  secret: secret\n  expire_time: 3600\n  users:\n    - username: \"{{ print \"{{ APISIX_DASHBOARD_USER }}\" }}\"\n      password: \"{{ print \"{{ APISIX_DASHBOARD_PASSWORD }}\" }}\"\n"
+                    "default": "conf:\n  listen:\n    host: 0.0.0.0\n    port: {{ .Values.dashboard.containerPorts.http }}\n  {{- if .Values.dashboard.tls.enabled }}\n  ssl:\n    host: 0.0.0.0\n    port: {{ .Values.dashboard.containerPorts.https }}\n    cert: /bitnami/certs/{{ .Values.dashboard.tls.certFilename }}\n    key: /bitnami/certs/{{ .Values.dashboard.tls.certKeyFilename }}\n  {{- end }}\n  etcd:\n    prefix: \"/apisix\"\n    endpoints:\n      {{- if .Values.etcd.enabled  }}\n        {{- $replicas := $.Values.etcd.replicaCount | int }}\n        {{- range $i, $_e := until $replicas }}\n      - {{ printf \"%s://%s-%d.%s:%v\" (ternary \"https\" \"http\" $.Values.etcd.auth.client.secureTransport) (include \"apisix.etcd.fullname\" $ ) $i (include \"apisix.etcd.headlessServiceName\" $) ( include \"apisix.etcd.port\" $ ) }}          {{- end }}\n      {{- else }}\n      {{- range $node :=.Values.externalEtcd.servers }}\n      - {{ printf \"%s:%v\" $node (include \"apisix.etcd.port\" $) }}\n      {{- end }}\n      {{- end }}\n    {{- if (include \"apisix.etcd.authEnabled\" .) }}\n    username: \"{{ print \"{{ APISIX_ETCD_USER }}\" }}\"\n    password: \"{{ print \"{{ APISIX_ETCD_PASSWORD }}\" }}\"\n    {{- end }}\n  log:\n    error_log:\n      level: warn\n      file_path: /dev/stderr\n    access_log:\n      file_path: /dev/stdout\nauthentication:\n  secret: secret\n  expire_time: 3600\n  users:\n    - username: \"{{ print \"{{ APISIX_DASHBOARD_USER }}\" }}\"\n      password: \"{{ print \"{{ APISIX_DASHBOARD_PASSWORD }}\" }}\"\nplugins:\n  - api-breaker\n  - authz-casbin\n  - authz-casdoor\n  - authz-keycloak\n  - aws-lambda\n  - azure-functions\n  - basic-auth\n  # - batch-requests\n  - clickhouse-logger\n  - client-control\n  - consumer-restriction\n  - cors\n  - csrf\n  - datadog\n  # - dubbo-proxy\n  - echo\n  - error-log-logger\n  # - example-plugin\n  - ext-plugin-post-req\n  - ext-plugin-post-resp\n  - ext-plugin-pre-req\n  - fault-injection\n  - file-logger\n  - forward-auth\n  - google-cloud-logging\n  - grpc-transcode\n  - grpc-web\n  - gzip\n  - hmac-auth\n  - http-logger\n  - ip-restriction\n  - jwt-auth\n  - kafka-logger\n  - kafka-proxy\n  - key-auth\n  - ldap-auth\n  - limit-conn\n  - limit-count\n  - limit-req\n  - loggly\n  # - log-rotate\n  - mocking\n  # - node-status\n  - opa\n  - openid-connect\n  - opentelemetry\n  - openwhisk\n  - prometheus\n  - proxy-cache\n  - proxy-control\n  - proxy-mirror\n  - proxy-rewrite\n  - public-api\n  - real-ip\n  - redirect\n  - referer-restriction\n  - request-id\n  - request-validation\n  - response-rewrite\n  - rocketmq-logger\n  - server-info\n  - serverless-post-function\n  - serverless-pre-function\n  - skywalking\n  - skywalking-logger\n  - sls-logger\n  - splunk-hec-logging\n  - syslog\n  - tcp-logger\n  - traffic-split\n  - ua-restriction\n  - udp-logger\n  - uri-blocker\n  - wolf-rbac\n  - zipkin\n  - elasticsearch-logge\n  - openfunction\n  - tencent-cloud-cls\n  - ai\n  - cas-auth\n"
                 },
                 "extraConfig": {
                     "type": "object",
@@ -2128,6 +2128,26 @@
                             "type": "string",
                             "description": "APISIX Dashboard statefulset strategy type",
                             "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
                         }
                     }
                 },
@@ -2718,7 +2738,7 @@
                         "tag": {
                             "type": "string",
                             "description": "APISIX Ingress Controller image tag (immutable tags are recommended)",
-                            "default": "1.6.1-debian-11-r3"
+                            "default": "1.6.1-debian-11-r97"
                         },
                         "digest": {
                             "type": "string",
@@ -3601,7 +3621,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Init container wait-container image tag",
-                            "default": "11-debian-11-r2"
+                            "default": "11-debian-11-r54"
                         },
                         "digest": {
                             "type": "string",

--- a/bitnami/appsmith/values.schema.json
+++ b/bitnami/appsmith/values.schema.json
@@ -1,0 +1,1865 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Appsmith image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Appsmith image repository",
+                    "default": "bitnami/appsmith"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Appsmith image tag (immutable tags are recommended)",
+                    "default": "1.9.36-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Appsmith image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Appsmith image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Appsmith image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Appsmith image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "client": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Appsmith client replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Appsmith client HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Appsmith client containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Appsmith client containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Appsmith client containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Appsmith client containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Appsmith client containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Appsmith client pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Appsmith client pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Appsmith client containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Appsmith client containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Appsmith client containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Appsmith client containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Appsmith client pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Appsmith client pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Appsmith client pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `client.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `client.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `client.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `client.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `client.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Appsmith client pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Appsmith client pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Appsmith client pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Appsmith client statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Appsmith client pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Appsmith client pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Appsmith client container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Appsmith client nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Appsmith client nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Appsmith client nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Appsmith client pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Appsmith client container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Appsmith client pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Appsmith client pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Appsmith client service type",
+                            "default": "LoadBalancer"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Appsmith client service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Appsmith client service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Appsmith client service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Appsmith client service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Appsmith client service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Appsmith client service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Appsmith client service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Appsmith",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "appsmith.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `client.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "backend": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Appsmith backend replicas to deploy",
+                    "default": 1
+                },
+                "adminUser": {
+                    "type": "string",
+                    "description": "Appsmith admin user",
+                    "default": "user"
+                },
+                "adminEmail": {
+                    "type": "string",
+                    "description": "Appsmith admin email",
+                    "default": "user@example.com"
+                },
+                "adminPassword": {
+                    "type": "string",
+                    "description": "Appsmith admin password",
+                    "default": ""
+                },
+                "encryptionSalt": {
+                    "type": "string",
+                    "description": "Appsmith database encryption salt",
+                    "default": ""
+                },
+                "encryptionPassword": {
+                    "type": "string",
+                    "description": "Appsmith database encryption password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a secret containing the admin password, encryption salt and encryption password",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Key inside the existing secret containing the admin password",
+                    "default": "admin-password"
+                },
+                "existingSecretEncryptionSaltKey": {
+                    "type": "string",
+                    "description": "Key inside the existing secret containing the encryption salt",
+                    "default": "encryption-salt"
+                },
+                "existingSecretEncryptionPasswordKey": {
+                    "type": "string",
+                    "description": "Key inside the existing secret containing the encryption password",
+                    "default": "encryption-password"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Appsmith backend HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Appsmith backend containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Appsmith backend containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Appsmith backend containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Appsmith backend containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Appsmith backend containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Appsmith backend pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Appsmith backend pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Appsmith backend containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Appsmith backend containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Appsmith backend containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Appsmith backend containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Appsmith backend pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Appsmith backend pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Appsmith backend pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `backend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `backend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `backend.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `backend.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `backend.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Appsmith backend pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Appsmith backend pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Appsmith backend pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Appsmith backend statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Appsmith backend pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Appsmith backend pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Appsmith backend container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Appsmith backend nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Appsmith backend nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Appsmith backend nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Appsmith backend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Appsmith backend container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Appsmith backend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Appsmith backend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Appsmith backend service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Appsmith backend service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Appsmith backend service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Appsmith backend service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Appsmith backend service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Appsmith backend service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Appsmith backend service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Appsmith backend service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where backend requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using Persistent Volume Claims",
+                            "default": true
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Path to mount the volume at.",
+                            "default": "/bitnami/appsmith"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Storage class of backing PVC",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Size of data volume",
+                            "default": "8Gi"
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "The name of an existing PVC to use for persistence",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "rts": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Appsmith rts replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Appsmith rts HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Appsmith rts containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Appsmith rts containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Appsmith rts containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Appsmith rts containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Appsmith rts containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Appsmith rts pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Appsmith rts pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Appsmith rts containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Appsmith rts containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Appsmith rts containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Appsmith rts containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Appsmith rts pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Appsmith rts pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Appsmith rts pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `rts.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `rts.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `rts.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `rts.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `rts.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Appsmith rts pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Appsmith rts pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Appsmith rts pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Appsmith rts statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Appsmith rts pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Appsmith rts pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Appsmith rts container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Appsmith rts nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Appsmith rts nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Appsmith rts nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Appsmith rts pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Appsmith rts container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Appsmith rts pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Appsmith rts pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Appsmith rts service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Appsmith rts service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Appsmith rts service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Appsmith rts service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Appsmith rts service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Appsmith rts service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Appsmith rts service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Appsmith rts service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where rts requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "hosts": {
+                    "type": "array",
+                    "description": "Database hosts",
+                    "default": [],
+                    "items": {}
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 27017
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Non-root username for Appsmith",
+                    "default": "root"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Appsmith",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Appsmith database name",
+                    "default": "appsmith"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": ""
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Redis host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Redis port number",
+                    "default": 6379
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the Redis",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the Redis credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the Redis credentials",
+                    "default": ""
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Redis subchart",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Set Redis architecture",
+                    "default": "standalone"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a secret containing redis credentials",
+                    "default": ""
+                },
+                "master": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "redis": {
+                                            "type": "number",
+                                            "description": "Redis port",
+                                            "default": 6379
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Redis auth",
+                            "default": true
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Redis password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of a secret containing the Redis password",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "mongodb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy MongoDB subchart",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MongoDB architecture (Appsmith requires a Replica Set)",
+                    "default": "replicaset"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "MongoDB number of replicas",
+                    "default": 2
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "usernames": {
+                            "type": "array",
+                            "description": "MongoDB non-root username creation",
+                            "default": [
+                                "bn_appsmith"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "databases": {
+                            "type": "array",
+                            "description": "MongoDB database creation",
+                            "default": [
+                                "bitnami_appsmith"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "number",
+                            "description": "MongoDB container port (used by the headless service)",
+                            "default": 27017
+                        }
+                    }
+                },
+                "arbiter": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Arbiter nodes in the ReplicaSet",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/argo-cd/values.schema.json
+++ b/bitnami/argo-cd/values.schema.json
@@ -1,0 +1,4622 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Argo CD image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Argo CD image repository",
+                    "default": "bitnami/argo-cd"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Argo CD image tag (immutable tags are recommended)",
+                    "default": "2.8.3-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Argo CD image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Argo CD image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Argo CD image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Argo CD image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Argo CD replicas to deploy",
+                    "default": 1
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Argo CD nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Argo CD nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Argo CD nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Argo CD containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Argo CD containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Argo CD pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Argo CD containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Argo CD containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Argo CD containers' Security Context capabilities to be dropped",
+                                    "default": [
+                                        "all"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Argo CD containers' Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Argo CD container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the application controller service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "clusterAdminAccess": {
+                    "type": "boolean",
+                    "description": "Enable K8s cluster admin access for the application controller",
+                    "default": true
+                },
+                "clusterRoleRules": {
+                    "type": "array",
+                    "description": "Use custom rules for the application controller's cluster role",
+                    "default": [],
+                    "items": {}
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Format for the Argo CD application controller logs. Options: [text, json]",
+                    "default": "text"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for the Argo CD application controller",
+                    "default": "info"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "controller": {
+                            "type": "number",
+                            "description": "Argo CD application controller port number",
+                            "default": 8082
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Argo CD application controller metrics port number",
+                            "default": 8082
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Argo CD application controller service port",
+                            "default": 8082
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Node port for Argo CD application controller service",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Argo CD application controller service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Argo CD application controller service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Argo CD application controller service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Argo CD application controller service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Argo CD application controller service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Argo CD application controller metrics",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Argo CD application controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Argo CD application controller metrics service port",
+                                    "default": 8082
+                                },
+                                "nodePort": {
+                                    "type": "string",
+                                    "description": "Node port for the application controller service",
+                                    "default": ""
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Argo CD application controller metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Argo CD application controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Argo CD application controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Argo CD application controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Argo CD application controller service",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": "10s"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "rules": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable render extra rules for PrometheusRule object",
+                                    "default": false
+                                },
+                                "spec": {
+                                    "type": "array",
+                                    "description": "Rules to render into the PrometheusRule object",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Selector for the PrometheusRule object",
+                                    "default": {}
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace where to create the PrometheusRule object",
+                                    "default": "monitoring"
+                                },
+                                "additionalLabels": {
+                                    "type": "object",
+                                    "description": "Additional lables to add to the PrometheusRule object",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "defaultArgs": {
+                    "type": "object",
+                    "properties": {
+                        "statusProcessors": {
+                            "type": "string",
+                            "description": "Default status processors for Argo CD controller",
+                            "default": "20"
+                        },
+                        "operationProcessors": {
+                            "type": "string",
+                            "description": "Default operation processors for Argo CD controller",
+                            "default": "10"
+                        },
+                        "appResyncPeriod": {
+                            "type": "string",
+                            "description": "Default application resync period for Argo CD controller",
+                            "default": "180"
+                        },
+                        "selfHealTimeout": {
+                            "type": "string",
+                            "description": "Default self heal timeout for Argo CD controller",
+                            "default": "5"
+                        }
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images). Overrides the defaultArgs.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add extra arguments to the default arguments for the Argo CD controller",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Argo CD pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Argo CD pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Argo CD pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `controller.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `controller.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Argo CD pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Argo CD pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Argo CD pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Enable shared process namespace in a pod.",
+                    "default": false
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Argo CD pods' priorityClassName",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Argo CD container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Argo CD nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Argo CD nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Argo CD nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Argo CD pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Argo CD container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Argo CD pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Argo CD pod(s)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "applicationSet": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ApplicationSet controller",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "The number of ApplicationSet controller pods to run",
+                    "default": 1
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "defaultArgs": {
+                    "type": "object",
+                    "properties": {
+                        "enableLeaderElection": {
+                            "type": "boolean",
+                            "description": "Enable leader election",
+                            "default": false
+                        },
+                        "policy": {
+                            "type": "string",
+                            "description": "Default policy",
+                            "default": "sync"
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable debug mode",
+                            "default": false
+                        },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "Enable dry-run mode",
+                            "default": false
+                        }
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images). Overrides the defaultArgs.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add extra arguments to the default arguments for the Argo CD applicationSet controller",
+                    "default": [],
+                    "items": {}
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Format for the Argo CD applicationSet controller logs. Options: [text, json]",
+                    "default": "text"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for the Argo CD applicationSet controller",
+                    "default": "info"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Argo CD applicationSet controller metrics port number",
+                            "default": 8085
+                        },
+                        "probe": {
+                            "type": "number",
+                            "description": "Argo CD applicationSet controller probe port number",
+                            "default": 8081
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Argo CD applicationSet controller metrics",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Argo CD applicationSet controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Argo CD applicationSet controller metrics service port",
+                                    "default": 8085
+                                },
+                                "nodePort": {
+                                    "type": "string",
+                                    "description": "Node port for the applicationSet controller service",
+                                    "default": ""
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Argo CD applicationSet controller metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Argo CD applicationSet controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Argo CD applicationSet controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Argo CD applicationSet controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Argo CD applicationSet controller service",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": "10s"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD applicationSet controller service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Argo CD applicationSet controller service port",
+                            "default": 7000
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Node port for Argo CD applicationSet controller service",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Argo CD applicationSet controller service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Argo CD applicationSet controller service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Argo CD applicationSet controller service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Argo CD applicationSet controller service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Argo CD applicationSet controller service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the applicationSet controller service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `applicationSet.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `applicationSet.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `applicationSet.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `applicationSet.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `applicationSet.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Argo CD applicationSet controller pods assignment",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Argo CD applicationSet controller pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Argo CD applicationSet controller pods",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD applicationSet controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Argo CD applicationSet controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Argo CD applicationSet controller containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Argo CD applicationSet controller containers' Security Context capabilities to be dropped",
+                                    "default": [
+                                        "all"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Argo CD applicationSet controller containers' Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Argo CD applicationSet controller container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Argo CD applicationSet controller nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Argo CD applicationSet controller nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Argo CD applicationSet controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Argo CD applicationSet controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD applicationSet controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Argo CD applicationSet controller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Argo CD applicationSet controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Argo CD applicationSet controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD applicationSet controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Argo CD applicationSet controller pods' priorityClassName",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Argo CD applicationSet controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Argo CD applicationSet controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Argo CD applicationSet controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Argo CD applicationSet controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Argo CD applicationSet controller nodes",
+                    "default": ""
+                },
+                "webhook": {
+                    "type": "object",
+                    "properties": {
+                        "ingress": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable an ingress resource for Webhooks",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional ingress annotations",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Additional ingress labels",
+                                    "default": {}
+                                },
+                                "ingressClassName": {
+                                    "type": "string",
+                                    "description": "Defines which ingress controller will implement the resource",
+                                    "default": ""
+                                },
+                                "hostname": {
+                                    "type": "string",
+                                    "description": "Ingress hostname for the Argo CD applicationSet ingress",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Argo CD applicationSet ingress path",
+                                    "default": "/api/webhook"
+                                },
+                                "pathType": {
+                                    "type": "string",
+                                    "description": "Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`",
+                                    "default": "Prefix"
+                                },
+                                "extraHosts": {
+                                    "type": "array",
+                                    "description": "Extra hosts array for the Argo CD applicationSet ingress",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraPaths": {
+                                    "type": "array",
+                                    "description": "Extra paths for the Argo CD applicationSet ingress",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraTls": {
+                                    "type": "array",
+                                    "description": "Extra TLS configuration for the Argo CD applicationSet ingress",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "tls": {
+                                    "type": "array",
+                                    "description": "Ingress TLS configuration",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "notifications": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable notifications controller",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images).",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add extra arguments to the default arguments for the Argo CD notifications controller",
+                    "default": [],
+                    "items": {}
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Format for the Argo CD notifications controller logs. Options: [text, json]",
+                    "default": "text"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for the Argo CD notifications controller",
+                    "default": "info"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Argo CD notifications controller metrics port number",
+                            "default": 8085
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Argo CD notifications controller metrics",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Argo CD notifications controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Argo CD notifications controller metrics service port",
+                                    "default": 8085
+                                },
+                                "nodePort": {
+                                    "type": "string",
+                                    "description": "Node port for the notifications controller service",
+                                    "default": ""
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Argo CD notifications controller metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Argo CD notifications controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Argo CD notifications controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Argo CD notifications controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Argo CD notifications controller service",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": "10s"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD notifications controller service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Argo CD notifications controller service port",
+                            "default": 7000
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Node port for Argo CD notifications controller service",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Argo CD notifications controller service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Argo CD notifications controller service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Argo CD notifications controller service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Argo CD notifications controller service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Argo CD notifications controller service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the notifications controller service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `notifications.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `notifications.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `notifications.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `notifications.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `notifications.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Argo CD notifications controller pods assignment",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Argo CD notifications controller pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Argo CD notifications controller pods",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD notifications controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Argo CD notifications controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Argo CD notifications controller containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Argo CD notifications controller containers' Security Context capabilities to be dropped",
+                                    "default": [
+                                        "all"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Argo CD notifications controller containers' Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Argo CD notifications controller container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Argo CD notifications controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Argo CD notifications controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD notifications controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Argo CD notifications controller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Argo CD notifications controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Argo CD notifications controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Argo CD notifications controller pods' priorityClassName",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Argo CD notifications controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Argo CD notifications controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Argo CD notifications controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Argo CD notifications controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Argo CD notifications controller nodes",
+                    "default": ""
+                },
+                "webhook": {
+                    "type": "object",
+                    "properties": {
+                        "ingress": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable an ingress resource for Webhooks",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional ingress annotations",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Additional ingress labels",
+                                    "default": {}
+                                },
+                                "ingressClassName": {
+                                    "type": "string",
+                                    "description": "Defines which ingress controller will implement the resource",
+                                    "default": ""
+                                },
+                                "hostname": {
+                                    "type": "string",
+                                    "description": "Ingress hostname for the Argo CD notifications ingress",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Argo CD notifications ingress path",
+                                    "default": "/api/webhook"
+                                },
+                                "pathType": {
+                                    "type": "string",
+                                    "description": "Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`",
+                                    "default": "Prefix"
+                                },
+                                "extraHosts": {
+                                    "type": "array",
+                                    "description": "Extra hosts array for the Argo CD notifications ingress",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraPaths": {
+                                    "type": "array",
+                                    "description": "Extra paths for the Argo CD notifications ingress",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraTls": {
+                                    "type": "array",
+                                    "description": "Extra TLS configuration for the Argo CD notifications ingress",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "tls": {
+                                    "type": "array",
+                                    "description": "Ingress TLS configuration",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "bots": {
+                    "type": "object",
+                    "properties": {
+                        "slack": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable notifications controller",
+                                    "default": false
+                                },
+                                "command": {
+                                    "type": "array",
+                                    "description": "Override default container command (useful when using custom images)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "args": {
+                                    "type": "array",
+                                    "description": "Override default container args (useful when using custom images).",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraArgs": {
+                                    "type": "array",
+                                    "description": "Add extra arguments to the default arguments for the Argo CD Slack bot",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "service": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Argo CD Slack bot service type",
+                                            "default": "LoadBalancer"
+                                        },
+                                        "port": {
+                                            "type": "number",
+                                            "description": "Argo CD Slack bot service port",
+                                            "default": 80
+                                        },
+                                        "nodePort": {
+                                            "type": "string",
+                                            "description": "Node port for Argo CD Slack bot service",
+                                            "default": ""
+                                        },
+                                        "clusterIP": {
+                                            "type": "string",
+                                            "description": "Argo CD Slack bot service Cluster IP",
+                                            "default": ""
+                                        },
+                                        "loadBalancerIP": {
+                                            "type": "string",
+                                            "description": "Argo CD Slack bot service Load Balancer IP",
+                                            "default": ""
+                                        },
+                                        "loadBalancerSourceRanges": {
+                                            "type": "array",
+                                            "description": "Argo CD Slack bot service Load Balancer sources",
+                                            "default": [],
+                                            "items": {}
+                                        },
+                                        "externalTrafficPolicy": {
+                                            "type": "string",
+                                            "description": "Argo CD Slack bot service external traffic policy",
+                                            "default": "Cluster"
+                                        },
+                                        "annotations": {
+                                            "type": "object",
+                                            "description": "Additional custom annotations for Argo CD Slack bot service",
+                                            "default": {}
+                                        },
+                                        "extraPorts": {
+                                            "type": "array",
+                                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                                            "default": [],
+                                            "items": {}
+                                        },
+                                        "sessionAffinity": {
+                                            "type": "string",
+                                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                            "default": "None"
+                                        },
+                                        "sessionAffinityConfig": {
+                                            "type": "object",
+                                            "description": "Additional settings for the sessionAffinity",
+                                            "default": {}
+                                        }
+                                    }
+                                },
+                                "serviceAccount": {
+                                    "type": "object",
+                                    "properties": {
+                                        "create": {
+                                            "type": "boolean",
+                                            "description": "Specifies whether a ServiceAccount should be created",
+                                            "default": true
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "description": "The name of the ServiceAccount to use.",
+                                            "default": ""
+                                        },
+                                        "automountServiceAccountToken": {
+                                            "type": "boolean",
+                                            "description": "Automount service account token for the notifications controller service account",
+                                            "default": true
+                                        },
+                                        "annotations": {
+                                            "type": "object",
+                                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                                            "default": {}
+                                        }
+                                    }
+                                },
+                                "podAffinityPreset": {
+                                    "type": "string",
+                                    "description": "Pod affinity preset. Ignored if `notifications.bots.slack.affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": ""
+                                },
+                                "podAntiAffinityPreset": {
+                                    "type": "string",
+                                    "description": "Pod anti-affinity preset. Ignored if `notifications.bots.slack.affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": "soft"
+                                },
+                                "nodeAffinityPreset": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Node affinity preset type. Ignored if `notifications.bots.slack.affinity` is set. Allowed values: `soft` or `hard`",
+                                            "default": ""
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "Node label key to match. Ignored if `notifications.bots.slack.affinity` is set",
+                                            "default": ""
+                                        },
+                                        "values": {
+                                            "type": "array",
+                                            "description": "Node label values to match. Ignored if `notifications.bots.slack.affinity` is set",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                },
+                                "affinity": {
+                                    "type": "object",
+                                    "description": "Affinity for Argo CD Slack bot pods assignment",
+                                    "default": {}
+                                },
+                                "podAnnotations": {
+                                    "type": "object",
+                                    "description": "Annotations for Argo CD Slack bot pods",
+                                    "default": {}
+                                },
+                                "podLabels": {
+                                    "type": "object",
+                                    "description": "Extra labels for Argo CD Slack bot pods",
+                                    "default": {}
+                                },
+                                "containerSecurityContext": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enabled Argo CD Slack bot containers' Security Context",
+                                            "default": true
+                                        },
+                                        "runAsUser": {
+                                            "type": "number",
+                                            "description": "Set Argo CD Slack bot containers' Security Context runAsUser",
+                                            "default": 1001
+                                        },
+                                        "allowPrivilegeEscalation": {
+                                            "type": "boolean",
+                                            "description": "Set Argo CD Slack bot containers' Security Context allowPrivilegeEscalation",
+                                            "default": false
+                                        },
+                                        "capabilities": {
+                                            "type": "object",
+                                            "properties": {
+                                                "drop": {
+                                                    "type": "array",
+                                                    "description": "Set Argo CD Slack bot containers' Security Context capabilities to be dropped",
+                                                    "default": [
+                                                        "all"
+                                                    ],
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                            "type": "boolean",
+                                            "description": "Set Argo CD Slack bot containers' Security Context readOnlyRootFilesystem",
+                                            "default": false
+                                        },
+                                        "runAsNonRoot": {
+                                            "type": "boolean",
+                                            "description": "Set Argo CD Slack bot container's Security Context runAsNonRoot",
+                                            "default": true
+                                        }
+                                    }
+                                },
+                                "resources": {
+                                    "type": "object",
+                                    "properties": {
+                                        "limits": {
+                                            "type": "object",
+                                            "description": "The resources limits for the Argo CD Slack bot containers",
+                                            "default": {}
+                                        },
+                                        "requests": {
+                                            "type": "object",
+                                            "description": "The requested resources for the Argo CD Slack bot containers",
+                                            "default": {}
+                                        }
+                                    }
+                                },
+                                "podSecurityContext": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enabled Argo CD Slack bot pods' Security Context",
+                                            "default": true
+                                        },
+                                        "fsGroup": {
+                                            "type": "number",
+                                            "description": "Set Argo CD Slack bot pod's Security Context fsGroup",
+                                            "default": 1001
+                                        }
+                                    }
+                                },
+                                "nodeSelector": {
+                                    "type": "object",
+                                    "description": "Node labels for Argo CD Slack bot pods assignment",
+                                    "default": {}
+                                },
+                                "tolerations": {
+                                    "type": "array",
+                                    "description": "Tolerations for Argo CD Slack bot pods assignment",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "priorityClassName": {
+                                    "type": "string",
+                                    "description": "Argo CD Slack bot pods' priorityClassName",
+                                    "default": ""
+                                },
+                                "extraVolumes": {
+                                    "type": "array",
+                                    "description": "Optionally specify extra list of additional volumes for the Argo CD Slack bot pod(s)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraVolumeMounts": {
+                                    "type": "array",
+                                    "description": "Optionally specify extra list of additional volumeMounts for the Argo CD Slack bot container(s)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraEnvVars": {
+                                    "type": "array",
+                                    "description": "Array with extra environment variables to add to Argo CD Slack bot nodes",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraEnvVarsCM": {
+                                    "type": "string",
+                                    "description": "Name of existing ConfigMap containing extra env vars for Argo CD Slack bot nodes",
+                                    "default": ""
+                                },
+                                "extraEnvVarsSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing Secret containing extra env vars for Argo CD Slack bot nodes",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Argo CD server replicas to deploy",
+                    "default": 1
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Argo CD server nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Argo CD server nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Argo CD server nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Argo CD server containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Argo CD server containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Argo CD server pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Argo CD server containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Argo CD server containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Argo CD containers' server Security Context capabilities to be dropped",
+                                    "default": [
+                                        "all"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Argo CD containers' server Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Argo CD server containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Argo CD server deployment autoscaling",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Argo CD server deployment autoscaling minimum number of replicas",
+                            "default": 1
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Argo CD server deployment autoscaling maximum number of replicas",
+                            "default": 5
+                        },
+                        "targetCPU": {
+                            "type": "number",
+                            "description": "Argo CD server deployment autoscaling target CPU percentage",
+                            "default": 50
+                        },
+                        "targetMemory": {
+                            "type": "number",
+                            "description": "Argo CD server deployment autoscaling target CPU memory",
+                            "default": 50
+                        }
+                    }
+                },
+                "insecure": {
+                    "type": "boolean",
+                    "description": "Disable HTTPS redirection for Argo CD server",
+                    "default": false
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "ArgoCD server logs format. Options: [text, json]",
+                    "default": "text"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "ArgoCD server logs level",
+                    "default": "info"
+                },
+                "configEnabled": {
+                    "type": "boolean",
+                    "description": "Enable Argo CD server config",
+                    "default": true
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Argo CD server base URL. Required when configuring SSO. Required when enabling dex.",
+                    "default": ""
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.server.url }}"
+                        },
+                        "application": {
+                            "type": "object",
+                            "properties": {
+                                "instanceLabelKey": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "argocd.argoproj.io/instance"
+                                }
+                            }
+                        },
+                        "dex": {
+                            "type": "object",
+                            "properties": {
+                                "config": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the creation of an ingress for the Argo CD server",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Path type for the Argo CD server ingress",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Ingress API version for the Argo CD server ingress",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Ingress hostname for the Argo CD server ingress",
+                            "default": "argocd.server.local"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the Argo CD server ingress. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS for the Argo CD server ingress",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "Extra hosts array for the Argo CD server ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path array for the Argo CD server ingress",
+                            "default": "/"
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Extra paths for the Argo CD server ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "Extra TLS configuration for the Argo CD server ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Secrets array to mount into the Ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable metrics for the Argo CD server",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Argo CD server service type",
+                                    "default": "ClusterIP"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Argo CD server metrics service port",
+                                    "default": 8083
+                                },
+                                "nodePort": {
+                                    "type": "string",
+                                    "description": "Node port for Argo CD server metrics service",
+                                    "default": ""
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Argo CD server metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Argo CD server service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Argo CD server service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Argo CD server service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Argo CD server service",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": "10s"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "ingressGrpc": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the creation of an ingress for the Argo CD gRPC server",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Path type for the Argo CD gRPC server ingress",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Ingress API version for the Argo CD gRPC server ingress",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Ingress hostname for the Argo CD gRPC server ingress",
+                            "default": "argocd.server.local"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the Argo CD gRPC server ingress. To enable certificate autogeneration, place here your cert-manager annotations",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS for the Argo CD server ingress",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "Extra hosts array for the Argo CD gRPC server ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path array for the Argo CD gRPC server ingress",
+                            "default": "/"
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Extra paths for the Argo CD gRPC server ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "Extra TLS configuration for the Argo CD gRPC server ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Secrets array to mount into the Ingress",
+                            "default": [],
+                            "items": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Argo CD server HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Argo CD server HTTPS container port",
+                            "default": 8443
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Argo CD server metrics container port",
+                            "default": 8083
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "HTTP port for the gRPC ingress when enabled",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "HTTPS port for the gRPC ingress when enabled",
+                                    "default": 443
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "https": {
+                                    "type": "string",
+                                    "description": "Node port for HTTPS",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Argo CD service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Argo CD service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Argo CD service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Argo CD service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Argo CD service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "concat to the default args",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Argo CD server pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Argo CD server pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Argo CD server pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `server.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `server.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Argo CD server pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Argo CD server pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Argo CD server pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Enable shared process namespace in a pod.",
+                    "default": false
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD server statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Argo CD server pods' priorityClassName",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Argo CD server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Argo CD server nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Argo CD server nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Argo CD server nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Argo CD server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Argo CD server container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Argo CD server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Argo CD server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "repoServer": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Argo CD repo server replicas to deploy",
+                    "default": 1
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Argo CD repo server nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Argo CD repo server nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Argo CD repo server nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Argo CD repo server containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Argo CD repo server containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD repo server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Argo CD repo server pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Argo CD repo server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Argo CD repo server containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Argo CD repo server containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Argo CD containers' repo server Security Context capabilities to be dropped",
+                                    "default": [
+                                        "all"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Argo CD containers' repo server Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Argo CD repo server containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Repo server service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Repo server service port",
+                            "default": 8081
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Node port for the repo server service",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Repo server service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Repo server service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Repo server service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Repo server service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Repo server service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Format for the Argo CD repo server logs. Options: [text, json]",
+                    "default": "text"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for the Argo CD repo server",
+                    "default": "info"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "repoServer": {
+                            "type": "number",
+                            "description": "Container port for Argo CD repo server",
+                            "default": 8081
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Metrics port for Argo CD repo server",
+                            "default": 8084
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable metrics for the Argo CD repo server",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Argo CD repo server service type",
+                                    "default": "ClusterIP"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Argo CD repo server metrics service port",
+                                    "default": 8084
+                                },
+                                "nodePort": {
+                                    "type": "string",
+                                    "description": "Node port for the repo server metrics service",
+                                    "default": ""
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Argo CD repo server metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Argo CD repo server service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Argo CD repo server service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Argo CD repo server service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Argo CD repo server service",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": "10s"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Argo CD repo server deployment autoscaling",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Argo CD repo server deployment autoscaling minimum number of replicas",
+                            "default": 1
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Argo CD repo server deployment autoscaling maximum number of replicas",
+                            "default": 5
+                        },
+                        "targetCPU": {
+                            "type": "number",
+                            "description": "Argo CD repo server deployment autoscaling target CPU percentage",
+                            "default": 50
+                        },
+                        "targetMemory": {
+                            "type": "number",
+                            "description": "Argo CD repo server deployment autoscaling target CPU memory",
+                            "default": 50
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount for repo server should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount for repo server to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the repo server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add extra args to the default repo server args",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Argo CD repo server pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Argo CD repo server pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Argo CD repo server pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `repoServer.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `repoServer.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Argo CD repo server pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Argo CD repo server pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Argo CD repo server pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Enable shared process namespace in a pod.",
+                    "default": false
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo CD repo server statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Argo CD repo server pods' priorityClassName",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Argo CD repo server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Argo CD repo server nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Argo CD repo server nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Argo CD repo server nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Argo CD repo server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Argo CD repo server container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Argo CD repo server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Argo CD repo server pod(s)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "dex": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Dex image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Dex image repository",
+                            "default": "bitnami/dex"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Dex image tag (immutable tags are recommended)",
+                            "default": "2.37.0-debian-11-r66"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Dex image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Dex image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Dex image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Dex image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a Dex deployment for SSO",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Dex replicas to deploy",
+                    "default": 1
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Dex nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Dex nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Dex nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Dex containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Dex containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dex pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Dex pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dex containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Dex containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Dex containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Dex containers' server Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Dex containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Dex service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Dex HTTP service port",
+                                    "default": 5556
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Dex grpc service port",
+                                    "default": 5557
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "HTTP node port for the Dex service",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "gRPC node port for the Dex service",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Dex service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Dex service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Dex service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Dex service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Dex service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Dex container HTTP port",
+                            "default": 5556
+                        },
+                        "grpc": {
+                            "type": "number",
+                            "description": "Dex gRPC port",
+                            "default": 5557
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Dex metrics port",
+                            "default": 5558
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable metrics service for Dex",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Dex service type",
+                                    "default": "ClusterIP"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Dex metrics service port",
+                                    "default": 5558
+                                },
+                                "nodePort": {
+                                    "type": "string",
+                                    "description": "Node port for the Dex service",
+                                    "default": ""
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Dex service metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Dex service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Dex service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Dex service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Dex service",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": "10s"
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created for Dex",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the Dex service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add extra args to the default args for Dex",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Dex pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Dex pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Dex pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `dex.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `dex.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Dex pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Dex pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Dex pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Enable shared process namespace in a pod.",
+                    "default": false
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Dex statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Dex pods' priorityClassName",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Dex container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Dex nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Dex nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Dex nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Dex pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Dex container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Dex pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Dex pod(s)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "knownHosts": {
+                    "type": "string",
+                    "description": "Known hosts to be added to the known hosts list by default. Check the values to see the default value",
+                    "default": "bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\ngitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=\ngitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf\ngitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9\nssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H\nvs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H\n"
+                },
+                "extraKnownHosts": {
+                    "type": "string",
+                    "description": "Add extra known hosts to the known hosts list",
+                    "default": ""
+                },
+                "createExtraKnownHosts": {
+                    "type": "boolean",
+                    "description": "Whether to create or not the extra known hosts configmap",
+                    "default": true
+                },
+                "styles": {
+                    "type": "string",
+                    "description": "Custom CSS styles",
+                    "default": ""
+                },
+                "existingStylesConfigmap": {
+                    "type": "string",
+                    "description": "Use an existing styles configmap",
+                    "default": ""
+                },
+                "tlsCerts": {
+                    "type": "object",
+                    "description": "TLS certificates used to verify the authenticity of the repository servers",
+                    "default": {}
+                },
+                "gpgKeys": {
+                    "type": "object",
+                    "description": "GnuPG public keys to add to the keyring",
+                    "default": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "description": "Role-based authentication configuration",
+                    "default": {}
+                },
+                "secret": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create or not the secret",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "General secret extra annotations",
+                            "default": {}
+                        },
+                        "githubSecret": {
+                            "type": "string",
+                            "description": "GitHub secret to configure webhooks",
+                            "default": ""
+                        },
+                        "gitlabSecret": {
+                            "type": "string",
+                            "description": "GitLab secret to configure webhooks",
+                            "default": ""
+                        },
+                        "bitbucketServerSecret": {
+                            "type": "string",
+                            "description": "BitBucket secret to configure webhooks",
+                            "default": ""
+                        },
+                        "bitbucketUUID": {
+                            "type": "string",
+                            "description": "BitBucket UUID to configure webhooks",
+                            "default": ""
+                        },
+                        "gogsSecret": {
+                            "type": "string",
+                            "description": "Gogs secret to configure webhooks",
+                            "default": ""
+                        },
+                        "extra": {
+                            "type": "object",
+                            "description": "Extra keys to add to the configuration secret.",
+                            "default": {}
+                        },
+                        "argocdServerTlsConfig": {
+                            "type": "object",
+                            "properties": {
+                                "key": {
+                                    "type": "string",
+                                    "description": "TLS key for the Argo CD config secret",
+                                    "default": ""
+                                },
+                                "crt": {
+                                    "type": "string",
+                                    "description": "TLS certificate for the Argo CD config secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "argocdServerAdminPassword": {
+                            "type": "string",
+                            "description": "Argo CD server admin password. Autogenerated by default.",
+                            "default": ""
+                        },
+                        "argocdServerAdminPasswordMtime": {
+                            "type": "string",
+                            "description": "Argo CD server password modification time",
+                            "default": ""
+                        },
+                        "repositoryCredentials": {
+                            "type": "object",
+                            "description": "Repository credentials to add to the Argo CD server confgi secret",
+                            "default": {}
+                        }
+                    }
+                },
+                "clusterCredentials": {
+                    "type": "array",
+                    "description": "Configure external cluster credentials",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Redis image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Redis image repository",
+                            "default": "bitnami/redis"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Redis image tag (immutable tags are recommended)",
+                            "default": "7.2.1-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Redis image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Redis image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Redis image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Redis dependency",
+                    "default": true
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "Name override for the Redis dependency",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "number",
+                            "description": "Service port for Redis dependency",
+                            "default": 6379
+                        }
+                    }
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Redis dependency authentication",
+                            "default": true
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret to load redis dependency password",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Pasword key name inside the existing secret",
+                            "default": "redis-password"
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Redis&reg; architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External Redis host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Redis port",
+                    "default": 6379
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External Redis password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret for the external redis",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Password key for the existing secret containing the external redis password",
+                    "default": "redis-password"
+                }
+            }
+        },
+        "redisWait": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enables waiting for redis",
+                    "default": true
+                },
+                "extraArgs": {
+                    "type": "string",
+                    "description": "Additional arguments for the redis-cli call, such as TLS",
+                    "default": ""
+                },
+                "securityContext": {
+                    "type": "object",
+                    "description": "Security context for init container",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/argo-workflows/values.schema.json
+++ b/bitnami/argo-workflows/values.schema.json
@@ -1,0 +1,1685 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "singleNamespace": {
+                    "type": "boolean",
+                    "description": "Restrict Argo to only deploy into a single namespace by apply Roles and RoleBindings instead of the Cluster equivalents, and start argo-cli with the --namespaced flag. Use it in clusters with strict access policy.",
+                    "default": false
+                }
+            }
+        },
+        "createAggregateRoles": {
+            "type": "boolean",
+            "description": "Create Aggregated cluster roles",
+            "default": true
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "server image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "server image repository",
+                            "default": "bitnami/argo-workflow-cli"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "server image tag (immutable tags are recommended)",
+                            "default": "3.4.11-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "server image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "server image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "server image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable server deployment",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of server replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on server nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on server nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to check for startupProbe",
+                            "default": "/"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 300
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Server custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Server custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Server custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the server containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the server containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set server pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set server containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set server containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set read only root file system pod's Security Conte",
+                            "default": true
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create RBAC resources for the Argo workflows server",
+                            "default": true
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "string",
+                    "description": "Extra arguments for the server command line",
+                    "default": ""
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable authentication",
+                            "default": true
+                        },
+                        "mode": {
+                            "type": "string",
+                            "description": "Set authentication mode. Either `server`, `client` or `sso`.",
+                            "default": "client"
+                        },
+                        "sso": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable SSO configuration for the server auth mode",
+                                    "default": false
+                                },
+                                "config": {
+                                    "type": "object",
+                                    "properties": {
+                                        "issuer": {
+                                            "type": "string",
+                                            "description": "Root URL for the OIDC identity provider",
+                                            "default": ""
+                                        },
+                                        "clientId": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Name of the secret containing the OIDC client ID",
+                                                    "default": ""
+                                                },
+                                                "key": {
+                                                    "type": "string",
+                                                    "description": "Key in the secret to obtain the OIDC client ID",
+                                                    "default": ""
+                                                }
+                                            }
+                                        },
+                                        "clientSecret": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "Name of the secret containing the OIDC client secret",
+                                                    "default": ""
+                                                },
+                                                "key": {
+                                                    "type": "string",
+                                                    "description": "Key in the secret to obtain the OIDC client secret",
+                                                    "default": ""
+                                                }
+                                            }
+                                        },
+                                        "redirectUrl": {
+                                            "type": "string",
+                                            "description": "The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "rbac": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Create RBAC resources for SSO",
+                                            "default": true
+                                        },
+                                        "secretWhitelist": {
+                                            "type": "array",
+                                            "description": "Restricts the secrets that the server can read",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                },
+                                "scopes": {
+                                    "type": "array",
+                                    "description": "Scopes requested from the SSO ID provider",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "clusterWorkflowTemplates": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ClusterRole and CRB for the controoler to access ClusterWorkflowTemplates",
+                            "default": true
+                        },
+                        "enableEditing": {
+                            "type": "boolean",
+                            "description": "Give the server permissions to edit ClusterWorkflowTemplates",
+                            "default": true
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create Pod Disruption Budget for the server component",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Sets the min number of pods availables for the Pod Disruption Budget",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Sets the max number of pods unavailable for the Pod Disruption Budget",
+                            "default": 1
+                        }
+                    }
+                },
+                "secure": {
+                    "type": "boolean",
+                    "description": "Run Argo server in secure mode",
+                    "default": false
+                },
+                "baseHref": {
+                    "type": "string",
+                    "description": "Base href of the Argo Workflows deployment",
+                    "default": "/"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "web": {
+                            "type": "number",
+                            "description": "argo Server container port",
+                            "default": 2746
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "server pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for server pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for server pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `server.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `server.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for server pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for server pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for server pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "server statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternate scheduler for the server deployment",
+                    "default": ""
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "server pods' priorityClassName",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to server nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for server nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for server nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the server container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "server service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "server service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "server service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "server service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "server service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "server service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for server service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on the server service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "controller image repository",
+                            "default": "bitnami/argo-workflow-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "controller image tag (immutable tags are recommended)",
+                            "default": "3.4.11-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of controller replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on controller nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on controller nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 60
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to check for startupProbe",
+                            "default": "/"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 300
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Controller custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Controller custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Controller custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set controller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set read only root file system pod's Security Conte",
+                            "default": true
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Port to expose controller metrics",
+                            "default": 9090
+                        },
+                        "telemetry": {
+                            "type": "number",
+                            "description": "Port to expose controller telemetry",
+                            "default": 8081
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create RBAC resources for the Argo workflows controller",
+                            "default": true
+                        }
+                    }
+                },
+                "existingConfigMap": {
+                    "type": "string",
+                    "description": "",
+                    "default": ""
+                },
+                "extraArgs": {
+                    "type": "string",
+                    "description": "Extra arguments for the controller command line",
+                    "default": ""
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "archive": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Save completed workflows to an SQL database.",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "instanceID": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable submission filtering based on instanceID attribute. Requires to set instanceID.useReleaseName or instanceID.explicitID",
+                            "default": false
+                        },
+                        "useReleaseName": {
+                            "type": "boolean",
+                            "description": "Use the release name to filter submissions",
+                            "default": false
+                        },
+                        "explicitID": {
+                            "type": "string",
+                            "description": "Filter submissions based on an explicit instance ID",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterWorkflowTemplates": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to create a ClusterRole and Cluster Role Binding to access ClusterWokflowTemplates resources",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable controller metrics exporter",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to expose controller metrics",
+                            "default": "/metrics"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable prometheus service monitor configuration",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "telemetry": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable telemetry for the controller",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to expose telemetry information",
+                            "default": "/telemetry"
+                        }
+                    }
+                },
+                "workflowWorkers": {
+                    "type": "number",
+                    "description": "Number of workflow workers to deploy",
+                    "default": 32
+                },
+                "workflowNamespaces": {
+                    "type": "array",
+                    "description": "Namespaces allowed to run workflows",
+                    "default": [
+                        "default"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workflowDefaults": {
+                    "type": "object",
+                    "description": "Default Workflow Values",
+                    "default": {}
+                },
+                "logging": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "string",
+                            "description": "Level for the controller logging",
+                            "default": "info"
+                        },
+                        "globalLevel": {
+                            "type": "string",
+                            "description": "Global logging level for the controller",
+                            "default": "0"
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create Pod Disruption Budget for the controller component",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Sets the min number of pods availables for the Pod Disruption Budget",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Sets the max number of pods unavailable for the Pod Disruption Budget",
+                            "default": 1
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `controller.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `controller.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternate scheduler for the server controller",
+                    "default": ""
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "controller pods' priorityClassName",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "controller service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Metrics port for the controller",
+                                    "default": 8080
+                                },
+                                "telemetry": {
+                                    "type": "number",
+                                    "description": "Telemetry port for the controller",
+                                    "default": 8081
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "telemetry": {
+                                    "type": "string",
+                                    "description": "Node port for HTTPS",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "controller service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "controller service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "controller service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "controller service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for controller service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on the controller service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "executor": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "executor image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "executor image repository",
+                            "default": "bitnami/argo-workflow-exec"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "executor image tag (immutable tags are recommended)",
+                            "default": "3.4.11-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "executor image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "executor image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "executor image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to server nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled executor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set executor pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set read only root file system pod's Security Context",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for server",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "server.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "workflows": {
+            "type": "object",
+            "properties": {
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a service account to run workflows",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Service account name to run workflows",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the workflows service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create RBAC resource to run workflows",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PostgreSQL subchart and controller persistence using PostgreSQL",
+                    "default": true
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL port",
+                                    "default": 5432
+                                }
+                            }
+                        }
+                    }
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "PostgreSQL username",
+                            "default": "postgres"
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "PortgreSQL database name",
+                            "default": "bn_argo_workflows"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "PortgreSQL database password",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "mysql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MySQL subchart and controller persistence using MySQL",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "number",
+                                    "description": "MySQL port",
+                                    "default": 3306
+                                }
+                            }
+                        }
+                    }
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "MySQL username",
+                            "default": "mysql"
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "MySQL database name",
+                            "default": "bn_argo_workflows"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MySQL database password",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable using externaldatabase and the controller to use persistence with it",
+                    "default": false
+                },
+                "host": {
+                    "type": "string",
+                    "description": "External Database server host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Database server port",
+                    "default": 3306
+                },
+                "username": {
+                    "type": "string",
+                    "description": "External Database username",
+                    "default": "bn_wordpress"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External Database user password",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "External Database database name",
+                    "default": "bitnami_wordpress"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of an existing secret with database credentials",
+                    "default": ""
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Either postgresql or mysql",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/aspnet-core/values.schema.json
+++ b/bitnami/aspnet-core/values.schema.json
@@ -1,0 +1,892 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override aspnet-core.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override aspnet-core.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "ASP.NET Core image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "ASP.NET Core image repository",
+                    "default": "bitnami/aspnet-core"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "ASP.NET Core image tag (immutable tags are recommended)",
+                    "default": "7.0.10-debian-11-r10"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "ASP.NET Core image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "ASP.NET Core image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "ASP.NET Core image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "bindURLs": {
+            "type": "string",
+            "description": "URLs to bind",
+            "default": "http://+:8080"
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on ASP.NET Core container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of ASP.NET Core replicas to deploy",
+            "default": 1
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "ASP.NET Core pod priority class name",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "ASP.NET Core pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for ASP.NET Core pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for ASP.NET Core container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the ASP.NET Core pods",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the ASP.NET Core pods",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Add lifecycle hooks to the ASP.NET Core deployment",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for ASP.NET Core pods",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for ASP.NET Core pods",
+            "default": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Deployment strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the ASP.NET Core container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the ASP.NET Core container",
+                    "default": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Port to expose at ASP.NET Core container level",
+                    "default": 8080
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled ASP.NET Core pods' Security Context",
+                    "default": false
+                },
+                "sysctls": {
+                    "type": "array",
+                    "description": "Set namespaced sysctls for the ASP.NET Core pods",
+                    "default": [],
+                    "items": {}
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Security Context fsGroup",
+                    "default": 0
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled ASP.NET Core containers' Security Context",
+                    "default": false
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set ASP.NET Core container's Security Context runAsUser",
+                    "default": 0
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set container's Security Context runAsNonRoot",
+                    "default": false
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable autoscaling for ASP.NET Core",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of ASP.NET Core replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of ASP.NET Core replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "string",
+                    "description": "Target CPU utilization percentage",
+                    "default": ""
+                },
+                "targetMemory": {
+                    "type": "string",
+                    "description": "Target Memory utilization percentage",
+                    "default": ""
+                }
+            }
+        },
+        "appFromExternalRepo": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable to download/build ASP.NET Core app from external git repository",
+                    "default": true
+                },
+                "clone": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Git image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Git image repository",
+                                    "default": "bitnami/git"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Git image tag (immutable tags are recommended)",
+                                    "default": "2.41.0-debian-11-r74"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Git image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Git image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Git repository to clone",
+                            "default": "https://github.com/dotnet/AspNetCore.Docs.git"
+                        },
+                        "revision": {
+                            "type": "string",
+                            "description": "Git revision to checkout",
+                            "default": "main"
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Add extra volume mounts for the GIT container",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "publish": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": ".NET SDK image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": ".NET SDK image repository",
+                                    "default": "bitnami/dotnet-sdk"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": ".NET SDK image tag (immutable tags are recommended)",
+                                    "default": "7.0.400-debian-11-r8"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": ".NET SDK image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": ".NET SDK image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": ".NET SDK image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "subFolder": {
+                            "type": "string",
+                            "description": "Sub folder under the Git repository containing the ASP.NET Core app",
+                            "default": "aspnetcore/performance/caching/output/samples/7.x/"
+                        },
+                        "extraFlags": {
+                            "type": "array",
+                            "description": "Extra flags to be appended to \"dotnet publish\" command",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "startCommand": {
+                    "type": "array",
+                    "description": "Command used to start ASP.NET Core app",
+                    "default": [
+                        "dotnet",
+                        "OCMinimal.dll"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "appFromExistingPVC": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable mounting your ASP.NET Core app from an existing PVC",
+                    "default": false
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A existing Persistent Volume Claim containing your ASP.NET Core app",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "ASP.NET Core service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "ASP.NET Core service HTTP port",
+                            "default": 80
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node ports to expose",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "ASP.NET Core service Cluster IP",
+                    "default": ""
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "ASP.NET Core service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "ASP.NET Core service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "ASP.NET Core service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for ASP.NET Core service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for ASP.NET Core",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource, a host pointing to this will be created",
+                    "default": "aspnet-core.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "healthIngress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable healthIngress record generation for ASP.NET Core",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the health ingress is enabled, a host pointing to this will be created",
+                    "default": "aspnet-core.local"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "n array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                },
+                "extraLabels": {
+                    "type": "object",
+                    "description": "Additional labels for the ServiceAccount",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": true
+                }
+            }
+        }
+    }
+}

--- a/bitnami/cassandra/values.schema.json
+++ b/bitnami/cassandra/values.schema.json
@@ -1,0 +1,1183 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects (sub-charts are not considered)",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Cassandra image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Cassandra image repository",
+                    "default": "bitnami/cassandra"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Cassandra image tag (immutable tags are recommended)",
+                    "default": "4.1.3-debian-11-r24"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Cassandra image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "dbUser": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string",
+                    "description": "Cassandra admin user",
+                    "default": "cassandra"
+                },
+                "forcePassword": {
+                    "type": "boolean",
+                    "description": "Force the user to provide a non",
+                    "default": false
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for `dbUser.user`. Randomly generated if empty",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use an existing secret object for `dbUser.user` password (will ignore `dbUser.password`)",
+                    "default": ""
+                }
+            }
+        },
+        "initDBConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data",
+            "default": ""
+        },
+        "initDBSecret": {
+            "type": "string",
+            "description": "Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data",
+            "default": ""
+        },
+        "existingConfiguration": {
+            "type": "string",
+            "description": "ConfigMap with custom cassandra configuration files. This overrides any other Cassandra configuration set in the chart",
+            "default": ""
+        },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Cassandra cluster name",
+                    "default": "cassandra"
+                },
+                "seedCount": {
+                    "type": "number",
+                    "description": "Number of seed nodes",
+                    "default": 1
+                },
+                "numTokens": {
+                    "type": "number",
+                    "description": "Number of tokens for each node",
+                    "default": 256
+                },
+                "datacenter": {
+                    "type": "string",
+                    "description": "Datacenter name",
+                    "default": "dc1"
+                },
+                "rack": {
+                    "type": "string",
+                    "description": "Rack name",
+                    "default": "rack1"
+                },
+                "endpointSnitch": {
+                    "type": "string",
+                    "description": "Endpoint Snitch",
+                    "default": "SimpleSnitch"
+                },
+                "internodeEncryption": {
+                    "type": "string",
+                    "description": "DEPRECATED: use tls.internode and tls.client instead. Encryption values.",
+                    "default": "none"
+                },
+                "clientEncryption": {
+                    "type": "boolean",
+                    "description": "Client Encryption",
+                    "default": false
+                },
+                "extraSeeds": {
+                    "type": "array",
+                    "description": "For an external/second cassandra ring.",
+                    "default": [],
+                    "items": {}
+                },
+                "enableUDF": {
+                    "type": "boolean",
+                    "description": "Enable User defined functions",
+                    "default": false
+                }
+            }
+        },
+        "jvm": {
+            "type": "object",
+            "properties": {
+                "extraOpts": {
+                    "type": "string",
+                    "description": "Set the value for Java Virtual Machine extra options",
+                    "default": ""
+                },
+                "maxHeapSize": {
+                    "type": "string",
+                    "description": "Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`",
+                    "default": ""
+                },
+                "newHeapSize": {
+                    "type": "string",
+                    "description": "Set Java Virtual Machine new heap size (HEAP_NEWSIZE). Calculated automatically if `nil`",
+                    "default": ""
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Command for running the container (set to default if not set). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Args for running the container (set to default if not set). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on cassandra container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Cassandra replicas",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "updateStrategy for Cassandra statefulset",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "StatefulSet pod management policy",
+            "default": "OrderedReady"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Cassandra pods' priority.",
+            "default": ""
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional pod labels",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Cassandra pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Cassandra pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Cassandra containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Cassandra container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Force the container to be run as non root",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for Cassandra containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for Cassandra containers",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 30
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 30
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 30
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the Cassandra pod needs to terminate gracefully",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for cassandra container",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for cassandra container",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the cassandra pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the cassandra pods",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Mininimum number of pods that must still be available after the eviction",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Max number of pods that can be unavailable after the eviction",
+                    "default": ""
+                }
+            }
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Enable HOST Network",
+            "default": false
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "intra": {
+                    "type": "number",
+                    "description": "Intra Port on the Host and Container",
+                    "default": 7000
+                },
+                "tls": {
+                    "type": "number",
+                    "description": "TLS Port on the Host and Container",
+                    "default": 7001
+                },
+                "jmx": {
+                    "type": "number",
+                    "description": "JMX Port on the Host and Container",
+                    "default": 7199
+                },
+                "cql": {
+                    "type": "number",
+                    "description": "CQL Port on the Host and Container",
+                    "default": 9042
+                }
+            }
+        },
+        "hostPorts": {
+            "type": "object",
+            "properties": {
+                "intra": {
+                    "type": "string",
+                    "description": "Intra Port on the Host",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "string",
+                    "description": "TLS Port on the Host",
+                    "default": ""
+                },
+                "jmx": {
+                    "type": "string",
+                    "description": "JMX Port on the Host",
+                    "default": ""
+                },
+                "cql": {
+                    "type": "string",
+                    "description": "CQL Port on the Host",
+                    "default": ""
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Cassandra pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Cassandra Service Account",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account.",
+                    "default": true
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Cassandra service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "cql": {
+                            "type": "number",
+                            "description": "Cassandra service CQL Port",
+                            "default": 9042
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Cassandra service metrics port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "cql": {
+                            "type": "string",
+                            "description": "Node port for CQL",
+                            "default": ""
+                        },
+                        "metrics": {
+                            "type": "string",
+                            "description": "Node port for metrics",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations which may be required.",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether a NetworkPolicy should be created",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Name of an existing PVC to use",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Cassandra data volume",
+                    "default": ""
+                },
+                "commitStorageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Cassandra Commit Log volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Mode",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Cassandra data volume",
+                    "default": "8Gi"
+                },
+                "commitLogsize": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Cassandra commit log volume. Unset by default",
+                    "default": "2Gi"
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "The path the data volume will be mounted at",
+                    "default": "/bitnami/cassandra"
+                },
+                "commitLogMountPath": {
+                    "type": "string",
+                    "description": "The path the commit log volume will be mounted at. Unset by default. Set it to '/bitnami/cassandra/commitlog' to enable a separate commit log volume",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Cassandra exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Cassandra exporter image name",
+                            "default": "bitnami/cassandra-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Cassandra exporter image tag",
+                            "default": "2.3.8-debian-11-r383"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Cassandra exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 45
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for cassandra-exporter container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "8080"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": "monitoring"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify Metric Relabelings to add to the scrape endpoint",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Used to pass Labels that are required by the installed Prometheus Operator",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "HTTP Port on the Host and Container",
+                            "default": 8080
+                        },
+                        "jmx": {
+                            "type": "number",
+                            "description": "JMX Port on the Host and Container",
+                            "default": 5555
+                        }
+                    }
+                },
+                "hostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "HTTP Port on the Host",
+                            "default": ""
+                        },
+                        "jmx": {
+                            "type": "string",
+                            "description": "JMX Port on the Host",
+                            "default": ""
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Configure Cassandra-exporter with a custom config.yml file",
+                    "default": "host: localhost:{{ .Values.containerPorts.jmx }}\nssl: False\nuser:\npassword:\nlistenPort: {{ .Values.metrics.containerPorts.http }}\nblacklist:\n  # To profile the duration of jmx call you can start the program with the following options\n  # > java -Dorg.slf4j.simpleLogger.defaultLogLevel=trace -jar cassandra_exporter.jar config.yml --oneshot\n  #\n  # To get intuition of what is done by cassandra when something is called you can look in cassandra\n  # https://github.com/apache/cassandra/tree/trunk/src/java/org/apache/cassandra/metrics\n  # Please avoid to scrape frequently those calls that are iterating over all sstables\n\n  # Unaccessible metrics (not enough privilege)\n  - java:lang:memorypool:.*usagethreshold.*\n\n  # Leaf attributes not interesting for us but that are presents in many path\n  - .*:999thpercentile\n  - .*:95thpercentile\n  - .*:fifteenminuterate\n  - .*:fiveminuterate\n  - .*:durationunit\n  - .*:rateunit\n  - .*:stddev\n  - .*:meanrate\n  - .*:mean\n  - .*:min\n\n  # Path present in many metrics but uninterresting\n  - .*:viewlockacquiretime:.*\n  - .*:viewreadtime:.*\n  - .*:cas[a-z]+latency:.*\n  - .*:colupdatetimedeltahistogram:.*\n\n  # Mostly for RPC, do not scrap them\n  - org:apache:cassandra:db:.*\n\n  # columnfamily is an alias for Table metrics\n  # https://github.com/apache/cassandra/blob/8b3a60b9a7dbefeecc06bace617279612ec7092d/src/java/org/apache/cassandra/metrics/TableMetrics.java#L162\n  - org:apache:cassandra:metrics:columnfamily:.*\n\n  # Should we export metrics for system keyspaces/tables ?\n  - org:apache:cassandra:metrics:[^:]+:system[^:]*:.*\n\n  # Don't scrap us\n  - com:criteo:nosql:cassandra:exporter:.*\n\nmaxScrapFrequencyInSec:\n  50:\n    - .*\n\n  # Refresh those metrics only every hour as it is costly for cassandra to retrieve them\n  3600:\n    - .*:snapshotssize:.*\n    - .*:estimated.*\n    - .*:totaldiskspaceused:.*\n"
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "internodeEncryption": {
+                    "type": "string",
+                    "description": "Set internode encryption",
+                    "default": "none"
+                },
+                "clientEncryption": {
+                    "type": "boolean",
+                    "description": "Set client-server encryption",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates. Currently only supports PEM certificates",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret that contains Cassandra Keystore and truststore",
+                    "default": ""
+                },
+                "passwordsSecret": {
+                    "type": "string",
+                    "description": "Secret containing the Keystore and Truststore passwords if needed",
+                    "default": ""
+                },
+                "keystorePassword": {
+                    "type": "string",
+                    "description": "Password for the keystore, if needed.",
+                    "default": ""
+                },
+                "truststorePassword": {
+                    "type": "string",
+                    "description": "Password for the truststore, if needed.",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the TLS init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the TLS init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "Secret with the TLS certificates.",
+                    "default": ""
+                },
+                "tlsEncryptionSecretName": {
+                    "type": "string",
+                    "description": "Secret with the encryption of the TLS certificates",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/cert-manager/values.schema.json
+++ b/bitnami/cert-manager/values.schema.json
@@ -1,0 +1,1240 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "logLevel": {
+            "type": "number",
+            "description": "Set up cert-manager log level",
+            "default": 2
+        },
+        "clusterResourceNamespace": {
+            "type": "string",
+            "description": "Namespace used to store DNS provider credentials etc. for ClusterIssuer resources. If empty, uses the namespace where the controller is deployed.",
+            "default": ""
+        },
+        "leaderElection": {
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace which leaderElection works.",
+                    "default": "kube-system"
+                }
+            }
+        },
+        "installCRDs": {
+            "type": "boolean",
+            "description": "Flag to install cert-manager CRDs",
+            "default": false
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of cert-manager replicas",
+            "default": 1
+        },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Controller replicas",
+                    "default": 1
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Controller image repository",
+                            "default": "bitnami/cert-manager"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Controller image tag (immutable tags are recommended)",
+                            "default": "1.12.4-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "acmesolver": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Controller image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Controller image repository",
+                                    "default": "bitnami/acmesolver"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Controller image tag (immutable tags are recommended)",
+                                    "default": "1.12.4-debian-11-r0"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Controller image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Controller image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "debug": {
+                                    "type": "boolean",
+                                    "description": "Controller image debug mode",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Controller container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Controller container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Controller container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Controller container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `controller.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `controller.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for cert-manager Controller",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Controller container port",
+                    "default": 9402
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Controller default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override Controller default args",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Controller pod priority class name",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for Controller pods",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Controller pods",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Controller pod DNS policy",
+                    "default": ""
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Controller pod DNS config. Required if `controller.dnsPolicy` is set to `None`",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Add lifecycle hooks to the Controller deployment",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Controller deployment update strategy",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Controller deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments to pass to the Controller container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables to the Controller container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Controller pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Controller pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Controller pod",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "webhook": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Webhook replicas",
+                    "default": 1
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Webhook image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Webhook image repository",
+                            "default": "bitnami/cert-manager-webhook"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Webhook image tag (immutable tags are recommended)",
+                            "default": "1.12.4-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Webhook image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Webhook image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Webhook image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Webhook image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Webhook container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Webhook container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Webhook pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Webhook pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Webhook containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Webhook container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Webhook container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `webhook.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `webhook.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `webhook.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `webhook.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `webhook.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for cert-manager Webhook",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Webhook container port",
+                    "default": 10250
+                },
+                "httpsPort": {
+                    "type": "number",
+                    "description": "Webhook container port",
+                    "default": 443
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Webhook default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override Webhook default args",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path for livenessProbe",
+                            "default": "/livez"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path for readinessProbe",
+                            "default": "/healthz"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Webhook pod priority class name",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for Webhook pods",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Webhook pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Webhook pods",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Add lifecycle hooks to the Webhook deployment",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Webhook deployment update strategy",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Controller deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments to pass to the Webhook container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables to the Webhook container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Webhook pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Webhook container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Webhook pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Webhook pod",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specifies hostNetwork value",
+                    "default": false
+                }
+            }
+        },
+        "cainjector": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of CAInjector replicas",
+                    "default": 1
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "CAInjector image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "CAInjector image repository",
+                            "default": "bitnami/cainjector"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "CAInjector image tag (immutable tags are recommended)",
+                            "default": "1.12.4-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "CAInjector image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "CAInjector image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "CAInjector image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "CAInjector image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the CAInjector container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the CAInjector container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled CAInjector pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set CAInjector pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled CAInjector containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set CAInjector container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set CAInjector container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `cainjector.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `cainjector.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `cainjector.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `cainjector.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `cainjector.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for cert-manager CAInjector",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override CAInjector default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override CAInjector default args",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "CAInjector pod priority class name",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for CAInjector pods",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for CAInjector pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for CAInjector pods",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Add lifecycle hooks to the CAInjector deployment",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Controller deployment update strategy",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Controller deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments to pass to the CAInjector container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables to the CAInjector container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for CAInjector pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for CAInjector container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the CAInjector pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the CAInjector pod",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start metrics",
+                    "default": true
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/path": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "/metrics"
+                                },
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.controller.containerPort }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "The path which the ServiceMonitor will monitor",
+                            "default": "/metrics"
+                        },
+                        "targetPort": {
+                            "type": "number",
+                            "description": "The port in which the ServiceMonitor will monitor",
+                            "default": 9402
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "60s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": "30s"
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "DEPRECATED. Use metrics.serviceMonitor.labels instead.",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        }
+    }
+}

--- a/bitnami/clickhouse/values.schema.json
+++ b/bitnami/clickhouse/values.schema.json
@@ -1,0 +1,1491 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "ClickHouse image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "ClickHouse image repository",
+                    "default": "bitnami/clickhouse"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "ClickHouse image tag (immutable tags are recommended)",
+                    "default": "23.8.2-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "ClickHouse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "ClickHouse image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "ClickHouse image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable ClickHouse image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "shards": {
+            "type": "number",
+            "description": "Number of ClickHouse shards to deploy",
+            "default": 2
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of ClickHouse replicas per shard to deploy",
+            "default": 3
+        },
+        "distributeReplicasByZone": {
+            "type": "boolean",
+            "description": "Schedules replicas of the same shard to different availability zones",
+            "default": false
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "ClickHouse HTTP container port",
+                    "default": 8123
+                },
+                "https": {
+                    "type": "number",
+                    "description": "ClickHouse HTTPS container port",
+                    "default": 8443
+                },
+                "tcp": {
+                    "type": "number",
+                    "description": "ClickHouse TCP container port",
+                    "default": 9000
+                },
+                "tcpSecure": {
+                    "type": "number",
+                    "description": "ClickHouse TCP (secure) container port",
+                    "default": 9440
+                },
+                "keeper": {
+                    "type": "number",
+                    "description": "ClickHouse keeper TCP container port",
+                    "default": 2181
+                },
+                "keeperSecure": {
+                    "type": "number",
+                    "description": "ClickHouse keeper TCP (secure) container port",
+                    "default": 3181
+                },
+                "keeperInter": {
+                    "type": "number",
+                    "description": "ClickHouse keeper interserver TCP container port",
+                    "default": 9444
+                },
+                "mysql": {
+                    "type": "number",
+                    "description": "ClickHouse MySQL container port",
+                    "default": 9004
+                },
+                "postgresql": {
+                    "type": "number",
+                    "description": "ClickHouse PostgreSQL container port",
+                    "default": 9005
+                },
+                "interserver": {
+                    "type": "number",
+                    "description": "ClickHouse Interserver container port",
+                    "default": 9009
+                },
+                "metrics": {
+                    "type": "number",
+                    "description": "ClickHouse metrics container port",
+                    "default": 8001
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on ClickHouse containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on ClickHouse containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on ClickHouse containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the ClickHouse containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the ClickHouse containers",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled ClickHouse pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set ClickHouse pod's Security Context fsGroup",
+                    "default": 1001
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set ClickHouse container's Security Context seccomp profile",
+                            "default": "RuntimeDefault"
+                        }
+                    }
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled ClickHouse containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set ClickHouse containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set ClickHouse containers' Security Context runAsNonRoot",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Set ClickHouse container's privilege escalation",
+                    "default": false
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "description": "Set ClickHouse container's Security Context runAsNonRoot",
+                            "default": [
+                                "ALL"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "description": "ClickHouse Admin username",
+                    "default": "default"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "ClickHouse Admin password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a secret containing the Admin password",
+                    "default": ""
+                },
+                "existingSecretKey": {
+                    "type": "string",
+                    "description": "Name of the key inside the existing secret",
+                    "default": ""
+                }
+            }
+        },
+        "logLevel": {
+            "type": "string",
+            "description": "Logging level",
+            "default": "information"
+        },
+        "keeper": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy ClickHouse keeper. Support is experimental.",
+                    "default": false
+                }
+            }
+        },
+        "defaultConfigurationOverrides": {
+            "type": "string",
+            "description": "Default configuration overrides (evaluated as a template)",
+            "default": "<clickhouse>\n  <!-- Macros -->\n  <macros>\n    <shard from_env=\"CLICKHOUSE_SHARD_ID\"></shard>\n    <replica from_env=\"CLICKHOUSE_REPLICA_ID\"></replica>\n    <layer>{{ include \"common.names.fullname\" . }}</layer>\n  </macros>\n  <!-- Log Level -->\n  <logger>\n    <level>{{ .Values.logLevel }}</level>\n  </logger>\n  {{- if or (ne (int .Values.shards) 1) (ne (int .Values.replicaCount) 1)}}\n  <!-- Cluster configuration - Any update of the shards and replicas requires helm upgrade -->\n  <remote_servers>\n    <default>\n      {{- $shards := $.Values.shards | int }}\n      {{- range $shard, $e := until $shards }}\n      <shard>\n          {{- $replicas := $.Values.replicaCount | int }}\n          {{- range $i, $_e := until $replicas }}\n          <replica>\n              <host>{{ printf \"%s-shard%d-%d.%s.%s.svc.%s\" (include \"common.names.fullname\" $ ) $shard $i (include \"clickhouse.headlessServiceName\" $) (include \"common.names.namespace\" $) $.Values.clusterDomain }}</host>\n              <port>{{ $.Values.service.ports.tcp }}</port>\n              <user from_env=\"CLICKHOUSE_ADMIN_USER\"></user>\n              <password from_env=\"CLICKHOUSE_ADMIN_PASSWORD\"></password>\n          </replica>\n          {{- end }}\n      </shard>\n      {{- end }}\n    </default>\n  </remote_servers>\n  {{- end }}\n  {{- if .Values.keeper.enabled }}\n  <!-- keeper configuration -->\n  <keeper_server>\n    {{/*ClickHouse keeper configuration using the helm chart */}}\n    <tcp_port>{{ $.Values.containerPorts.keeper }}</tcp_port>\n    {{- if .Values.tls.enabled }}\n    <tcp_port_secure>{{ $.Values.containerPorts.keeperSecure }}</tcp_port_secure>\n    {{- end }}\n    <server_id from_env=\"KEEPER_SERVER_ID\"></server_id>\n    <log_storage_path>/bitnami/clickhouse/keeper/coordination/log</log_storage_path>\n    <snapshot_storage_path>/bitnami/clickhouse/keeper/coordination/snapshots</snapshot_storage_path>\n\n    <coordination_settings>\n        <operation_timeout_ms>10000</operation_timeout_ms>\n        <session_timeout_ms>30000</session_timeout_ms>\n        <raft_logs_level>trace</raft_logs_level>\n    </coordination_settings>\n\n    <raft_configuration>\n    {{- $nodes := .Values.replicaCount | int }}\n    {{- range $node, $e := until $nodes }}\n    <server>\n      <id>{{ $node | int }}</id>\n      <hostname from_env=\"{{ printf \"KEEPER_NODE_%d\" $node }}\"></hostname>\n      <port>{{ $.Values.service.ports.keeperInter }}</port>\n    </server>\n    {{- end }}\n    </raft_configuration>\n  </keeper_server>\n  {{- end }}\n  {{- if or .Values.keeper.enabled .Values.zookeeper.enabled .Values.externalZookeeper.servers }}\n  <!-- Zookeeper configuration -->\n  <zookeeper>\n    {{- if or .Values.keeper.enabled }}\n    {{- $nodes := .Values.replicaCount | int }}\n    {{- range $node, $e := until $nodes }}\n    <node>\n      <host from_env=\"{{ printf \"KEEPER_NODE_%d\" $node }}\"></host>\n      <port>{{ $.Values.service.ports.keeper }}</port>\n    </node>\n    {{- end }}\n    {{- else if .Values.zookeeper.enabled }}\n    {{/* Zookeeper configuration using the helm chart */}}\n    {{- $nodes := .Values.zookeeper.replicaCount | int }}\n    {{- range $node, $e := until $nodes }}\n    <node>\n      <host from_env=\"{{ printf \"KEEPER_NODE_%d\" $node }}\"></host>\n      <port>{{ $.Values.zookeeper.service.ports.client }}</port>\n    </node>\n    {{- end }}\n    {{- else if .Values.externalZookeeper.servers }}\n    {{/* Zookeeper configuration using an external instance */}}\n    {{- range $node :=.Values.externalZookeeper.servers }}\n    <node>\n      <host>{{ $node }}</host>\n      <port>{{ $.Values.externalZookeeper.port }}</port>\n    </node>\n    {{- end }}\n    {{- end }}\n  </zookeeper>\n  {{- end }}\n  {{- if .Values.tls.enabled }}\n  <!-- TLS configuration -->\n  <tcp_port_secure from_env=\"CLICKHOUSE_TCP_SECURE_PORT\"></tcp_port_secure>\n  <https_port from_env=\"CLICKHOUSE_HTTPS_PORT\"></https_port>\n  <openSSL>\n      <server>\n          {{- $certFileName := default \"tls.crt\" .Values.tls.certFilename }}\n          {{- $keyFileName := default \"tls.key\" .Values.tls.certKeyFilename }}\n          <certificateFile>/bitnami/clickhouse/certs/{{$certFileName}}</certificateFile>\n          <privateKeyFile>/bitnami/clickhouse/certs/{{$keyFileName}}</privateKeyFile>\n          <verificationMode>none</verificationMode>\n          <cacheSessions>true</cacheSessions>\n          <disableProtocols>sslv2,sslv3</disableProtocols>\n          <preferServerCiphers>true</preferServerCiphers>\n          {{- if or .Values.tls.autoGenerated .Values.tls.certCAFilename }}\n          {{- $caFileName := default \"ca.crt\" .Values.tls.certCAFilename }}\n          <caConfig>/bitnami/clickhouse/certs/{{$caFileName}}</caConfig>\n          {{- else }}\n          <loadDefaultCAFile>true</loadDefaultCAFile>\n          {{- end }}\n      </server>\n      <client>\n          <loadDefaultCAFile>true</loadDefaultCAFile>\n          <cacheSessions>true</cacheSessions>\n          <disableProtocols>sslv2,sslv3</disableProtocols>\n          <preferServerCiphers>true</preferServerCiphers>\n          <verificationMode>none</verificationMode>\n          <invalidCertificateHandler>\n              <name>AcceptCertificateHandler</name>\n          </invalidCertificateHandler>\n      </client>\n  </openSSL>\n  {{- end }}\n  {{- if .Values.metrics.enabled }}\n   <!-- Prometheus metrics -->\n   <prometheus>\n      <endpoint>/metrics</endpoint>\n      <port from_env=\"CLICKHOUSE_METRICS_PORT\"></port>\n      <metrics>true</metrics>\n      <events>true</events>\n      <asynchronous_metrics>true</asynchronous_metrics>\n  </prometheus>\n  {{- end }}\n</clickhouse>\n"
+        },
+        "existingOverridesConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your custom configuration for ClickHouse",
+            "default": ""
+        },
+        "extraOverrides": {
+            "type": "string",
+            "description": "Extra configuration overrides (evaluated as a template) apart from the default",
+            "default": ""
+        },
+        "extraOverridesConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with extra configuration for ClickHouse",
+            "default": ""
+        },
+        "extraOverridesSecret": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your custom configuration for ClickHouse",
+            "default": ""
+        },
+        "usersExtraOverrides": {
+            "type": "string",
+            "description": "Users extra configuration overrides (evaluated as a template) apart from the default",
+            "default": ""
+        },
+        "usersExtraOverridesConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with users extra configuration for ClickHouse",
+            "default": ""
+        },
+        "usersExtraOverridesSecret": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your custom users configuration for ClickHouse",
+            "default": ""
+        },
+        "initdbScripts": {
+            "type": "object",
+            "description": "Dictionary of initdb scripts",
+            "default": {}
+        },
+        "initdbScriptsSecret": {
+            "type": "string",
+            "description": "ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)",
+            "default": ""
+        },
+        "startdbScripts": {
+            "type": "object",
+            "description": "Dictionary of startdb scripts",
+            "default": {}
+        },
+        "startdbScriptsSecret": {
+            "type": "string",
+            "description": "ConfigMap with the startdb scripts (Note: Overrides `startdbScripts`)",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [
+                "/scripts/setup.sh"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "ClickHouse pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for ClickHouse pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for ClickHouse pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for ClickHouse pods assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for ClickHouse pods assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for ClickHouse pods assignment",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "ClickHouse statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+            "default": "Parallel"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "ClickHouse pods' priorityClassName",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default) for ClickHouse pods",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Redmine pod needs to terminate gracefully",
+            "default": ""
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the ClickHouse container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to ClickHouse nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for ClickHouse nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for ClickHouse nodes",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the ClickHouse pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the ClickHouse container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the ClickHouse pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the ClickHouse pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS traffic support",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates",
+                    "default": false
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret that contains the certificates",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "Certificate filename",
+                    "default": ""
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "description": "Certificate key filename",
+                    "default": ""
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "description": "CA Certificate filename",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "ClickHouse service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "ClickHouse service HTTP port",
+                            "default": 8123
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "ClickHouse service HTTPS port",
+                            "default": 443
+                        },
+                        "tcp": {
+                            "type": "number",
+                            "description": "ClickHouse service TCP port",
+                            "default": 9000
+                        },
+                        "tcpSecure": {
+                            "type": "number",
+                            "description": "ClickHouse service TCP (secure) port",
+                            "default": 9440
+                        },
+                        "keeper": {
+                            "type": "number",
+                            "description": "ClickHouse keeper TCP container port",
+                            "default": 2181
+                        },
+                        "keeperSecure": {
+                            "type": "number",
+                            "description": "ClickHouse keeper TCP (secure) container port",
+                            "default": 3181
+                        },
+                        "keeperInter": {
+                            "type": "number",
+                            "description": "ClickHouse keeper interserver TCP container port",
+                            "default": 9444
+                        },
+                        "mysql": {
+                            "type": "number",
+                            "description": "ClickHouse service MySQL port",
+                            "default": 9004
+                        },
+                        "postgresql": {
+                            "type": "number",
+                            "description": "ClickHouse service PostgreSQL port",
+                            "default": 9005
+                        },
+                        "interserver": {
+                            "type": "number",
+                            "description": "ClickHouse service Interserver port",
+                            "default": 9009
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "ClickHouse service metrics port",
+                            "default": 8001
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        },
+                        "tcp": {
+                            "type": "string",
+                            "description": "Node port for TCP",
+                            "default": ""
+                        },
+                        "tcpSecure": {
+                            "type": "string",
+                            "description": "Node port for TCP (with TLS)",
+                            "default": ""
+                        },
+                        "keeper": {
+                            "type": "string",
+                            "description": "ClickHouse keeper TCP container port",
+                            "default": ""
+                        },
+                        "keeperSecure": {
+                            "type": "string",
+                            "description": "ClickHouse keeper TCP (secure) container port",
+                            "default": ""
+                        },
+                        "keeperInter": {
+                            "type": "string",
+                            "description": "ClickHouse keeper interserver TCP container port",
+                            "default": ""
+                        },
+                        "mysql": {
+                            "type": "string",
+                            "description": "Node port for MySQL",
+                            "default": ""
+                        },
+                        "postgresql": {
+                            "type": "string",
+                            "description": "Node port for PostgreSQL",
+                            "default": ""
+                        },
+                        "interserver": {
+                            "type": "string",
+                            "description": "Node port for Interserver",
+                            "default": ""
+                        },
+                        "metrics": {
+                            "type": "string",
+                            "description": "Node port for metrics",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "ClickHouse service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "ClickHouse service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "ClickHouse service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "ClickHouse service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for ClickHouse service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in ClickHouse service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "externalAccess": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Kubernetes external cluster access to ClickHouse",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP",
+                            "default": "LoadBalancer"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "ClickHouse service HTTP port",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "ClickHouse service HTTPS port",
+                                    "default": 443
+                                },
+                                "tcp": {
+                                    "type": "number",
+                                    "description": "ClickHouse service TCP port",
+                                    "default": 9000
+                                },
+                                "tcpSecure": {
+                                    "type": "number",
+                                    "description": "ClickHouse service TCP (secure) port",
+                                    "default": 9440
+                                },
+                                "keeper": {
+                                    "type": "number",
+                                    "description": "ClickHouse keeper TCP container port",
+                                    "default": 2181
+                                },
+                                "keeperSecure": {
+                                    "type": "number",
+                                    "description": "ClickHouse keeper TCP (secure) container port",
+                                    "default": 3181
+                                },
+                                "keeperInter": {
+                                    "type": "number",
+                                    "description": "ClickHouse keeper interserver TCP container port",
+                                    "default": 9444
+                                },
+                                "mysql": {
+                                    "type": "number",
+                                    "description": "ClickHouse service MySQL port",
+                                    "default": 9004
+                                },
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "ClickHouse service PostgreSQL port",
+                                    "default": 9005
+                                },
+                                "interserver": {
+                                    "type": "number",
+                                    "description": "ClickHouse service Interserver port",
+                                    "default": 9009
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "ClickHouse service metrics port",
+                                    "default": 8001
+                                }
+                            }
+                        },
+                        "loadBalancerIPs": {
+                            "type": "array",
+                            "description": "Array of load balancer IPs for each ClickHouse . Length must be the same as replicaCount",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerAnnotations": {
+                            "type": "array",
+                            "description": "Array of load balancer annotations for each ClickHouse . Length must be the same as replicaCount",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address(es) that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "array",
+                                    "description": "Node port for HTTP",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "https": {
+                                    "type": "array",
+                                    "description": "Node port for HTTPS",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "tcp": {
+                                    "type": "array",
+                                    "description": "Node port for TCP",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "tcpSecure": {
+                                    "type": "array",
+                                    "description": "Node port for TCP (with TLS)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "keeper": {
+                                    "type": "array",
+                                    "description": "ClickHouse keeper TCP container port",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "keeperSecure": {
+                                    "type": "array",
+                                    "description": "ClickHouse keeper TCP container port (with TLS)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "keeperInter": {
+                                    "type": "array",
+                                    "description": "ClickHouse keeper interserver TCP container port",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "mysql": {
+                                    "type": "array",
+                                    "description": "Node port for MySQL",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "postgresql": {
+                                    "type": "array",
+                                    "description": "Node port for PostgreSQL",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "interserver": {
+                                    "type": "array",
+                                    "description": "Node port for Interserver",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metrics": {
+                                    "type": "array",
+                                    "description": "Node port for metrics",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Service labels for external access",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Service annotations for external access",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the ClickHouse external service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for ClickHouse",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "clickhouse.local"
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Name of an existing PVC to use",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Storage class of backing PVC",
+                    "default": ""
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim labels",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.containerPorts.metrics }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a PrometheusRule for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "PrometheusRule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "externalZookeeper": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "description": "List of external zookeeper servers to use",
+                    "default": [],
+                    "items": {}
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the Zookeeper servers",
+                    "default": 2888
+                }
+            }
+        },
+        "zookeeper": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Zookeeper subchart",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Zookeeper instances",
+                    "default": 3
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "client": {
+                                    "type": "number",
+                                    "description": "Zookeeper client port",
+                                    "default": 2181
+                                }
+                            }
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Zookeeper image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Zookeeper image repository",
+                            "default": "bitnami/zookeeper"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Zookeeper image tag (immutable tags are recommended)",
+                            "default": "3.8.2-debian-11-r43"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Zookeeper image pull policy",
+                            "default": "IfNotPresent"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/common/values.schema.json
+++ b/bitnami/common/values.schema.json
@@ -1,0 +1,11 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "exampleValue": {
+            "type": "string",
+            "description": "",
+            "default": "common-chart"
+        }
+    }
+}

--- a/bitnami/concourse/values.schema.json
+++ b/bitnami/concourse/values.schema.json
@@ -1,0 +1,1792 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "image repository",
+                    "default": "bitnami/concourse"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "image tag (immutable tags are recommended)",
+                    "default": "7.10.0-debian-11-r32"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "secrets": {
+            "type": "object",
+            "properties": {
+                "localAuth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "the use of local authentication (basic auth).",
+                            "default": true
+                        }
+                    }
+                },
+                "localUsers": {
+                    "type": "string",
+                    "description": "List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users. Auto-generated if not set",
+                    "default": ""
+                },
+                "teamAuthorizedKeys": {
+                    "type": "array",
+                    "description": "Array of team names and public keys for team external workers",
+                    "default": [],
+                    "items": {}
+                },
+                "conjurAccount": {
+                    "type": "string",
+                    "description": "Account for Conjur auth provider.",
+                    "default": ""
+                },
+                "conjurAuthnLogin": {
+                    "type": "string",
+                    "description": "Host username for Conjur auth provider.",
+                    "default": ""
+                },
+                "conjurAuthnApiKey": {
+                    "type": "string",
+                    "description": "API key for host used for Conjur auth provider. Either API key or token file can be used, but not both.",
+                    "default": ""
+                },
+                "conjurAuthnTokenFile": {
+                    "type": "string",
+                    "description": "Token file used for Conjur auth provider if running in Kubernetes or IAM. Either token file or API key can be used, but not both.",
+                    "default": ""
+                },
+                "conjurCACert": {
+                    "type": "string",
+                    "description": "CA Certificate to specify if conjur instance is deployed with a self-signed cert",
+                    "default": ""
+                },
+                "hostKey": {
+                    "type": "string",
+                    "description": "Concourse Host Keys.",
+                    "default": "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEA2AUPXxuiDC/qrBWjIdT5fvNcMlMEYpR3X4SLQIgLC1ULDsCO\nfleKZ+Wi4RzwbkUKiKmJm5GeyNVVCDdfvdD1Sd1+5faqmp2/OQBzLS7o8NY/btMw\n8h9lx4KVJaJJ1EM1EiyGY41Nx591KP14pBfr0/NdOIrDu2JvF6e7CHEbrzkN57kb\nBVQkaIMaS01Rw/5Oe68GFalli2ii8L8dNWVVzquBh5PwVWimvTgwv3TYG2TH8L1V\nV7n+/zRRpkjMl2+PUouGqD+Bp+4wF+hp4AW5v24CqjtLJEMv4IEJv2FRfrOauBIZ\nXjAS1SSg9VaTOS3iwxaYrv8uG1XfMFHICvkEPQIDAQABAoIBAG87W8jrX6vK2Jm3\nooJ/OeFmymiXWsCwFi+2/kVCR/2T0tfLyxO/W+NX2WD1F9CP+HaaZeMXPp3HS7up\nV8FT4ZohVYBwXTS0WYyucKApcYThrVQRpzhldnEfClGQmVeVK7Sp/KEyV4Sc1SVA\nL2i/cI142N2Ohm7spquVkLcuFsVINzZ0fXCv25dTqbkEgjTJzNdBzyFXvc4z0Mt9\ngW14M7mz+YKYOfsCxIEm438fC9b16C96yIFBdN+/jaP8pmb2RoIE2D0F8bj5K1hR\nYyGFKMOU4e6cYq59iWfubKuu2WNJEBk/5aO7x7Xu2S0k8wIYlwxFuu4LfR2Kvizu\n+mFVf3kCgYEA9e0+40tJGpOPM8hAB3DwXjYc8lCuyYf3z30T3RqVNCUVSWnlaj/s\n3ENi6+Ng3u+Zs8cR2CFou+jAClTyWLuSnI9yACD0eyW9n4bzYMUbgdC6vneLjpzx\nwWR9Xv5RmZVly7xWuqcgEeEf8RNcYI3oXby0laF3EObvuAx/4ETIkFcCgYEA4N42\nw1UEWGopWBIIXYHkEPHQuF0SxR2CZyh9ExTeSxFphyibkcHRjDW+t91ZLnSm5k1N\nTOdYuc0ApBV3U+TexeFvDI94L/Oze6Ht5MatRQz8kRwMFGJL3TrpbgTmWdfG05Ad\noiScJzwY16oJXnKusxik7V+gCCNNE0/2UuMnY4sCgYAEf82pvOPef5qcGOrK+A79\nukG3UTCRcVJgUmp9nhHivVbxW+WdlwPPV9BEfol0KrAGMPsrmBjhbzWsOregVfYt\ntRYh2HiAlEUu2Po06AZDzrzL5UYBWu+1WRBOH5sAk1IkcxKnIY2dph++elszTQVW\nSbCIGEckYQU7ucbRJJECywKBgBb4vHFx8vKxTa3wkagzx7+vZFohL/SxEgxFx5k2\nbYsPqU8kZ9gZC7YeG3CfDShAxHgMd5QeoiLA/YrFop4QaG2gnP6UfXuwkqpTnYDc\nhwDh1b9hNR6z9/oOtaAGoh2VfHtKYqyYvtcHPaZyeWiLoKstHlQdi7SpHouVhJ1t\nFS4HAoGAGy+56+zvdROjJy9A2Mn/4BvWrsu4RSQILBJ6Hb4TpF46p2fn0rwqyhOj\nOccs+xkdEsI9w5phXzIEeOq2LqvWHDPxtdLpxOrrmx4AftAWdM8S1+OqTpzHihK1\ny1ZOrWfvON+XjWFFAEej/CpQZkNUkTzjTtSC0dnfAveZlasQHdI=\n-----END RSA PRIVATE KEY-----"
+                },
+                "hostKeyPub": {
+                    "type": "string",
+                    "description": "Concourse Host Keys.",
+                    "default": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse"
+                },
+                "sessionSigningKey": {
+                    "type": "string",
+                    "description": "Concourse Session Signing Keys.",
+                    "default": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwLql/rUIaI+PX7Tl3FWcTee4sQf8/daakALXx955tPwkhqlY\ne4T2V84p/ylFvNWpM4vfcMYKfMY0JLKgAgBvJhCytSkDBhTBoWmN6yE0AB11P9En\nlIZRBWNYqaC2cSge2ZD8qOSnwfFhnQAW8+7pE+ElJAVh7dtdF3A478H50lIigq8I\nzMWp2EGJpFC7/Uu36oIL/03MNGCmrH1jvtTuJiAMQUZYyL1ReBkvvHOzw9i4HXPy\nSMVtcllm4NBs2aVPtwhr2kwSkLt8t1bPdRn6OIyEAw5WktzAKaiZnkTvj6g3xzdp\nzKcrdlBr9aznlNvoSinBUfvtwyFmvFN1HHbA9wIDAQABAoIBAE7G/DrUfI9gvtX7\n90jMpYsigFe8UCjho2PiBZlo0o6r0bJJXiV+/8J8PqZRlHPPUc4EClzqVjcSPRYS\n/VxUGRqSELoD/Xxq14rGvn+xnrO9VsOzFl6bWFq/dOpBCtHN+G4t2VifvgKES8YE\n11z19sdta+UBXjn/RFnkQSGfRCI3QqTaYvjxevt0uWlyPmqkFPQQw8bvHIXzoB+B\nrzeiMa++nMvbX5pAH9XA0BvhyuH3fHidTUwiVBpkMcpLWtjP0A0JTsecDdbinDDq\nun2EIo8zMWRwKQN/JnUxsi8AUEigBTCUqeDgREXtW62uvFkSpcVMXwmVityLYIVy\nqnVLUCECgYEA6IwXkP1qnSfcNeoVI/ypDuz1/kdqcjSPhLYe+jdiLLoFkMW9AlDm\nlzwNaWlTFD9ygo+NjJCo63/A8HCm55sajws5hZ6r20vdZcKFMk9h0qF5oVA7lkQ2\ngvG2WaznuU7KkqhfP+pXhiLgZKoJkst/+g7r6uHpredwDY6hxeBK4vsCgYEA1CqH\n8ywC5qUo/36kQg/TU2adN/YEHdJAAbU23EVrGQSVmnXW08H2NLFk0tsxrwoNnbgp\nPIk2J7BimbJvbND17ibr4GAklDTsR8aJkDl+0JgNCAK9N07qVt1s7FXzhg95jUL9\nEQW55z60GAJpecqNwA4Jsa8P852N0355Obp92TUCgYBkOBvf7JcJ66fHxH4f6D+j\noxPQ5k5Fsck4VJS9GSlCRVkor09ptBvsiYDuMOoRC9b51YwXTDDAbWplNOd5YSrt\nAtVjdKJz/BoKRO7KY9Owxs54au+DLxqfDDSeKRokjoRW+CE0lnXp5RX3zCAcF3+r\n8MpTi9D9lYSBEzs84BDmCQKBgQCMcH6/K3HcJJVn0fd+tyUGftUw9sswxjySJNbk\npZrH263/qWMDls+Xf5kire9MU1ZCAWZiaN0NFoed/2wcVpGEDAV0548u/30r4bKr\nYjOcdhmiJNYFJ1qdF0MDib2CDvpB1IbZXrX46RujDO2urbJ435HxKNVhR/had8xc\ntyKYxQKBgCVDhN0MhnlUQJVZfX42APmF4gQg0r3sfL/NGXjEjMIKKFe5a88eZVHr\nL8x1+dp0q7czC8a/l1DUuiwDKl8OEpxLsGCq/J/wAfrSMPifu6EUlbUwlJOPdgha\n+p/KFAelHXJ2w/8yackAcarh35VP7ixhuvxswHNdgvfsBTFcjn30\n-----END RSA PRIVATE KEY-----"
+                },
+                "workerKey": {
+                    "type": "string",
+                    "description": "Concourse Worker Keys.",
+                    "default": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAuPehUmBXAQCoA7TLAQCYhf+vzcZVyj+VGXnMhLHnWLk7dRjo\nCU8GgNamdS5h7G3ywxOvKA3YjOLr8XyOMLS4c+e8N7tIzlMWdiXhe0lcBH9Z1ai5\n+Bof3/BlDUBksiKdc1A+QcfX6tDwMkOO5re1H4vOK3H/Cype58wCB03HYNgb05ED\nfW1Bj2qvz29VtmyjwEMuDs100iMqwCfPUx9oxXmmX8sUBRmw/Y1Rx/8pdKIjKw3m\nkWIHHBOSCPimO1qC47Aa8v/UH9hERCykyuFHiBiKlnIvZWm9bYvhsRTz4gt5KzRY\n6OI0oVeHlLOHDSK48Da8VWij15lOqO2Nx6WssQIDAQABAoIBADET22UNFOi6MNpS\n5S5N5ypezlnOD0NLnZcV3zMyNQ0wkNsgEakuo64Zxi7/cJIYFjq2hVoeWl//cdUw\nVFYODYcLbMBo3AeKukH9CRf6PgUfeUmcrENtQxnbIiTi+hTd5GMNXod7rAmtCJ59\nmHQVOGS3ZqvWYnKm+mmMktk3RPinynX/A4y3WHPacuAS58HM09Ck43WcHMxbGpsL\n/gZpICyFYZ2DviM+AHyWGcmw7LJrpC0QHo6+BAFMs4xlUecNgVIFUpfOoAcfsdtG\nK9j4AbuZ47iFisbay+1pyg/7O5eRTdGVQRtc7PBMOjea5jGsfmlDmdn1ZS50ykun\nANfoQ5UCgYEA9Ak73PRy9nLlRkt4OBCF/4fwThUCMedsnWaVjQBMJYim4FB2ivF5\ncKdWt3y/RZI85KKYu0EXhLEoSIEAfz057R8t3QdVK4tZx6B47UFjBjCYeVMtwHDQ\nprxQiOPHIHCplBNFuGzA5VXL9gQLRD+ek0uOy2GJJ0Wu1xyeouI+SW8CgYEAwgkO\nTOtOogqmcAALjWgeeQiZetflSKbJlpQNhmCPAMm0SFI8eF4SpRXLzd41VC2mLIwT\nL3tjc7/8ocXoElFM4L0fo9Lx/SHFH4JEn5FT0PXPmvsF2JRhsXJFLJSihxF/91Xs\n2aBcQILPFzLcrI6OFUakNwGTU/CIxpkzRvQrG98CgYEAzNVnUuo4CNadzagRK3Xr\nE3Yl5VRK+FpY17FAfA6w25xc/dFr/un61e0Po4no/ltmEz7LVfmn5O/ScTEemq5o\njbjrBShfe+JGpIH0nqiQlqR5hvSjZXEMIbfVHWGbRYZrQGgA0HEwZA7k2QXB8zI3\nR0lXfSzMM5OQ0uwp12xxfa8CgYBHILq1R6zTicPpWprhg0FobNaWSX4rW7iaEjvC\n/rJtP4Nu33Z7SUDcc1j6ZnJ2ISXBPrfpt/mE/OPHCZ1A2bysxadLjpBWkoKIQmCV\nfdiTyQgJb+t8sSf+vDzPUs0hZjDaogzo2ff3TfxMLMDoIHnFItgfsdwn8QyygIZj\nhC4pUQKBgQDqsxnkI6yXFE5gshnW7H8zqKNlzKd/dZEL6e+lRz4R3UY/KcEkRAfq\nYi3cwo9fE3U3kSmpl5MQwUjWm/BZ7JyueoY/4ndwaFPgc34IKsgJ0wau9pZiQAB1\nDxpOSF+BR71Jx3sxvIdCODNTtm645j5yrZVnJAuMPofo5XFmunDoJA==\n-----END RSA PRIVATE KEY-----"
+                },
+                "workerKeyPub": {
+                    "type": "string",
+                    "description": "Concourse Worker Keys.",
+                    "default": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse"
+                },
+                "workerAdditionalCerts": {
+                    "type": "string",
+                    "description": "Additional certificates to add to the worker nodes",
+                    "default": ""
+                }
+            }
+        },
+        "web": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Concourse web component",
+                    "default": true
+                },
+                "baseUrl": {
+                    "type": "string",
+                    "description": "url",
+                    "default": "/"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Minimum level of logs to see. Possible options: debug, info, error.",
+                    "default": "debug"
+                },
+                "clusterName": {
+                    "type": "string",
+                    "description": "A name for this Concourse cluster, to be displayed on the dashboard page.",
+                    "default": ""
+                },
+                "bindIp": {
+                    "type": "string",
+                    "description": "IP address on which to listen for HTTP traffic (web UI and API).",
+                    "default": "0.0.0.0"
+                },
+                "peerAddress": {
+                    "type": "string",
+                    "description": "Network address of this web node, reachable by other web nodes.",
+                    "default": ""
+                },
+                "externalUrl": {
+                    "type": "string",
+                    "description": "URL used to reach any ATC from the outside world.",
+                    "default": ""
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "cookieSecure": {
+                            "type": "boolean",
+                            "description": "use cookie secure true or false",
+                            "default": false
+                        },
+                        "duration": {
+                            "type": "string",
+                            "description": "Length of time for which tokens are valid. Afterwards, users will have to log back in.",
+                            "default": "24h"
+                        },
+                        "passwordConnector": {
+                            "type": "string",
+                            "description": "The connector to use for password authentication for `fly login -u ... -p ...`.",
+                            "default": ""
+                        },
+                        "mainTeam": {
+                            "type": "object",
+                            "properties": {
+                                "config": {
+                                    "type": "string",
+                                    "description": "Configuration file for specifying the main teams params.",
+                                    "default": ""
+                                },
+                                "localUser": {
+                                    "type": "string",
+                                    "description": "Comma-separated list of local Concourse users to be included as members of the `main` team.",
+                                    "default": "user"
+                                }
+                            }
+                        }
+                    }
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use an existing secret for the Web service credentials",
+                    "default": ""
+                },
+                "enableAcrossStep": {
+                    "type": "boolean",
+                    "description": "Enable the experimental across step to be used in jobs. The API is subject to change.",
+                    "default": false
+                },
+                "enablePipelineInstances": {
+                    "type": "boolean",
+                    "description": "Enable the creation of instanced pipelines.",
+                    "default": false
+                },
+                "enableCacheStreamedVolumes": {
+                    "type": "boolean",
+                    "description": "Enable caching streamed resource volumes on the destination worker.",
+                    "default": false
+                },
+                "baseResourceTypeDefaults": {
+                    "type": "string",
+                    "description": "Configuration file for specifying defaults for base resource types",
+                    "default": ""
+                },
+                "tsa": {
+                    "type": "object",
+                    "properties": {
+                        "logLevel": {
+                            "type": "string",
+                            "description": "Minimum level of logs to see. Possible values: debug, info, error",
+                            "default": "debug"
+                        },
+                        "bindIp": {
+                            "type": "string",
+                            "description": "IP address on which to listen for SSH",
+                            "default": "0.0.0.0"
+                        },
+                        "debugBindIp": {
+                            "type": "string",
+                            "description": "IP address on which to listen for the pprof debugger endpoints (default: 127.0.0.1)",
+                            "default": "127.0.0.1"
+                        },
+                        "heartbeatInterval": {
+                            "type": "string",
+                            "description": "Interval on which to heartbeat workers to the ATC",
+                            "default": "30s"
+                        },
+                        "gardenRequestTimeout": {
+                            "type": "string",
+                            "description": "How long to wait for requests to Garden to complete. 0 means no timeout",
+                            "default": ""
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "enable serving HTTPS traffic directly through the web component.",
+                            "default": false
+                        }
+                    }
+                },
+                "configRBAC": {
+                    "type": "string",
+                    "description": "Set RBAC configuration",
+                    "default": ""
+                },
+                "conjur": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the use of Conjur as a credential manager",
+                            "default": false
+                        },
+                        "applianceUrl": {
+                            "type": "string",
+                            "description": "URL of the Conjur instance.",
+                            "default": ""
+                        },
+                        "pipelineSecretTemplate": {
+                            "type": "string",
+                            "description": "Path used to locate pipeline-level secret",
+                            "default": "concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"
+                        },
+                        "teamSecretTemplate": {
+                            "type": "string",
+                            "description": "Path used to locate team-level secret",
+                            "default": "concourse/{{.Team}}/{{.Secret}}"
+                        },
+                        "secretTemplate": {
+                            "type": "string",
+                            "description": "Path used to locate a vault or safe-level secret",
+                            "default": "concourse/{{.Secret}}"
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with your custom configuration for web",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Concourse web nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Concourse web nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Concourse web nodes",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Concourse web replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Concourse web UI and API HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Concourse web UI and API HTTPS container port",
+                            "default": 8443
+                        },
+                        "tsa": {
+                            "type": "number",
+                            "description": "Concourse web TSA SSH container port",
+                            "default": 2222
+                        },
+                        "pprof": {
+                            "type": "number",
+                            "description": "Concourse web TSA pprof server container port",
+                            "default": 2221
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Concourse web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 1
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Concourse web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 1
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Concourse web containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Concourse web containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Concourse web containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled web pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set web pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled web containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set web containers' Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Concourse web pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Concourse web pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Concourse web pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `web.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `web.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for web pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for web pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for web pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class to use for each pod (Concourse web)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Concourse web pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Concourse web statefulset rolling update configuration parameters",
+                            "default": {}
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Concourse web statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the Concourse web container(s)",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Concourse web container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Concourse web container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Concourse web pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Concourse web pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "psp": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": false
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Override Web service account name",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "worker": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Concourse worker nodes",
+                    "default": true
+                },
+                "runtime": {
+                    "type": "string",
+                    "description": "Set CONCURSE_RUNTIME in worker nodes. Please note the default runtime (guardian) only supports cgroupsv1.",
+                    "default": "containerd"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Minimum level of logs to see. Possible options: debug, info, error",
+                    "default": "debug"
+                },
+                "bindIp": {
+                    "type": "string",
+                    "description": "IP address on which to listen for the Garden server.",
+                    "default": "127.0.0.1"
+                },
+                "tsa": {
+                    "type": "object",
+                    "properties": {
+                        "hosts": {
+                            "type": "array",
+                            "description": "TSA host(s) to forward the worker through",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "name of an existing secret resource containing the keys and the pub",
+                    "default": ""
+                },
+                "baggageclaim": {
+                    "type": "object",
+                    "properties": {
+                        "logLevel": {
+                            "type": "string",
+                            "description": "Minimum level of logs to see. Allowed values: `debug`, `info`, and `error`",
+                            "default": "info"
+                        },
+                        "bindIp": {
+                            "type": "string",
+                            "description": "IP address on which to listen for API traffic",
+                            "default": "127.0.0.1"
+                        },
+                        "debugBindIp": {
+                            "type": "string",
+                            "description": "IP address on which to listen for the pprof debugger endpoints",
+                            "default": "127.0.0.1"
+                        },
+                        "disableUserNamespaces": {
+                            "type": "string",
+                            "description": "Disable remapping of user/group IDs in unprivileged volumes",
+                            "default": ""
+                        },
+                        "volumes": {
+                            "type": "string",
+                            "description": "Directory in which to place volume data",
+                            "default": ""
+                        },
+                        "driver": {
+                            "type": "string",
+                            "description": "Driver to use for managing volumes. Allowed values: `detect`, `naive`, `btrfs`, and `overlay`",
+                            "default": ""
+                        },
+                        "btrfsBin": {
+                            "type": "string",
+                            "description": "Path to btrfs binary",
+                            "default": "btrfs"
+                        },
+                        "mkfsBin": {
+                            "type": "string",
+                            "description": "Path to mkfs.btrfs binary",
+                            "default": "mkfs.btrfs"
+                        },
+                        "overlaysDir": {
+                            "type": "string",
+                            "description": "Path to directory in which to store overlay data",
+                            "default": ""
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override worker default args",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of worker replicas",
+                    "default": 2
+                },
+                "mode": {
+                    "type": "string",
+                    "description": "Selects kind of Deployment. Allowed values: `deployment` or `statefulset`",
+                    "default": "deployment"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "garden": {
+                            "type": "number",
+                            "description": "Concourse worker Garden server container port",
+                            "default": 7777
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Concourse worker health-check container port",
+                            "default": 8888
+                        },
+                        "baggageclaim": {
+                            "type": "number",
+                            "description": "Concourse worker baggageclaim API container port",
+                            "default": 7788
+                        },
+                        "pprof": {
+                            "type": "number",
+                            "description": "Concourse worker baggageclaim pprof server container port",
+                            "default": 7787
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Concourse worker containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 1
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Concourse worker containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 1
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Concourse worker containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Concourse worker containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Concourse worker containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled worker pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set worker pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled worker containers' Security Context",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set worker containers' Security Context with privileged or not",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set worker containers' Security Context user",
+                            "default": 0
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Concourse worker pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Custom labels for Concourse worker pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Concourse worker pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity type",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for worker pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class to use for each pod (Concourse worker)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Concourse worker pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod Management Policy Type. Allowed values: `OrderedReady` or `Parallel`",
+                    "default": "OrderedReady"
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Concourse worker statefulset rolling update configuration parameters",
+                            "default": {}
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Concourse worker statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Concourse worker container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Concourse worker nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Concourse worker nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Concourse worker nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Concourse worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Concourse worker container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Concourse worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Concourse worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for the Concourse worker nodes",
+                            "default": false
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Set maximum number of replicas to the Concourse worker nodes",
+                            "default": ""
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Set minimum number of replicas to the Concourse worker nodes",
+                            "default": ""
+                        },
+                        "builtInMetrics": {
+                            "type": "array",
+                            "description": "Array with built-in metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "customMetrics": {
+                            "type": "array",
+                            "description": "Array with custom metrics",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create Pod disruption budget object for Concourse worker nodes",
+                            "default": true
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number / percentage of Concourse worker pods that should remain scheduled",
+                            "default": 2
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of Concourse worker pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "psp": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": false
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Concourse worker data persistence using PVC",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Concourse worker data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Mode for Concourse worker volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Concourse worker volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Override worker service account name",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "web": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Concourse web service type",
+                            "default": "LoadBalancer"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Concourse web service HTTP port",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Concourse web service HTTPS port",
+                                    "default": 443
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "https": {
+                                    "type": "string",
+                                    "description": "Node port for HTTPS",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Concourse web service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Concourse web service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Concourse web service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Concourse web service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Concourse web service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on Concourse web service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "workerGateway": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Concourse worker gateway service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "tsa": {
+                                    "type": "number",
+                                    "description": "Concourse worker gateway service port",
+                                    "default": 2222
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "tsa": {
+                                    "type": "string",
+                                    "description": "Node port for worker gateway service",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Concourse worker gateway service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Concourse worker gateway service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Concourse worker gateway service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Concourse worker gateway service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Concourse worker gateway service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on Concourse worker gateway service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Concourse",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "concourse.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled init container Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enablePostgresUser": {
+                            "type": "boolean",
+                            "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                            "default": false
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_concourse"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_concourse"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Concourse",
+                    "default": "bn_concourse"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Concourse",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Concourse database name",
+                    "default": "bitnami_concourse"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/consul/values.schema.json
+++ b/bitnami/consul/values.schema.json
@@ -1,0 +1,1026 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects (sub-charts are not considered)",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects (sub-charts are not considered)",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "HashiCorp Consul image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "HashiCorp Consul image repository",
+                    "default": "bitnami/consul"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "HashiCorp Consul image tag (immutable tags are recommended)",
+                    "default": "1.16.1-debian-11-r10"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "HashiCorp Consul image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "HashiCorp Consul image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "HashiCorp Consul image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "datacenterName": {
+            "type": "string",
+            "description": "Datacenter name for Consul. If not supplied, will use the Consul",
+            "default": "dc1"
+        },
+        "domain": {
+            "type": "string",
+            "description": "Consul domain name",
+            "default": "consul"
+        },
+        "raftMultiplier": {
+            "type": "string",
+            "description": "Multiplier used to scale key Raft timing parameters",
+            "default": "1"
+        },
+        "gossipKey": {
+            "type": "string",
+            "description": "Gossip key for all members. The key must be 16-bytes, can be generated with $(consul keygen)",
+            "default": ""
+        },
+        "tlsEncryptionSecretName": {
+            "type": "string",
+            "description": "Name of existing secret with TLS encryption data",
+            "default": ""
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "configuration": {
+            "type": "string",
+            "description": "HashiCorp Consul configuration to be injected as ConfigMap",
+            "default": ""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "ConfigMap with HashiCorp Consul configuration",
+            "default": ""
+        },
+        "localConfig": {
+            "type": "string",
+            "description": "Extra configuration that will be added to the default one",
+            "default": ""
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod labels",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority class assigned to the Pods",
+            "default": ""
+        },
+        "runtimeClassName": {
+            "type": "string",
+            "description": "Name of the runtime class to be used by pod(s)",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the Consul pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Command for running the container (set to default if not set). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Args for running the container (set to default if not set). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on HashiCorp Consul container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Port to open for HTTP in Consul",
+                    "default": 8500
+                },
+                "dns": {
+                    "type": "number",
+                    "description": "Port to open for DNS server in Consul",
+                    "default": 8600
+                },
+                "rpc": {
+                    "type": "number",
+                    "description": "Port to open for RPC in Consul",
+                    "default": 8400
+                },
+                "rpcServer": {
+                    "type": "number",
+                    "description": "Port to open for RPC Server in Consul",
+                    "default": 8300
+                },
+                "serfLAN": {
+                    "type": "number",
+                    "description": "Port to open for Serf LAN in Consul",
+                    "default": 8301
+                }
+            }
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Add lifecycle hooks to the deployment",
+            "default": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of HashiCorp Consul replicas to deploy",
+            "default": 3
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy type for the HashiCorp Consul statefulset",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "StatefulSet pod management policy",
+            "default": "Parallel"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional pod annotations",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable security context for HashiCorp Consul pods",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the volumes of the pod",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "HashiCorp Consul Container securityContext",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the HashiCorp Consul container",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Force the container to be run as non root",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Force the child process to be run as nonprivilege",
+                    "default": false
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for HashiCorp Consul containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for HashiCorp Consul containers",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Hashicorp Consul container",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Hashicorp Consul container",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Hashicorp Consul pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Hashicorp Consul pods",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number of pods that must still be available after the eviction",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Max number of pods that can be unavailable after the eviction",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Use a service to access HashiCorp Consul Ui",
+                    "default": true
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "HashiCorp Consul UI svc port",
+                            "default": 80
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "description": "HashiCorp Consul UI Service Type",
+                    "default": "ClusterIP"
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HashiCorp Consul UI",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Consul service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "HashiCorp Consul UI service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Consul service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for HashiCorp Consul UI service",
+                    "default": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress resource for Management console",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the default host",
+                    "default": "/"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource, a host pointing to this will be created",
+                    "default": "consul-ui.local"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "Set the ingerssClassName on the ingress record for k8s 1.18+",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "It is you own the certificate as secret.",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable HashiCorp Consul data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Mode",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for HashiCorp Consul data volume",
+                    "default": "8Gi"
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "HashiCorp Consul Prometheus Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "HashiCorp Consul Prometheus Exporter image repository",
+                            "default": "bitnami/consul-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "HashiCorp Consul Prometheus Exporter image tag (immutable tags are recommended)",
+                            "default": "0.9.0-debian-11-r252"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "HashiCorp Consul Prometheus Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "HashiCorp Consul Prometheus Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "HashiCorp Consul Prometheus Exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "HashiCorp Consul Prometheus Exporter securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the HashiCorp Consul Prometheus Exporter",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Service Load Balancer IP",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "9107"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9107"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Service Monitor Entry",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the ServiceMonitor will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "The timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metrics relabelings to add to the scrape endpoint",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/contour/values.schema.json
+++ b/bitnami/contour/values.schema.json
@@ -1,0 +1,2009 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override contour.fullname include (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override contour.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "existingConfigMap": {
+            "type": "string",
+            "description": "Specifies the name of an externally-defined ConfigMap to use as the configuration (this is mutually exclusive with `configInline`)",
+            "default": ""
+        },
+        "configInline": {
+            "type": "object",
+            "properties": {
+                "disablePermitInsecure": {
+                    "type": "boolean",
+                    "description": "",
+                    "default": false
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "fallback-certificate": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        }
+                    }
+                },
+                "accesslog-format": {
+                    "type": "string",
+                    "description": "",
+                    "default": "envoy"
+                }
+            }
+        },
+        "contour": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Contour Deployment creation.",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Contour image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Contour image name",
+                            "default": "bitnami/contour"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Contour image tag",
+                            "default": "1.25.2-debian-11-r22"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Contour image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Contour Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Contour Image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Contour Pod replicas",
+                    "default": 1
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class assigned to the pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Contour pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "xds": {
+                            "type": "number",
+                            "description": "Set xds port inside Contour pod",
+                            "default": 8001
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Set metrics port inside Contour pod",
+                            "default": 8000
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "description": "Strategy to use to update Pods",
+                    "default": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments passed to Contour container",
+                    "default": [],
+                    "items": {}
+                },
+                "manageCRDs": {
+                    "type": "boolean",
+                    "description": "Manage the creation, upgrade and deletion of Contour CRDs.",
+                    "default": true
+                },
+                "envoyServiceNamespace": {
+                    "type": "string",
+                    "description": "Namespace of the envoy service to inspect for Ingress status details.",
+                    "default": ""
+                },
+                "envoyServiceName": {
+                    "type": "string",
+                    "description": "Name of the envoy service to inspect for Ingress status details.",
+                    "default": ""
+                },
+                "leaderElectionResourceName": {
+                    "type": "string",
+                    "description": "Name of the contour (Lease) leader election will lease.",
+                    "default": ""
+                },
+                "ingressStatusAddress": {
+                    "type": "string",
+                    "description": "Address to set in Ingress object status. It is exclusive with `envoyServiceName` and `envoyServiceNamespace`.",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Contour Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Contour Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the container to automate configuration before or after startup.",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Contour Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Contour Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Contour Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default args",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Contour pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a serviceAccount for the Contour pod",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Use the serviceAccount with the specified name, a name is generated using the fullname template",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Default backend Pod securityContext",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Default backend Pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Envoy Container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Contour container (to change this, http and https containerPorts must be set to >1024)",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the Liveness probe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                            "default": 1
+                        }
+                    }
+                },
+                "certgen": {
+                    "type": "object",
+                    "properties": {
+                        "serviceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Create a serviceAccount for the Contour pod",
+                                    "default": true
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Use the serviceAccount with the specified name, a name is generated using the fullname template",
+                                    "default": ""
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Automount service account token for the server service account",
+                                    "default": true
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "certificateLifetime": {
+                            "type": "number",
+                            "description": "Generated certificate lifetime (in days).",
+                            "default": 365
+                        }
+                    }
+                },
+                "tlsExistingSecret": {
+                    "type": "string",
+                    "description": "Name of the existingSecret to be use in Contour deployment. If it is not nil `contour.certgen` will be disabled.",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "xds": {
+                                    "type": "number",
+                                    "description": "Contour service xds port",
+                                    "default": 8001
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Contour service xds port",
+                                    "default": 8000
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "xds": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Contour service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Contour service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Contour service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerClass": {
+                            "type": "string",
+                            "description": "Contour service Load Balancer Class",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Contour service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Contour service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on Contour service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Attach additional init containers to Contour pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Contour pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array to add extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array to add extra mounts (normally used with extraVolumes)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to be added to all Contour containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to be added to all Contour containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to be added to all Contour containers",
+                    "default": ""
+                },
+                "ingressClass": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the ingress class to route through this controller.",
+                            "default": ""
+                        },
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create or not the IngressClass resource",
+                            "default": true
+                        },
+                        "default": {
+                            "type": "boolean",
+                            "description": "Mark IngressClass resource as default for cluster",
+                            "default": true
+                        }
+                    }
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Contour debug log level",
+                    "default": false
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Set contour log-format. Default text, either text or json.",
+                    "default": "text"
+                },
+                "kubernetesDebug": {
+                    "type": "number",
+                    "description": "Contour kubernetes debug log level, Default 0, minimum 0, maximum 9.",
+                    "default": 0
+                },
+                "rootNamespaces": {
+                    "type": "string",
+                    "description": "Restrict Contour to searching these namespaces for root ingress routes.",
+                    "default": ""
+                },
+                "overloadManager": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Overload Manager",
+                            "default": false
+                        },
+                        "maxHeapBytes": {
+                            "type": "string",
+                            "description": "Overload Manager's maximum heap size in bytes",
+                            "default": "2147483648"
+                        }
+                    }
+                }
+            }
+        },
+        "envoy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Envoy Proxy creation",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Envoy Proxy image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Envoy Proxy image repository",
+                            "default": "bitnami/envoy"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Envoy Proxy image tag (immutable tags are recommended)",
+                            "default": "1.26.4-debian-11-r20"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Envoy Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Envoy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Envoy image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class assigned to the pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments passed to Envoy container",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default args",
+                    "default": [],
+                    "items": {}
+                },
+                "shutdownManager": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Contour shutdownManager sidecar",
+                            "default": true
+                        },
+                        "extraArgs": {
+                            "type": "array",
+                            "description": "Extra arguments passed to shutdown container",
+                            "default": [],
+                            "items": {}
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Specify Port for shutdown container",
+                            "default": "8090"
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Shutdown Manager Container securityContext",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "User ID for the Shutdown Manager container (to change this, http and https containerPorts must be set to >1024)",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Run as non root",
+                                    "default": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "initConfig": {
+                    "type": "object",
+                    "properties": {
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Envoy initconfig Container securityContext",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "User ID for the Envoy initconfig container (to change this, http and https containerPorts must be set to >1024)",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Run as non root",
+                                    "default": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Install as deployment or daemonset",
+                    "default": "daemonset"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Desired number of Controller pods",
+                    "default": 1
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the container to automate configuration before or after startup.",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "minReadySeconds": {
+                    "type": "number",
+                    "description": "The minimum number of seconds for which a newly created Pod should be ready",
+                    "default": 0
+                },
+                "revisionHistoryLimit": {
+                    "type": "number",
+                    "description": "The number of old history to retain to allow rollback",
+                    "default": 10
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Controller",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Minimum number of Controller replicas",
+                            "default": 1
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Maximum number of Controller replicas",
+                            "default": 11
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        },
+                        "behavior": {
+                            "type": "object",
+                            "description": "HPA Behavior",
+                            "default": {}
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Envoy Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Envoy Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Envoy Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Envoy Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Envoy Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Envoy pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Envoy pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Envoy Pod securityContext",
+                            "default": false
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "User ID for the for the mounted volumes",
+                            "default": 0
+                        },
+                        "sysctls": {
+                            "type": "array",
+                            "description": "Array of sysctl options to allow",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Envoy Container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Envoy container (to change this, http and https containerPorts must be set to >1024)",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Envoy Pod host network access",
+                    "default": false
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Envoy Pod Dns Policy's DNS Policy",
+                    "default": "ClusterFirst"
+                },
+                "tlsExistingSecret": {
+                    "type": "string",
+                    "description": "Name of the existingSecret to be use in Envoy deployment",
+                    "default": ""
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Whether to auto mount API credentials for a service account",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "LivenessProbe port",
+                            "default": 8002
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe",
+                            "default": true
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "ReadinessProbe port",
+                            "default": 8002
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 3
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "StartupProbe port",
+                            "default": 8002
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "Envoy termination grace period in seconds",
+                    "default": 300
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Envoy log level",
+                    "default": "info"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "targetPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "http"
+                                },
+                                "https": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "https"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "envoy service name",
+                            "default": ""
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Type of Envoy service to create",
+                            "default": "LoadBalancer"
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Envoy Service external cluster policy. If `envoy.service.type` is NodePort or LoadBalancer",
+                            "default": "Local"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels to add to te envoy service",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Internal envoy cluster service IP",
+                            "default": ""
+                        },
+                        "externalIPs": {
+                            "type": "array",
+                            "description": "Envoy service external IP addresses",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "IP address to assign to load balancer (if supported)",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "List of IP CIDRs allowed access to load balancer (if supported)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerClass": {
+                            "type": "string",
+                            "description": "Envoy service Load Balancer Class",
+                            "default": ""
+                        },
+                        "ipFamilyPolicy": {
+                            "type": "string",
+                            "description": ", support SingleStack, PreferDualStack and RequireDualStack",
+                            "default": ""
+                        },
+                        "ipFamilies": {
+                            "type": "array",
+                            "description": "List of IP families (e.g. IPv4, IPv6) assigned to the service.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Sets service http port",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Sets service https port",
+                                    "default": 443
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "HTTP Port. If `envoy.service.type` is NodePort and this is non-empty",
+                                    "default": ""
+                                },
+                                "https": {
+                                    "type": "string",
+                                    "description": "HTTPS Port. If `envoy.service.type` is NodePort and this is non-empty",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "useHostPort": {
+                    "type": "boolean",
+                    "description": "Enable/disable `hostPort` for TCP/80 and TCP/443",
+                    "default": true
+                },
+                "useHostIP": {
+                    "type": "boolean",
+                    "description": "Enable/disable `hostIP`",
+                    "default": false
+                },
+                "hostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Sets `hostPort` http port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Sets `hostPort` https port",
+                            "default": 443
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Sets `hostPort` metrics port",
+                            "default": 8002
+                        }
+                    }
+                },
+                "hostIPs": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Sets `hostIP` http IP",
+                            "default": "127.0.0.1"
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Sets `hostIP` https IP",
+                            "default": "127.0.0.1"
+                        },
+                        "metrics": {
+                            "type": "string",
+                            "description": "Sets `hostIP` metrics IP",
+                            "default": "127.0.0.1"
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Sets http port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Sets https port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)",
+                            "default": 8443
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Sets metrics port inside Envoy pod (change this to >1024 to run envoy as a non-root user)",
+                            "default": 8002
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Attach additional init containers to Envoy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Envoy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array to add extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array to add extra mounts (normally used with extraVolumes)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to be added to all Envoy containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to be added to all Envoy containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to be added to all Envoy containers",
+                    "default": ""
+                }
+            }
+        },
+        "defaultBackend": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable a default backend based on NGINX",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Default backend image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Default backend image name",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Default backend image tag",
+                            "default": "1.25.2-debian-11-r2"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the container to automate configuration before or after startup.",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to be added to all Contour containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to be added to all Contour containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to be added to all Contour containers",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array to add extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array to add extra mounts (normally used with extraVolumes)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Attach additional init containers to the http backend pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the default backend",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Set http port inside Contour pod",
+                            "default": 8001
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "description": "Strategy to use to update Pods",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default args",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Desired number of default backend pods",
+                    "default": 1
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Default backend Pod securityContext",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Default backend Pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Default backend container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Envoy container (to change this, http and https containerPorts must be set to >1024)",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class assigned to the pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "In seconds, time the given to the default backend pod needs to terminate gracefully",
+                    "default": 60
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment. Evaluated as a template.",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Service port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations to add to the service",
+                            "default": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable Pod Disruption Budget configuration",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of Default backend pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of Default backend pods that should remain scheduled",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Ingress configuration enabled",
+                    "default": false
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "certManager": {
+                    "type": "boolean",
+                    "description": "Add annotations for cert-manager",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to be added to the web ingress.",
+                    "default": {}
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Hostname for the Ingress object",
+                    "default": "contour.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Concourse",
+                    "default": "/"
+                },
+                "rulesOverride": {
+                    "type": "array",
+                    "description": "Ingress rules override",
+                    "default": [],
+                    "items": {}
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Add additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "TLS configuration.",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "namespace": {
+                            "type": "string",
+                            "description": "Specify if the servicemonitors will be deployed into a different namespace (blank deploys into same namespace as chart)",
+                            "default": ""
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Specify if a servicemonitor will be deployed for prometheus-operator.",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "Specify the jobLabel to use for the prometheus-operator",
+                            "default": "app.kubernetes.io/name"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the scrape interval if not specified use default prometheus scrapeIntervall, the Prometheus default scrape interval is used.",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "The timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a Prometheus Operator prometheusRule",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the prometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create the RBAC roles for API accessibility",
+                    "default": true
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "tlsExistingSecret": {
+            "type": "string",
+            "description": "Name of the existingSecret to be use in both contour and envoy. If it is not nil `contour.certgen` will be disabled.",
+            "default": ""
+        }
+    }
+}

--- a/bitnami/deepspeed/values.schema.json
+++ b/bitnami/deepspeed/values.schema.json
@@ -105,7 +105,7 @@
                 "tag": {
                     "type": "string",
                     "description": "Deepspeed image tag (immutable tags are recommended)",
-                    "default": "0.10.0-debian-11-r17"
+                    "default": "0.10.2-debian-11-r0"
                 },
                 "digest": {
                     "type": "string",
@@ -1394,7 +1394,7 @@
                 "tag": {
                     "type": "string",
                     "description": "Git image tag (immutable tags are recommended)",
-                    "default": "2.41.0-debian-11-r16"
+                    "default": "2.42.0-debian-11-r8"
                 },
                 "digest": {
                     "type": "string",
@@ -1438,7 +1438,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Init container volume-permissions image tag (immutable tags are recommended)",
-                            "default": "11-debian-11-r16"
+                            "default": "11-debian-11-r54"
                         },
                         "digest": {
                             "type": "string",

--- a/bitnami/discourse/values.schema.json
+++ b/bitnami/discourse/values.schema.json
@@ -1,0 +1,1337 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override discourse.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override discourse.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to be added to all deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to be added to all deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Discourse image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Discourse image repository",
+                    "default": "bitnami/discourse"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Discourse image tag",
+                    "default": "3.0.6-debian-11-r15"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Discourse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Discourse image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Discourse image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "description": "Discourse admin user email",
+                    "default": "user@example.com"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Discourse admin user",
+                    "default": "user"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Discourse admin password. WARNING: Minimum length of 10 characters",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret to use for Discourse credentials",
+                    "default": ""
+                }
+            }
+        },
+        "host": {
+            "type": "string",
+            "description": "Hostname to create application URLs (include the port if =/= 80)",
+            "default": ""
+        },
+        "siteName": {
+            "type": "string",
+            "description": "Discourse site name",
+            "default": "My Site!"
+        },
+        "smtp": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable SMTP",
+                    "default": false
+                },
+                "host": {
+                    "type": "string",
+                    "description": "SMTP host name",
+                    "default": ""
+                },
+                "port": {
+                    "type": "string",
+                    "description": "SMTP port number",
+                    "default": ""
+                },
+                "user": {
+                    "type": "string",
+                    "description": "SMTP account user name",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "SMTP account password",
+                    "default": ""
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "SMTP protocol (Allowed values: tls, ssl)",
+                    "default": ""
+                },
+                "auth": {
+                    "type": "string",
+                    "description": "SMTP authentication method",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`",
+                    "default": ""
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Discourse & Sidekiq replicas",
+            "default": 1
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Discourse pods' Security Context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Discourse pod's Security Context fsGroup",
+                    "default": 0
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional pod labels",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Allowed values: soft, hard",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment.",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority Class Name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Use an alternate scheduler, e.g. \"stork\".",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Discourse pod needs to terminate gracefully",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Discourse deployment strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Discourse deployment rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Discourse pods",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Discourse pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Discourse pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the Discourse pods",
+            "default": [],
+            "items": {}
+        },
+        "discourse": {
+            "type": "object",
+            "properties": {
+                "skipInstall": {
+                    "type": "boolean",
+                    "description": "Do not run the Discourse installation wizard",
+                    "default": false
+                },
+                "plugins": {
+                    "type": "array",
+                    "description": "List of plugins to be installed before the container initialization",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Custom command to override image cmd",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Custom args for the custom command",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Discourse pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Discourse pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Discourse pods",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Discourse HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Discourse containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 500
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Discourse containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Discourse containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Discourse containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Discourse containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Discourse containers' Security Context",
+                            "default": false
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Discourse containers' Security Context runAsUser",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Discourse containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Discourse container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Discourse pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "accessMode": {
+                    "type": "string",
+                    "description": "Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)",
+                    "default": "ReadWriteOnce"
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "10Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for Discourse data PVC",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "sidekiq": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Custom command to override image cmd (evaluated as a template)",
+                    "default": [
+                        "/opt/bitnami/scripts/discourse/entrypoint.sh"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Custom args for the custom command (evaluated as a template)",
+                    "default": [
+                        "/opt/bitnami/scripts/discourse-sidekiq/run.sh"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Sidekiq pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Sidekiq pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Sidekiq pods",
+                    "default": ""
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Sidekiq containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated",
+                            "default": 500
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Sidekiq containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Sidekiq containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Sidekiq containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Sidekiq containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Sidekiq containers' Security Context",
+                            "default": false
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Sidekiq containers' Security Context runAsUser",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Sidekiq containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Sidekiq container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Sidekiq pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Discourse service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Discourse service HTTP port",
+                            "default": 80
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Discourse service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Discourse service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Discourse service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Discourse service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Discourse service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Discourse service",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Discourse",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "discourse.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Discourse pods",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backends (PostgreSQL and Redis) only accessible by Discourse's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Discourse only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Discourse. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Discourse. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enablePostgresUser": {
+                            "type": "boolean",
+                            "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                            "default": true
+                        },
+                        "postgresPassword": {
+                            "type": "string",
+                            "description": "Password for the \"postgres\" admin user",
+                            "default": "bitnami"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_discourse"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_application"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Discourse",
+                    "default": "bn_discourse"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Discourse",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Discourse database name",
+                    "default": "bitnami_application"
+                },
+                "create": {
+                    "type": "boolean",
+                    "description": "Switch to enable user/database creation during the installation stage",
+                    "default": true
+                },
+                "postgresUser": {
+                    "type": "string",
+                    "description": "PostgreSQL admin user, used during the installation stage",
+                    "default": ""
+                },
+                "postgresPassword": {
+                    "type": "string",
+                    "description": "PostgreSQL admin password, used during the installation stage",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": "password"
+                },
+                "existingSecretPostgresPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database admin user credentials",
+                    "default": "postgres-password"
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the Redis&reg; helm",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable password authentication",
+                            "default": true
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Redis&reg; password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "The name of an existing secret with Redis&reg; credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Redis&reg; architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Redis&reg; host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Redis&reg; port number",
+                    "default": 6379
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Redis&reg; password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the Redis&trade credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the Redis&trade credentials",
+                    "default": "redis-password"
+                }
+            }
+        }
+    }
+}

--- a/bitnami/dokuwiki/values.schema.json
+++ b/bitnami/dokuwiki/values.schema.json
@@ -1,0 +1,938 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override dokuwiki.fullname template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override dokuwiki.fullname template with a string",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "DokuWiki image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "DokuWiki image repository",
+                    "default": "bitnami/dokuwiki"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "DokuWiki image tag",
+                    "default": "20230404.1.0-debian-11-r54"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "DokuWiki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Image pull policy",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debugging",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "dokuwikiUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "dokuwikiPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Use an existing secret with the dokuwiki password",
+            "default": ""
+        },
+        "dokuwikiEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "dokuwikiFullName": {
+            "type": "string",
+            "description": "User's Full Name",
+            "default": "User Name"
+        },
+        "dokuwikiWikiName": {
+            "type": "string",
+            "description": "Wiki name",
+            "default": "My Wiki"
+        },
+        "customPostInitScripts": {
+            "type": "object",
+            "description": "Custom post-init.d user scripts",
+            "default": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "description": "Strategy to use to update Pods",
+            "default": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for DokuWiki volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for DokuWiki volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for DokuWiki volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Name of an existing PVC to be used",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the PVC",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable securityContext on for DokuWiki deployment",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group to configure permissions for volumes",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable securityContext on for DokuWiki deployment",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User for the securityContext",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Force the container as be run as non root",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the liveness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before liveness probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures to be considered failed",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes to be considered successful",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the readiness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before readinessProbe is initiated",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures to be considered failed",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes to be considered successful",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the startup probe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before startup probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures to be considered failed",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes to be considered successful",
+                    "default": 1
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra env vars",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup. Evaluated as a template",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Attach additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority class assigned to the Pods",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the pod to terminate gracefully",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Container HTTP port",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Container HTTPS port",
+                    "default": 8443
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank",
+                    "default": ""
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Kubernetes service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Kubernetes service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the ingress is enabled, a host pointing to this will be created",
+                    "default": "dokuwiki.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Dokuwiki. You may need to set this to '/*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a exporter side-car",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image name",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Exporter resource requests/limit",
+                    "default": {}
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables (eg proxy)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/drupal/values.schema.json
+++ b/bitnami/drupal/values.schema.json
@@ -1,233 +1,1308 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "drupalUsername": {
-      "type": "string",
-      "title": "Username",
-      "form": true
-    },
-    "drupalPassword": {
-      "type": "string",
-      "title": "Password",
-      "form": true,
-      "description": "Defaults to a random 10-character alphanumeric string if not set"
-    },
-    "drupalEmail": {
-      "type": "string",
-      "title": "Admin email",
-      "form": true
-    },
-    "persistence": {
-      "type": "object",
-      "properties": {
-        "drupal": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi"
-            }
-          }
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress Configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the Drupal installation."
-        },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\"" 
-        }
-      }
-    },
-    "mariadb": {
-      "type": "object",
-      "title": "MariaDB Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MariaDB database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
-        },
-        "primary": {
-          "type": "object",
-          "properties": {
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "title": "Volume Size",
-                  "form": true,
-                  "hidden": {
-                    "value": false,
-                    "path": "mariadb/enabled"
-                  },
-                  "render": "slider",
-                  "sliderMin": 1,
-                  "sliderMax": 100,
-                  "sliderUnit": "Gi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MariaDB is disabled. Use this section to specify the external database details",
-      "form": true,
-      "hidden": "mariadb/enabled",
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host"
         },
-        "user": {
-          "type": "string",
-          "form": true,
-          "title": "Database Username"
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
         },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password"
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override drupal.fullname template (will maintain the release name)",
+            "default": ""
         },
-        "database": {
-          "type": "string",
-          "form": true,
-          "title": "Database Name"
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override drupal.fullname template",
+            "default": ""
         },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port"
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Requested Resources",
-      "description": "Configure resource requests",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Drupal resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Drupal resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Drupal image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Drupal Image name",
+                    "default": "bitnami/drupal"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Drupal Image tag",
+                    "default": "10.1.3-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Drupal image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Drupal image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
             }
-          }
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Metrics",
-          "description": "Prometheus Exporter / Metrics",
-          "form": true
         },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Drupal Pods to run (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "drupalProfile": {
+            "type": "string",
+            "description": "Drupal installation profile",
+            "default": "standard"
+        },
+        "drupalSkipInstall": {
+            "type": "boolean",
+            "description": "Skip Drupal installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "drupalUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "drupalPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "drupalEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": true
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
             }
-          }
-        }        
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "properties": {
-        "drupal": {
-          "type": "object",
-          "properties": {
-            "create": {
-              "type": "string",
-              "title": "Specifies whether a service account should be created",
-              "form": true
-            },
-            "name": {
-              "type": "string",
-              "title": "The name of the service account to use",
-              "form": true
-            },
-            "annotations": {
-              "type": "string",
-              "title": "Add annotations",
-              "form": true
-            },
-            "automountServiceAccountToken": {
-              "type": "string",
-              "title": "Automount API credentials for a service account",
-              "form": true
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Drupal pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
-          }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a service account should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Add annotations",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account.",
+                    "default": true
+                }
+            }
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "sessionAffinity": {
+            "type": "string",
+            "description": "Control where client requests go, to the same pod or round-robin. Values: ClientIP or None",
+            "default": "None"
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Drupal volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Drupal volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Drupal volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume Claim",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "If defined, the drupal-data volume will mount to the specified hostPath.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for Matomo containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for Matomo containers",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Drupal pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Drupal pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Drupal containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Drupal containers' Security Context",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Controller container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/user/login"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/user/login"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/user/login"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)",
+                    "default": [],
+                    "items": {}
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the Drupal Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "%%MAIN_CONTAINER_NAME%% service Cluster IP",
+                    "default": ""
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for %%MAIN_CONTAINER_NAME%% service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "drupal.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Drupal. You may need to set this to '/*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_drupal"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_drupal"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Database Persistent Volume Access Modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_drupal"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username. Ignored if existing secret is provided",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_drupal"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a secret with the database password. (externalDatabase.password will be ignored and picked up from this secret). The secret has to contain the key db-password",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a exporter side-car",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag",
+                            "default": "1.0.1-debian-11-r38"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Drupal exporter service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Drupal exporter service port",
+                                    "default": 9117
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Drupal exporter service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Drupal exporter service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Drupal exporter service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Drupal exporter service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the ServiceMonitor will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "The interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "The timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabellings": {
+                            "type": "array",
+                            "description": "Metrics RelabelConfigs to apply to samples before scraping.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metrics RelabelConfigs to apply to samples before ingestion.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor resource(s) can be discovered by Prometheus",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a custom prometheusRule Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the prometheusRule will be created",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels for the prometheusRule",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom Prometheus rules",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": "secret-name"
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": "secret-key"
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables (eg proxy)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by drupal's pods.",
+                            "default": false
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes drupal only accessible from a particular origin",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/ejbca/values.schema.json
+++ b/bitnami/ejbca/values.schema.json
@@ -1,0 +1,917 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override ebjca.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override ebjca.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to be added to all deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "EJBCA image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "EJBCA image name",
+                    "default": "bitnami/ejbca"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "EJBCA image tag",
+                    "default": "8.0.20230531-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "EJBCA image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "EJBCA image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of EJBCA replicas to deploy",
+            "default": 1
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Additional volume mounts (used along with `extraVolumes`)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional pod labels",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable security context for EJBCA container",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the volumes of the pod",
+                    "default": 1001
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "EJBCA deployment strategy type.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable persistence based on Persistent Volume Claims",
+                    "default": true
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of the PVC to request",
+                    "default": "2Gi"
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Name of an existing PVC to reuse",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional sidecar containers to the pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Additional init containers to add to the pods",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "EJBCA pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "ejbcaAdminUsername": {
+            "type": "string",
+            "description": "EJBCA administrator username",
+            "default": "bitnami"
+        },
+        "ejbcaAdminPassword": {
+            "type": "string",
+            "description": "Password for the administrator account",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Alternatively, you can provide the name of an existing secret containing",
+            "default": ""
+        },
+        "ejbcaJavaOpts": {
+            "type": "string",
+            "description": "Options used to launch the WildFly server",
+            "default": ""
+        },
+        "ejbcaCA": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the CA EJBCA will instantiate by default",
+                    "default": "ManagementCA"
+                },
+                "baseDN": {
+                    "type": "string",
+                    "description": "Base DomainName of the CA EJBCA will instantiate by default",
+                    "default": ""
+                }
+            }
+        },
+        "ejbcaKeystoreExistingSecret": {
+            "type": "string",
+            "description": "Name of an existing Secret containing a Keystore object",
+            "default": ""
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to EJBCA nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for EJBCA nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for EJBCA nodes",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Custom command to override image cmd",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Custom args for the custom command",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the EJBCA container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for Ejbca containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for Ejbca containers",
+                    "default": {}
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled EJBCA containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set EJBCA containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set EJBCA container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before startup probe is initiated",
+                    "default": 500
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before liveness probe is initiated",
+                    "default": 500
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before readiness probe is initiated",
+                    "default": 500
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startup probe to execute (when the main one is disabled)",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe to execute (when the main one is disabled)",
+            "default": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readiness probe to execute (when the main one is disabled)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 8443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "advertisedHttpsPort": {
+                    "type": "number",
+                    "description": "Port number used in the rendered URLs for the admistrator login.",
+                    "default": 443
+                },
+                "httpsTargetPort": {
+                    "type": "string",
+                    "description": "Service Target HTTPS port",
+                    "default": "https"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "EJBCA service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "EJBCA service Load Balancer IP",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Service annotations",
+                    "default": {}
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Limits which cidr blocks can connect to service's load balancer",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "ejbca.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to EJBCA. You may need to set this to '/*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements.",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_ejbca"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_ejbca"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessMode": {
+                                    "type": "string",
+                                    "description": "Persistent Volume access mode",
+                                    "default": "ReadWriteOnce"
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external database",
+                    "default": "localhost"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "non-root Username for EJBCA Database",
+                    "default": "bn_ejbca"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password in a 'mariadb-password' key",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_ejbca"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 3306
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by EJBCA's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes EJBCA only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access EJBCA. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access EJBCA. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/elasticsearch/values.schema.json
+++ b/bitnami/elasticsearch/values.schema.json
@@ -1,0 +1,3300 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "elasticsearch": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Elasticsearch service name to be used in the Kibana subchart (ignored if kibanaEnabled=false)",
+                                    "default": "elasticsearch"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "restAPI": {
+                                            "type": "number",
+                                            "description": "Elasticsearch service restAPI port to be used in the Kibana subchart (ignored if kibanaEnabled=false)",
+                                            "default": 9200
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "kibanaEnabled": {
+                    "type": "boolean",
+                    "description": "Whether or not to enable Kibana",
+                    "default": false
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "clusterName": {
+            "type": "string",
+            "description": "Elasticsearch cluster name",
+            "default": "elastic"
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "restAPI": {
+                    "type": "number",
+                    "description": "Elasticsearch REST API port",
+                    "default": 9200
+                },
+                "transport": {
+                    "type": "number",
+                    "description": "Elasticsearch Transport port",
+                    "default": 9300
+                }
+            }
+        },
+        "plugins": {
+            "type": "string",
+            "description": "Comma, semi-colon or space separated list of plugins to install at initialization",
+            "default": ""
+        },
+        "snapshotRepoPath": {
+            "type": "string",
+            "description": "File System snapshot repository path",
+            "default": ""
+        },
+        "config": {
+            "type": "object",
+            "description": "Override elasticsearch configuration",
+            "default": {}
+        },
+        "extraConfig": {
+            "type": "object",
+            "description": "Append extra configuration to the elasticsearch node configuration",
+            "default": {}
+        },
+        "extraHosts": {
+            "type": "array",
+            "description": "A list of external hosts which are part of this cluster",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "A list of volumes to be added to the pod",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "A list of volume mounts to be added to the pod",
+            "default": [],
+            "items": {}
+        },
+        "initScripts": {
+            "type": "object",
+            "description": "Dictionary of init scripts. Evaluated as a template.",
+            "default": {}
+        },
+        "initScriptsCM": {
+            "type": "string",
+            "description": "ConfigMap with the init scripts. Evaluated as a template.",
+            "default": ""
+        },
+        "initScriptsSecret": {
+            "type": "string",
+            "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+            "default": ""
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array containing extra env vars to be added to all pods (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars to be added to all pods (evaluated as a template)",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars to be added to all pods (evaluated as a template)",
+            "default": ""
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the all elasticsearch node pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the all elasticsearch node pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "useIstioLabels": {
+            "type": "boolean",
+            "description": "Use this variable to add Istio labels to all pods",
+            "default": true
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Elasticsearch image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Elasticsearch image repository",
+                    "default": "bitnami/elasticsearch"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Elasticsearch image tag (immutable tags are recommended)",
+                    "default": "8.9.1-debian-11-r2"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Elasticsearch image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Elasticsearch image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Elasticsearch image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Elasticsearch image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "security": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable X-Pack Security settings",
+                    "default": false
+                },
+                "elasticPassword": {
+                    "type": "string",
+                    "description": "Password for 'elastic' user",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing the Elasticsearch password and",
+                    "default": ""
+                },
+                "fipsMode": {
+                    "type": "boolean",
+                    "description": "Configure elasticsearch with FIPS 140 compliant mode",
+                    "default": false
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "restEncryption": {
+                            "type": "boolean",
+                            "description": "Enable SSL/TLS encryption for Elasticsearch REST API.",
+                            "default": true
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Create self-signed TLS certificates.",
+                            "default": false
+                        },
+                        "verificationMode": {
+                            "type": "string",
+                            "description": "Verification mode for SSL communications.",
+                            "default": "full"
+                        },
+                        "master": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the master nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the data nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "ingest": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the ingest nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "coordinating": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the coordinating nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "keystoreFilename": {
+                            "type": "string",
+                            "description": "Name of the keystore file",
+                            "default": "elasticsearch.keystore.jks"
+                        },
+                        "truststoreFilename": {
+                            "type": "string",
+                            "description": "Name of the truststore",
+                            "default": "elasticsearch.truststore.jks"
+                        },
+                        "usePemCerts": {
+                            "type": "boolean",
+                            "description": "Use this variable if your secrets contain PEM certificates instead of JKS/PKCS12",
+                            "default": false
+                        },
+                        "passwordsSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing the Keystore and Truststore passwords, or key password if PEM certs are used",
+                            "default": ""
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access the JKS/PKCS12 keystore or PEM key when they are password-protected.",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access the JKS/PKCS12 truststore when they are password-protected.",
+                            "default": ""
+                        },
+                        "keyPassword": {
+                            "type": "string",
+                            "description": "Password to access the PEM key when they are password-protected.",
+                            "default": ""
+                        },
+                        "secretKeystoreKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the Keystore password",
+                            "default": ""
+                        },
+                        "secretTruststoreKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the Truststore password",
+                            "default": ""
+                        },
+                        "secretKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the PEM key password",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Elasticsearch service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "restAPI": {
+                            "type": "number",
+                            "description": "Elasticsearch service REST API port",
+                            "default": 9200
+                        },
+                        "transport": {
+                            "type": "number",
+                            "description": "Elasticsearch service transport port",
+                            "default": 9300
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "restAPI": {
+                            "type": "string",
+                            "description": "Node port for REST API",
+                            "default": ""
+                        },
+                        "transport": {
+                            "type": "string",
+                            "description": "Node port for REST API",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Elasticsearch service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Elasticsearch service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Elasticsearch service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Elasticsearch service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Elasticsearch service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in Elasticsearch service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Elasticsearch",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "elasticsearch.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "master": {
+            "type": "object",
+            "properties": {
+                "masterOnly": {
+                    "type": "boolean",
+                    "description": "Deploy the Elasticsearch master-elegible nodes as master-only nodes. Recommended for high-demand deployments.",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of master-elegible replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override elasticsearch.master.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.master.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.master.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Master-elegible nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for elasticsearch containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for elasticsearch containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "Elasticsearch master-eligible node heap size.",
+                    "default": "128m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled master-elegible pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set master-elegible pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled master-elegible containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set master-elegible containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set master-elegible containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "master-elegible pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for master-elegible pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for master-elegible pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `master.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `master.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for master-elegible pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for master-elegible pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for master-elegible pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "master-elegible pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for master-elegible pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Elasticsearch Master pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Elasticsearch master pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (master nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (master nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (master nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (master nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (master nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (master-eligible nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (master-eligible nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (master-eligible nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (master-eligible nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (master-eligible nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (master-eligible nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (master-eligible nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (master-eligible nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (master-eligible nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (master-eligible nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the master-elegible container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to master-elegible nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for master-elegible nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for master-elegible nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the master-elegible pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the master-elegible container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the master-elegible pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the master-elegible pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using a `PersistentVolumeClaim`",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume Storage Class",
+                            "default": ""
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume Claim",
+                            "default": ""
+                        },
+                        "existingVolume": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume for use as volume match label selector to the `volumeClaimTemplate`. Ignored when `master.persistence.selector` is set.",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Configure custom selector for existing Persistent Volume. Overwrites `master.persistence.existingVolume`",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume Size",
+                            "default": "8Gi"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether enable horizontal pod autoscale",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Configure a minimum amount of pods",
+                            "default": 3
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Configure a maximum amount of pods",
+                            "default": 11
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Define the CPU target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Define the memory target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of data-only replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override elasticsearch.data.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.data.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.data.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Data-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the data containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "2048Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "Elasticsearch data node heap size.",
+                    "default": "1024m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled data pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set data pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled data containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set data containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set data containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "data pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for data pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for data pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `data.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `data.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `data.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `data.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `data.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for data pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for data pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for data pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "data pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for data pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Elasticsearch data pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Elasticsearch data pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (data nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (data nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (data nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (data nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (data nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (data nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the data container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to data nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for data nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for data nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the data container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using a `PersistentVolumeClaim`",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume Storage Class",
+                            "default": ""
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume Claim",
+                            "default": ""
+                        },
+                        "existingVolume": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume for use as volume match label selector to the `volumeClaimTemplate`. Ignored when `data.persistence.selector` is set.",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Configure custom selector for existing Persistent Volume. Overwrites `data.persistence.existingVolume`",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume Size",
+                            "default": "8Gi"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether enable horizontal pod autoscale",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Configure a minimum amount of pods",
+                            "default": 3
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Configure a maximum amount of pods",
+                            "default": 11
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Define the CPU target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Define the memory target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "coordinating": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of coordinating-only replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override elasticsearch.coordinating.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.coordinating.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.coordinating.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Coordinating-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the coordinating-only containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "256Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "Elasticsearch coordinating node heap size.",
+                    "default": "128m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled coordinating-only pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set coordinating-only pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled coordinating-only containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set coordinating-only containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set coordinating-only containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "coordinating-only pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for coordinating-only pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for coordinating-only pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `coordinating.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `coordinating.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `coordinating.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `coordinating.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `coordinating.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for coordinating-only pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for coordinating-only pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for coordinating-only pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "coordinating-only pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for coordinating-only pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Elasticsearch coordinating pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Elasticsearch coordinating pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (coordinating-only nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (coordinating-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (coordinating-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (coordinating-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (coordinating-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (coordinating-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (coordinating-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (coordinating-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (coordinating-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (coordinating-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (coordinating-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (coordinating-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (coordinating-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (coordinating-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (coordinating-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the coordinating-only container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to coordinating-only nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for coordinating-only nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for coordinating-only nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the coordinating-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the coordinating-only container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the coordinating-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the coordinating-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether enable horizontal pod autoscale",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Configure a minimum amount of pods",
+                            "default": 3
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Configure a maximum amount of pods",
+                            "default": 11
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Define the CPU target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Define the memory target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "ingest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingest nodes",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of ingest-only replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override elasticsearch.ingest.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override elasticsearch.ingest.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override ingest.master.servicename",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "restAPI": {
+                            "type": "number",
+                            "description": "Elasticsearch REST API port",
+                            "default": 9200
+                        },
+                        "transport": {
+                            "type": "number",
+                            "description": "Elasticsearch Transport port",
+                            "default": 9300
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingest-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "256Mi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the ingest-only containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "Elasticsearch ingest-only node heap size.",
+                    "default": "128m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled ingest-only pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set ingest-only pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled ingest-only containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set ingest-only containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set ingest-only containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingest-only pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingest-only pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingest-only pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ingest.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ingest.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ingest.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ingest.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ingest.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for ingest-only pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for ingest-only pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for ingest-only pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "ingest-only pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for ingest-only pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Elasticsearch ingest pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Elasticsearch ingest pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (ingest-only nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (ingest-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (ingest-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (ingest-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (ingest-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (ingest-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (ingest-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (ingest-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (ingest-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (ingest-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (ingest-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (ingest-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (ingest-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (ingest-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (ingest-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingest-only container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingest-only nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingest-only nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingest-only nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the ingest-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the ingest-only container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the ingest-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the ingest-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether enable horizontal pod autoscale",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Configure a minimum amount of pods",
+                            "default": 3
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Configure a maximum amount of pods",
+                            "default": 11
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Define the CPU target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Define the memory target to trigger the scaling actions (utilization percentage)",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Ingest-only service",
+                            "default": false
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Elasticsearch ingest-only service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "restAPI": {
+                                    "type": "number",
+                                    "description": "Elasticsearch service REST API port",
+                                    "default": 9200
+                                },
+                                "transport": {
+                                    "type": "number",
+                                    "description": "Elasticsearch service transport port",
+                                    "default": 9300
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "restAPI": {
+                                    "type": "string",
+                                    "description": "Node port for REST API",
+                                    "default": ""
+                                },
+                                "transport": {
+                                    "type": "string",
+                                    "description": "Node port for REST API",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Elasticsearch ingest-only service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Elasticsearch ingest-only service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Elasticsearch ingest-only service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Elasticsearch ingest-only service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Elasticsearch ingest-only service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Elasticsearch",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "elasticsearch-ingest.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable prometheus exporter",
+                    "default": false
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "Metrics pod name",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override common.names.fullname",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Metrics exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Metrics exporter image repository",
+                            "default": "bitnami/elasticsearch-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Metrics exporter image tag",
+                            "default": "1.6.0-debian-11-r48"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Metrics exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Metrics exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Metrics exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "helm": {
+                            "type": "object",
+                            "properties": {
+                                "sh/hook": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "post-install,post-upgrade"
+                                },
+                                "sh/hook-weight": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "5"
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments to add to the default exporter command",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "9114"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Metrics exporter endpoint service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Metrics exporter endpoint service port",
+                            "default": 9114
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Elasticsearch metrics exporter pods' priorityClassName",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Metrics Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Metrics Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Metrics Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Metrics Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Metrics Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Metrics Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Metrics Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Metrics Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (metrics pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (metrics pod)",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (metrics pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (metrics pod)",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (metrics pod)",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (metrics pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (metrics pod)",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (metrics pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (metrics pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (metrics pod)",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (metrics pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (metrics pod)",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (metrics pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (metrics pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (metrics pod)",
+                            "default": 1
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9114"
+                                }
+                            }
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels to add to Pod",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Elasticsearch metrics exporter pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Elasticsearch metrics exporter pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Elasticsearch metrics exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Elasticsearch metrics exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Elasticsearch metrics exporter container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Elasticsearch metrics exporter nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Elasticsearch metrics exporter nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Elasticsearch metrics exporter nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Elasticsearch metrics exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Elasticsearch metrics exporter container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Elasticsearch metrics exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Elasticsearch metrics exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "sysctlImage": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable kernel settings modifier image",
+                    "default": true
+                },
+                "registry": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image repository",
+                    "default": "bitnami/os-shell"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image tag",
+                    "default": "11-debian-11-r40"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Kernel settings modifier image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "kibana": {
+            "type": "object",
+            "properties": {
+                "elasticsearch": {
+                    "type": "object",
+                    "properties": {
+                        "hosts": {
+                            "type": "array",
+                            "description": "Array containing hostnames for the ES instances. Used to generate the URL",
+                            "default": [
+                                "{{ include \"elasticsearch.service.name\" . }}"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port to connect Kibana and ES instance. Used to generate the URL",
+                            "default": "{{ include \"elasticsearch.service.ports.restAPI\" . }}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/etcd/values.schema.json
+++ b/bitnami/etcd/values.schema.json
@@ -1,0 +1,1115 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "etcd image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "etcd image name",
+                    "default": "bitnami/etcd"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "etcd image tag",
+                    "default": "3.5.9-debian-11-r118"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "etcd image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "etcd image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Switch to enable RBAC authentication",
+                            "default": true
+                        },
+                        "allowNoneAuthentication": {
+                            "type": "boolean",
+                            "description": "Allow to use etcd without configuring RBAC authentication",
+                            "default": true
+                        },
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Root user password. The root user is always `root`",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing credentials for the root user",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key containing password to be retrieved from the existing secret",
+                            "default": ""
+                        }
+                    }
+                },
+                "token": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enables token authentication",
+                            "default": true
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Authentication token type. Allowed values: 'simple' or 'jwt'",
+                            "default": "jwt"
+                        },
+                        "privateKey": {
+                            "type": "object",
+                            "properties": {
+                                "filename": {
+                                    "type": "string",
+                                    "description": "Name of the file containing the private key for signing the JWT token",
+                                    "default": "jwt-token.pem"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of the existing secret containing the private key for signing the JWT token",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "signMethod": {
+                            "type": "string",
+                            "description": "JWT token sign method",
+                            "default": "RS256"
+                        },
+                        "ttl": {
+                            "type": "string",
+                            "description": "JWT token TTL",
+                            "default": "10m"
+                        }
+                    }
+                },
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "secureTransport": {
+                            "type": "boolean",
+                            "description": "Switch to encrypt client-to-server communications using TLS certificates",
+                            "default": false
+                        },
+                        "useAutoTLS": {
+                            "type": "boolean",
+                            "description": "Switch to automatically create the TLS certificates",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for client-to-server communications",
+                            "default": ""
+                        },
+                        "enableAuthentication": {
+                            "type": "boolean",
+                            "description": "Switch to enable host authentication using TLS certificates. Requires existing secret",
+                            "default": false
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "Name of the file containing the client certificate",
+                            "default": "cert.pem"
+                        },
+                        "certKeyFilename": {
+                            "type": "string",
+                            "description": "Name of the file containing the client certificate private key",
+                            "default": "key.pem"
+                        },
+                        "caFilename": {
+                            "type": "string",
+                            "description": "Name of the file containing the client CA certificate",
+                            "default": ""
+                        }
+                    }
+                },
+                "peer": {
+                    "type": "object",
+                    "properties": {
+                        "secureTransport": {
+                            "type": "boolean",
+                            "description": "Switch to encrypt server-to-server communications using TLS certificates",
+                            "default": false
+                        },
+                        "useAutoTLS": {
+                            "type": "boolean",
+                            "description": "Switch to automatically create the TLS certificates",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for server-to-server communications",
+                            "default": ""
+                        },
+                        "enableAuthentication": {
+                            "type": "boolean",
+                            "description": "Switch to enable host authentication using TLS certificates. Requires existing secret",
+                            "default": false
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "Name of the file containing the peer certificate",
+                            "default": "cert.pem"
+                        },
+                        "certKeyFilename": {
+                            "type": "string",
+                            "description": "Name of the file containing the peer certificate private key",
+                            "default": "key.pem"
+                        },
+                        "caFilename": {
+                            "type": "string",
+                            "description": "Name of the file containing the peer CA certificate",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "autoCompactionMode": {
+            "type": "string",
+            "description": "Auto compaction mode, by default periodic. Valid values: \"periodic\", \"revision\".",
+            "default": ""
+        },
+        "autoCompactionRetention": {
+            "type": "string",
+            "description": "Auto compaction retention for mvcc key value store in hour, by default 0, means disabled",
+            "default": ""
+        },
+        "initialClusterState": {
+            "type": "string",
+            "description": "Initial cluster state. Allowed values: 'new' or 'existing'",
+            "default": ""
+        },
+        "initialClusterToken": {
+            "type": "string",
+            "description": "Initial cluster token. Can be used to protect etcd from cross-cluster-interaction, which might corrupt the clusters.",
+            "default": "etcd-cluster-k8s"
+        },
+        "logLevel": {
+            "type": "string",
+            "description": "Sets the log level for the etcd process. Allowed values: 'debug', 'info', 'warn', 'error', 'panic', 'fatal'",
+            "default": "info"
+        },
+        "maxProcs": {
+            "type": "string",
+            "description": "Limits the number of operating system threads that can execute user-level",
+            "default": ""
+        },
+        "removeMemberOnContainerTermination": {
+            "type": "boolean",
+            "description": "Use a PreStop hook to remove the etcd members from the etcd cluster on container termination",
+            "default": true
+        },
+        "configuration": {
+            "type": "string",
+            "description": "etcd configuration. Specify content for etcd.conf.yml",
+            "default": ""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "Existing ConfigMap with etcd configuration",
+            "default": ""
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on etcd container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of etcd replicas to deploy",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy type, can be set to RollingUpdate or OnDelete.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Pod management policy for the etcd statefulset",
+            "default": "Parallel"
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "etcd pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "client": {
+                    "type": "number",
+                    "description": "Client port to expose at container level",
+                    "default": 2379
+                },
+                "peer": {
+                    "type": "number",
+                    "description": "Peer port to expose at container level",
+                    "default": 2380
+                },
+                "metrics": {
+                    "type": "number",
+                    "description": "Metrics port to expose at container level when metrics.useSeparateEndpoint is true",
+                    "default": 9090
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled etcd pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set etcd pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled etcd containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set etcd container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set etcd container's Security Context runAsNonRoot",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Force the child process to be run as nonprivilege",
+                    "default": false
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 30
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for etcd pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for etcd container(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeClaimTemplates": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeClaimTemplates for etcd container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the etcd pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the etcd pods",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds the pod needs to gracefully terminate",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of the priority class to be used by etcd pods",
+            "default": ""
+        },
+        "runtimeClassName": {
+            "type": "string",
+            "description": "Name of the runtime class to be used by pod(s)",
+            "default": ""
+        },
+        "shareProcessNamespace": {
+            "type": "boolean",
+            "description": "Enable shared process namespace in a pod.",
+            "default": false
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "persistentVolumeClaimRetentionPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Controls if and how PVCs are deleted during the lifecycle of a StatefulSet",
+                    "default": false
+                },
+                "whenScaled": {
+                    "type": "string",
+                    "description": "Volume retention behavior when the replica count of the StatefulSet is reduced",
+                    "default": "Retain"
+                },
+                "whenDeleted": {
+                    "type": "string",
+                    "description": "Volume retention behavior that applies when the StatefulSet is deleted",
+                    "default": "Retain"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "create second service if equal true",
+                    "default": true
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Kubernetes service Cluster IP",
+                    "default": ""
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "number",
+                            "description": "etcd client port",
+                            "default": 2379
+                        },
+                        "peer": {
+                            "type": "number",
+                            "description": "etcd peer port",
+                            "default": 2380
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "etcd metrics port when metrics.useSeparateEndpoint is true",
+                            "default": 9090
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "string",
+                            "description": "Specify the nodePort client value for the LoadBalancer and NodePort service types.",
+                            "default": ""
+                        },
+                        "peer": {
+                            "type": "string",
+                            "description": "Specify the nodePort peer value for the LoadBalancer and NodePort service types.",
+                            "default": ""
+                        },
+                        "metrics": {
+                            "type": "string",
+                            "description": "Specify the nodePort metrics value for the LoadBalancer and NodePort service types. The metrics port is only exposed when metrics.useSeparateEndpoint is true.",
+                            "default": ""
+                        }
+                    }
+                },
+                "clientPortNameOverride": {
+                    "type": "string",
+                    "description": "etcd client port name override",
+                    "default": ""
+                },
+                "peerPortNameOverride": {
+                    "type": "string",
+                    "description": "etcd peer port name override",
+                    "default": ""
+                },
+                "metricsPortNameOverride": {
+                    "type": "string",
+                    "description": "etcd metrics port name override. The metrics port is only exposed when metrics.useSeparateEndpoint is true.",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the etcd service (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Load Balancer source ranges",
+                    "default": [],
+                    "items": {}
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "External IPs",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "%%MAIN_CONTAINER_NAME%% service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "If true, use a Persistent Volume Claim. If false, use emptyDir.",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for etcd data volume",
+                    "default": "8Gi"
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "extraIngress": {
+                    "type": "array",
+                    "description": "Add extra ingress rules to the NetworkPolicy",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEgress": {
+                    "type": "array",
+                    "description": "Add extra ingress rules to the NetworkPolicy",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Expose etcd metrics",
+                    "default": false
+                },
+                "useSeparateEndpoint": {
+                    "type": "boolean",
+                    "description": "Use a separate endpoint for exposing metrics",
+                    "default": false
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.metrics.useSeparateEndpoint | ternary .Values.containerPorts.metrics .Values.containerPorts.client }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create PodMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": "monitoring"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": "30s"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "Scheme to use for scraping",
+                            "default": "http"
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Prometheus relabeling rules",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "startFromSnapshot": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Initialize new cluster recovering an existing snapshot",
+                    "default": false
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Existing PVC containing the etcd snapshot",
+                    "default": ""
+                },
+                "snapshotFilename": {
+                    "type": "string",
+                    "description": "Snapshot filename",
+                    "default": ""
+                }
+            }
+        },
+        "disasterRecovery": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable auto disaster recovery by periodically snapshotting the keyspace",
+                    "default": false
+                },
+                "cronjob": {
+                    "type": "object",
+                    "properties": {
+                        "schedule": {
+                            "type": "string",
+                            "description": "Schedule in Cron format to save snapshots",
+                            "default": "*/30 * * * *"
+                        },
+                        "historyLimit": {
+                            "type": "number",
+                            "description": "Number of successful finished jobs to retain",
+                            "default": 1
+                        },
+                        "snapshotHistoryLimit": {
+                            "type": "number",
+                            "description": "Number of etcd snapshots to retain, tagged by date",
+                            "default": 1
+                        },
+                        "snapshotsDir": {
+                            "type": "string",
+                            "description": "Directory to store snapshots",
+                            "default": "/snapshots"
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "description": "Node labels for cronjob pods assignment",
+                            "default": {}
+                        },
+                        "tolerations": {
+                            "type": "array",
+                            "description": "Tolerations for cronjob pods assignment",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pvc": {
+                    "type": "object",
+                    "properties": {
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "A manually managed Persistent Volume and Claim",
+                            "default": ""
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request",
+                            "default": "2Gi"
+                        },
+                        "storageClassName": {
+                            "type": "string",
+                            "description": "Storage Class for snapshots volume",
+                            "default": "nfs"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "Path within the volume from which to mount",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable service account creation",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to create or use",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of service account token",
+                    "default": true
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": true
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": "51%"
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/external-dns/values.schema.json
+++ b/bitnami/external-dns/values.schema.json
@@ -1,0 +1,1660 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override external-dns.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override external-dns.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "watchReleaseNamespace": {
+            "type": "boolean",
+            "description": "Watch only namepsace used for the release",
+            "default": false
+        },
+        "useDaemonset": {
+            "type": "boolean",
+            "description": "Use ExternalDNS in Daemonset mode",
+            "default": false
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "ExternalDNS image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "ExternalDNS image repository",
+                    "default": "bitnami/external-dns"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "ExternalDNS Image tag (immutable tags are recommended)",
+                    "default": "0.13.6-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "ExternalDNS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "ExternalDNS image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "ExternalDNS image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "description": "update strategy type",
+            "default": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override kiam default command",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override kiam default args",
+            "default": [],
+            "items": {}
+        },
+        "sources": {
+            "type": "array",
+            "description": "K8s resources type to be observed for new DNS entries by ExternalDNS",
+            "default": [
+                "service",
+                "ingress"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "provider": {
+            "type": "string",
+            "description": "DNS provider where the DNS records will be created.",
+            "default": "aws"
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Attach additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "namespace": {
+            "type": "string",
+            "description": "Limit sources of endpoints to a specific namespace (default: all namespaces)",
+            "default": ""
+        },
+        "fqdnTemplates": {
+            "type": "array",
+            "description": "Templated strings that are used to generate DNS names from sources that don't define a hostname themselves",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "HTTP Container port",
+                    "default": 7979
+                }
+            }
+        },
+        "combineFQDNAnnotation": {
+            "type": "boolean",
+            "description": "Combine FQDN template and annotations instead of overwriting",
+            "default": false
+        },
+        "ignoreHostnameAnnotation": {
+            "type": "boolean",
+            "description": "Ignore hostname annotation when generating DNS names, valid only when fqdn-template is set",
+            "default": false
+        },
+        "publishInternalServices": {
+            "type": "boolean",
+            "description": "Allow external-dns to publish DNS records for ClusterIP services",
+            "default": false
+        },
+        "publishHostIP": {
+            "type": "boolean",
+            "description": "Allow external-dns to publish host-ip for headless services",
+            "default": false
+        },
+        "serviceTypeFilter": {
+            "type": "array",
+            "description": "The service types to take care about (default: all, options: ClusterIP, NodePort, LoadBalancer, ExternalName)",
+            "default": [],
+            "items": {}
+        },
+        "akamai": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Hostname to use for EdgeGrid auth",
+                    "default": ""
+                },
+                "accessToken": {
+                    "type": "string",
+                    "description": "Access Token to use for EdgeGrid auth",
+                    "default": ""
+                },
+                "clientToken": {
+                    "type": "string",
+                    "description": "Client Token to use for EdgeGrid auth",
+                    "default": ""
+                },
+                "clientSecret": {
+                    "type": "string",
+                    "description": "When using the Akamai provider, `AKAMAI_CLIENT_SECRET` to set (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Use an existing secret with key \"akamai_api_seret\" defined.",
+                    "default": ""
+                }
+            }
+        },
+        "alibabacloud": {
+            "type": "object",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string",
+                    "description": "When using the Alibaba Cloud provider, set `accessKeyId` in the Alibaba Cloud configuration file (optional)",
+                    "default": ""
+                },
+                "accessKeySecret": {
+                    "type": "string",
+                    "description": "When using the Alibaba Cloud provider, set `accessKeySecret` in the Alibaba Cloud configuration file (optional)",
+                    "default": ""
+                },
+                "regionId": {
+                    "type": "string",
+                    "description": "When using the Alibaba Cloud provider, set `regionId` in the Alibaba Cloud configuration file (optional)",
+                    "default": ""
+                },
+                "vpcId": {
+                    "type": "string",
+                    "description": "Alibaba Cloud VPC Id",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Use an existing secret with key \"alibaba-cloud.json\" defined.",
+                    "default": ""
+                },
+                "zoneType": {
+                    "type": "string",
+                    "description": "Zone Filter. Available values are: public, private, or no value for both",
+                    "default": ""
+                }
+            }
+        },
+        "aws": {
+            "type": "object",
+            "properties": {
+                "credentials": {
+                    "type": "object",
+                    "properties": {
+                        "secretKey": {
+                            "type": "string",
+                            "description": "When using the AWS provider, set `aws_secret_access_key` in the AWS credentials (optional)",
+                            "default": ""
+                        },
+                        "accessKey": {
+                            "type": "string",
+                            "description": "When using the AWS provider, set `aws_access_key_id` in the AWS credentials (optional)",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "When using the AWS provider, determine `mountPath` for `credentials` secret",
+                            "default": "/.aws"
+                        },
+                        "secretName": {
+                            "type": "string",
+                            "description": "Use an existing secret with key \"credentials\" defined.",
+                            "default": ""
+                        },
+                        "accessKeyIDSecretRef": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Define the name of the secret that stores aws_access_key_id.",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Define the key of the secret that stores aws_access_key_id.",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "secretAccessKeySecretRef": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Define the name of the secret that stores aws_secret_access_key",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Define the key of the secret that stores aws_secret_access_key",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "region": {
+                    "type": "string",
+                    "description": "When using the AWS provider, `AWS_DEFAULT_REGION` to set in the environment (optional)",
+                    "default": "us-east-1"
+                },
+                "zoneType": {
+                    "type": "string",
+                    "description": "When using the AWS provider, filter for zones of this type (optional, options: public, private)",
+                    "default": ""
+                },
+                "assumeRoleArn": {
+                    "type": "string",
+                    "description": "When using the AWS provider, assume role by specifying --aws-assume-role to the external-dns daemon",
+                    "default": ""
+                },
+                "roleArn": {
+                    "type": "string",
+                    "description": "Specify role ARN to the external-dns daemon",
+                    "default": ""
+                },
+                "apiRetries": {
+                    "type": "number",
+                    "description": "Maximum number of retries for AWS API calls before giving up",
+                    "default": 3
+                },
+                "batchChangeSize": {
+                    "type": "number",
+                    "description": "When using the AWS provider, set the maximum number of changes that will be applied in each batch",
+                    "default": 1000
+                },
+                "zonesCacheDuration": {
+                    "type": "number",
+                    "description": "If the list of Route53 zones managed by ExternalDNS doesn't change frequently, cache it by setting a TTL",
+                    "default": 0
+                },
+                "zoneTags": {
+                    "type": "array",
+                    "description": "When using the AWS provider, filter for zones with these tags",
+                    "default": [],
+                    "items": {}
+                },
+                "preferCNAME": {
+                    "type": "string",
+                    "description": "When using the AWS provider, replaces Alias records with CNAME (options: true, false)",
+                    "default": ""
+                },
+                "evaluateTargetHealth": {
+                    "type": "string",
+                    "description": "When using the AWS provider, sets the evaluate target health flag (options: true, false)",
+                    "default": ""
+                }
+            }
+        },
+        "azure": {
+            "type": "object",
+            "properties": {
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the secret containing the `azure.json` file",
+                    "default": ""
+                },
+                "cloud": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the Azure Cloud",
+                    "default": ""
+                },
+                "resourceGroup": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the Azure Resource Group",
+                    "default": ""
+                },
+                "tenantId": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the Azure Tenant ID",
+                    "default": ""
+                },
+                "subscriptionId": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the Azure Subscription ID",
+                    "default": ""
+                },
+                "aadClientId": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the Azure AAD Client ID",
+                    "default": ""
+                },
+                "aadClientSecret": {
+                    "type": "string",
+                    "description": "When using the Azure provider, set the Azure AAD Client Secret",
+                    "default": ""
+                },
+                "useWorkloadIdentityExtension": {
+                    "type": "boolean",
+                    "description": "When using the Azure provider, set if you use Workload Identity extension.",
+                    "default": false
+                },
+                "useManagedIdentityExtension": {
+                    "type": "boolean",
+                    "description": "When using the Azure provider, set if you use Azure MSI",
+                    "default": false
+                },
+                "userAssignedIdentityID": {
+                    "type": "string",
+                    "description": "When using the Azure provider with Azure MSI, set Client ID of Azure user-assigned managed identity (optional, otherwise system-assigned managed identity is used)",
+                    "default": ""
+                }
+            }
+        },
+        "cloudflare": {
+            "type": "object",
+            "properties": {
+                "apiToken": {
+                    "type": "string",
+                    "description": "When using the Cloudflare provider, `CF_API_TOKEN` to set (optional)",
+                    "default": ""
+                },
+                "apiKey": {
+                    "type": "string",
+                    "description": "When using the Cloudflare provider, `CF_API_KEY` to set (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the Cloudflare provider, it's the name of the secret containing cloudflare_api_token or cloudflare_api_key.",
+                    "default": ""
+                },
+                "email": {
+                    "type": "string",
+                    "description": "When using the Cloudflare provider, `CF_API_EMAIL` to set (optional). Needed when using CF_API_KEY",
+                    "default": ""
+                },
+                "proxied": {
+                    "type": "boolean",
+                    "description": "When using the Cloudflare provider, enable the proxy feature (DDOS protection, CDN...) (optional)",
+                    "default": true
+                }
+            }
+        },
+        "coredns": {
+            "type": "object",
+            "properties": {
+                "etcdEndpoints": {
+                    "type": "string",
+                    "description": "When using the CoreDNS provider, set etcd backend endpoints (comma-separated list)",
+                    "default": "http://etcd-extdns:2379"
+                },
+                "etcdTLS": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "When using the CoreDNS provider, enable secure communication with etcd",
+                            "default": false
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Generate automatically self-signed TLS certificates",
+                            "default": false
+                        },
+                        "secretName": {
+                            "type": "string",
+                            "description": "When using the CoreDNS provider, specify a name of existing Secret with etcd certs and keys",
+                            "default": "etcd-client-certs"
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "When using the CoreDNS provider, set destination dir to mount data from `coredns.etcdTLS.secretName` to",
+                            "default": "/etc/coredns/tls/etcd"
+                        },
+                        "caFilename": {
+                            "type": "string",
+                            "description": "When using the CoreDNS provider, specify CA PEM file name from the `coredns.etcdTLS.secretName`",
+                            "default": "ca.crt"
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "When using the CoreDNS provider, specify cert PEM file name from the `coredns.etcdTLS.secretName`",
+                            "default": "cert.pem"
+                        },
+                        "keyFilename": {
+                            "type": "string",
+                            "description": "When using the CoreDNS provider, specify private key PEM file name from the `coredns.etcdTLS.secretName`",
+                            "default": "key.pem"
+                        }
+                    }
+                }
+            }
+        },
+        "designate": {
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack authentication username. (optional)",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack authentication password. (optional)",
+                    "default": ""
+                },
+                "applicationCredentialId": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack authentication application credential ID. This conflicts with `designate.username`. (optional)",
+                    "default": ""
+                },
+                "applicationCredentialSecret": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack authentication application credential ID. This conflicts with `designate.password`. (optional)",
+                    "default": ""
+                },
+                "authUrl": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack authentication Url. (optional)",
+                    "default": ""
+                },
+                "regionName": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack region name. (optional)",
+                    "default": ""
+                },
+                "userDomainName": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack user domain name. (optional)",
+                    "default": ""
+                },
+                "projectName": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack project name. (optional)",
+                    "default": ""
+                },
+                "authType": {
+                    "type": "string",
+                    "description": "When using the Designate provider, specify the OpenStack auth type. (optional)",
+                    "default": ""
+                },
+                "customCAHostPath": {
+                    "type": "string",
+                    "description": "When using the Designate provider, use a CA file already on the host to validate Openstack APIs.  This conflicts with `designate.customCA.enabled`",
+                    "default": ""
+                },
+                "customCA": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "When using the Designate provider, enable a custom CA (optional)",
+                            "default": false
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "When using the Designate provider, set the content of the custom CA",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "When using the Designate provider, set the mountPath in which to mount the custom CA configuration",
+                            "default": "/config/designate"
+                        },
+                        "filename": {
+                            "type": "string",
+                            "description": "When using the Designate provider, set the custom CA configuration filename",
+                            "default": "designate-ca.pem"
+                        }
+                    }
+                }
+            }
+        },
+        "exoscale": {
+            "type": "object",
+            "properties": {
+                "apiKey": {
+                    "type": "string",
+                    "description": "When using the Exoscale provider, `EXTERNAL_DNS_EXOSCALE_APIKEY` to set (optional)",
+                    "default": ""
+                },
+                "apiToken": {
+                    "type": "string",
+                    "description": "When using the Exoscale provider, `EXTERNAL_DNS_EXOSCALE_APISECRET` to set (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Use an existing secret with keys \"exoscale_api_key\" and \"exoscale_api_token\" defined.",
+                    "default": ""
+                }
+            }
+        },
+        "digitalocean": {
+            "type": "object",
+            "properties": {
+                "apiToken": {
+                    "type": "string",
+                    "description": "When using the DigitalOcean provider, `DO_TOKEN` to set (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Use an existing secret with key \"digitalocean_api_token\" defined.",
+                    "default": ""
+                }
+            }
+        },
+        "google": {
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "description": "When using the Google provider, specify the Google project (required when provider=google)",
+                    "default": ""
+                },
+                "batchChangeSize": {
+                    "type": "number",
+                    "description": "When using the google provider, set the maximum number of changes that will be applied in each batch",
+                    "default": 1000
+                },
+                "serviceAccountSecret": {
+                    "type": "string",
+                    "description": "When using the Google provider, specify the existing secret which contains credentials.json (optional)",
+                    "default": ""
+                },
+                "serviceAccountSecretKey": {
+                    "type": "string",
+                    "description": "When using the Google provider with an existing secret, specify the key name (optional)",
+                    "default": "credentials.json"
+                },
+                "serviceAccountKey": {
+                    "type": "string",
+                    "description": "When using the Google provider, specify the service account key JSON file. In this case a new secret will be created holding this service account (optional)",
+                    "default": ""
+                },
+                "zoneVisibility": {
+                    "type": "string",
+                    "description": "When using the Google provider, fiter for zones of a specific visibility (private or public)",
+                    "default": ""
+                }
+            }
+        },
+        "hetzner": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "When using the Hetzner provider, specify your token here. (required when `hetzner.secretName` is not provided. In this case a new secret will be created holding the token.)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the Hetzner provider, specify the existing secret which contains your token. Disables the usage of `hetzner.token` (optional)",
+                    "default": ""
+                },
+                "secretKey": {
+                    "type": "string",
+                    "description": "When using the Hetzner provider with an existing secret, specify the key name (optional)",
+                    "default": "hetzner_token"
+                }
+            }
+        },
+        "infoblox": {
+            "type": "object",
+            "properties": {
+                "wapiUsername": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox WAPI username",
+                    "default": "admin"
+                },
+                "wapiPassword": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox WAPI password (required when provider=infoblox)",
+                    "default": ""
+                },
+                "gridHost": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox Grid host (required when provider=infoblox)",
+                    "default": ""
+                },
+                "view": {
+                    "type": "string",
+                    "description": "Infoblox view",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Existing secret name, when in place wapiUsername and wapiPassword are not required",
+                    "default": ""
+                },
+                "domainFilter": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the domain (optional)",
+                    "default": ""
+                },
+                "nameRegex": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the name regex filter (optional)",
+                    "default": ""
+                },
+                "noSslVerify": {
+                    "type": "boolean",
+                    "description": "When using the Infoblox provider, disable SSL verification (optional)",
+                    "default": false
+                },
+                "wapiPort": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox WAPI port (optional)",
+                    "default": ""
+                },
+                "wapiVersion": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox WAPI version (optional)",
+                    "default": ""
+                },
+                "wapiConnectionPoolSize": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox WAPI request connection pool size (optional)",
+                    "default": ""
+                },
+                "wapiHttpTimeout": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox WAPI request timeout in seconds (optional)",
+                    "default": ""
+                },
+                "maxResults": {
+                    "type": "string",
+                    "description": "When using the Infoblox provider, specify the Infoblox Max Results (optional)",
+                    "default": ""
+                }
+            }
+        },
+        "linode": {
+            "type": "object",
+            "properties": {
+                "apiToken": {
+                    "type": "string",
+                    "description": "When using the Linode provider, `LINODE_TOKEN` to set (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Use an existing secret with key \"linode_api_token\" defined.",
+                    "default": ""
+                }
+            }
+        },
+        "ns1": {
+            "type": "object",
+            "properties": {
+                "minTTL": {
+                    "type": "number",
+                    "description": "When using the ns1 provider, specify minimal TTL, as an integer, for records",
+                    "default": 10
+                },
+                "apiKey": {
+                    "type": "string",
+                    "description": "When using the ns1 provider, specify the API key to use",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Use an existing secret with key \"ns1-api-key\" defined.",
+                    "default": ""
+                }
+            }
+        },
+        "oci": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string",
+                    "description": "When using the OCI provider, specify the region, where your zone is located in.",
+                    "default": ""
+                },
+                "tenancyOCID": {
+                    "type": "string",
+                    "description": "When using the OCI provider, specify your Tenancy OCID",
+                    "default": ""
+                },
+                "userOCID": {
+                    "type": "string",
+                    "description": "When using the OCI provider, specify your User OCID",
+                    "default": ""
+                },
+                "compartmentOCID": {
+                    "type": "string",
+                    "description": "When using the OCI provider, specify your Compartment OCID where your DNS Zone is located in.",
+                    "default": ""
+                },
+                "privateKey": {
+                    "type": "string",
+                    "description": "When using the OCI provider, paste in your RSA private key file for the Oracle API",
+                    "default": "-----BEGIN RSA PRIVATE KEY-----\n-----END RSA PRIVATE KEY-----\n"
+                },
+                "privateKeyFingerprint": {
+                    "type": "string",
+                    "description": "When using the OCI provider, put in the fingerprint of your privateKey",
+                    "default": ""
+                },
+                "privateKeyPassphrase": {
+                    "type": "string",
+                    "description": "When using the OCI provider and your privateKey has a passphrase, put it in here. (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the OCI provider, it's the name of the secret containing `oci.yaml` file.",
+                    "default": ""
+                }
+            }
+        },
+        "ovh": {
+            "type": "object",
+            "properties": {
+                "consumerKey": {
+                    "type": "string",
+                    "description": "When using the OVH provider, specify the existing consumer key. (required when provider=ovh and `ovh.secretName` is not provided.)",
+                    "default": ""
+                },
+                "applicationKey": {
+                    "type": "string",
+                    "description": "When using the OVH provider with an existing application, specify the application key. (required when provider=ovh and `ovh.secretName` is not provided.)",
+                    "default": ""
+                },
+                "applicationSecret": {
+                    "type": "string",
+                    "description": "When using the OVH provider with an existing application, specify the application secret. (required when provider=ovh and `ovh.secretName` is not provided.)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the OVH provider, it's the name of the secret containing `ovh_consumer_key`, `ovh_application_key` and `ovh_application_secret`. Disables usage of other `ovh`.",
+                    "default": ""
+                }
+            }
+        },
+        "scaleway": {
+            "type": "object",
+            "properties": {
+                "scwAccessKey": {
+                    "type": "string",
+                    "description": "When using the Scaleway provider, specify an existing access key. (required when provider=scaleway)",
+                    "default": ""
+                },
+                "scwSecretKey": {
+                    "type": "string",
+                    "description": "When using the Scaleway provider, specify an existing secret key. (required when provider=scaleway)",
+                    "default": ""
+                }
+            }
+        },
+        "rfc2136": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify the RFC2136 host (required when provider=rfc2136)",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "When using the rfc2136 provider, specify the RFC2136 port (optional)",
+                    "default": 53
+                },
+                "zone": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify the zone (required when provider=rfc2136)",
+                    "default": ""
+                },
+                "tsigSecret": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify the tsig secret to enable security. (do not specify if `rfc2136.secretName` is provided.) (optional)",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify the existing secret which contains your tsig secret in the key \"rfc2136_tsig_secret\". Disables the usage of `rfc2136.tsigSecret` (optional)",
+                    "default": ""
+                },
+                "tsigSecretAlg": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify the tsig secret to enable security (optional)",
+                    "default": "hmac-sha256"
+                },
+                "tsigKeyname": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify the tsig keyname to enable security (optional)",
+                    "default": "rfc2136_tsig_secret"
+                },
+                "tsigAxfr": {
+                    "type": "boolean",
+                    "description": "When using the rfc2136 provider, enable AFXR to enable security (optional)",
+                    "default": true
+                },
+                "minTTL": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider, specify minimal TTL (in duration format) for records[ns, us, ms, s, m, h], see more <https://golang.org/pkg/time/#ParseDuration>",
+                    "default": "0s"
+                },
+                "rfc3645Enabled": {
+                    "type": "boolean",
+                    "description": "When using the rfc2136 provider, extend using RFC3645 to support secure updates over Kerberos with GSS-TSIG",
+                    "default": false
+                },
+                "kerberosConfig": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider with rfc3645Enabled, the contents of a configuration file for krb5 (optional)",
+                    "default": ""
+                },
+                "kerberosUsername": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider with rfc3645Enabled, specify the username to authenticate with (optional)",
+                    "default": ""
+                },
+                "kerberosPassword": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider with rfc3645Enabled, specify the password to authenticate with (optional)",
+                    "default": ""
+                },
+                "kerberosRealm": {
+                    "type": "string",
+                    "description": "When using the rfc2136 provider with rfc3645Enabled, specify the realm to authenticate to (required when provider=rfc2136 and rfc2136.rfc3645Enabled=true)",
+                    "default": ""
+                }
+            }
+        },
+        "pdns": {
+            "type": "object",
+            "properties": {
+                "apiUrl": {
+                    "type": "string",
+                    "description": "When using the PowerDNS provider, specify the API URL of the server.",
+                    "default": ""
+                },
+                "apiPort": {
+                    "type": "string",
+                    "description": "When using the PowerDNS provider, specify the API port of the server.",
+                    "default": "8081"
+                },
+                "apiKey": {
+                    "type": "string",
+                    "description": "When using the PowerDNS provider, specify the API key of the server.",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "When using the PowerDNS provider, specify as secret name containing the API Key",
+                    "default": ""
+                }
+            }
+        },
+        "transip": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "type": "string",
+                    "description": "When using the TransIP provider, specify the account name.",
+                    "default": ""
+                },
+                "apiKey": {
+                    "type": "string",
+                    "description": "When using the TransIP provider, specify the API key to use.",
+                    "default": ""
+                }
+            }
+        },
+        "vinyldns": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "When using the VinylDNS provider, specify the VinylDNS API host.",
+                    "default": ""
+                },
+                "accessKey": {
+                    "type": "string",
+                    "description": "When using the VinylDNS provider, specify the Access Key to use.",
+                    "default": ""
+                },
+                "secretKey": {
+                    "type": "string",
+                    "description": "When using the VinylDNS provider, specify the Secret key to use.",
+                    "default": ""
+                }
+            }
+        },
+        "domainFilters": {
+            "type": "array",
+            "description": "Limit possible target zones by domain suffixes (optional)",
+            "default": [],
+            "items": {}
+        },
+        "excludeDomains": {
+            "type": "array",
+            "description": "Exclude subdomains (optional)",
+            "default": [],
+            "items": {}
+        },
+        "regexDomainFilter": {
+            "type": "string",
+            "description": "Limit possible target zones by regex domain suffixes (optional)",
+            "default": ""
+        },
+        "regexDomainExclusion": {
+            "type": "string",
+            "description": "Exclude subdomains by using regex pattern (optional)",
+            "default": ""
+        },
+        "zoneNameFilters": {
+            "type": "array",
+            "description": "Filter target zones by zone domain (optional)",
+            "default": [],
+            "items": {}
+        },
+        "zoneIdFilters": {
+            "type": "array",
+            "description": "Limit possible target zones by zone id (optional)",
+            "default": [],
+            "items": {}
+        },
+        "annotationFilter": {
+            "type": "string",
+            "description": "Filter sources managed by external-dns via annotation using label selector (optional)",
+            "default": ""
+        },
+        "labelFilter": {
+            "type": "string",
+            "description": "Select sources managed by external-dns using label selector (optional)",
+            "default": ""
+        },
+        "ingressClassFilters": {
+            "type": "array",
+            "description": "Filter sources managed by external-dns via IngressClass (optional)",
+            "default": [],
+            "items": {}
+        },
+        "managedRecordTypesFilters": {
+            "type": "array",
+            "description": "Filter record types managed by external-dns (optional)",
+            "default": [],
+            "items": {}
+        },
+        "dryRun": {
+            "type": "boolean",
+            "description": "When enabled, prints DNS record changes rather than actually performing them (optional)",
+            "default": false
+        },
+        "triggerLoopOnEvent": {
+            "type": "boolean",
+            "description": "When enabled, triggers run loop on create/update/delete events in addition to regular interval (optional)",
+            "default": false
+        },
+        "interval": {
+            "type": "string",
+            "description": "Interval update period to use",
+            "default": "1m"
+        },
+        "logLevel": {
+            "type": "string",
+            "description": "Verbosity of the logs (options: panic, debug, info, warning, error, fatal, trace)",
+            "default": "info"
+        },
+        "logFormat": {
+            "type": "string",
+            "description": "Which format to output logs in (options: text, json)",
+            "default": "text"
+        },
+        "policy": {
+            "type": "string",
+            "description": "Modify how DNS records are synchronized between sources and providers (options: sync, upsert-only )",
+            "default": "upsert-only"
+        },
+        "registry": {
+            "type": "string",
+            "description": "Registry method to use (options: txt, aws-sd, noop)",
+            "default": "txt"
+        },
+        "txtPrefix": {
+            "type": "string",
+            "description": "When using the TXT registry, a prefix for ownership records that avoids collision with CNAME entries (optional)<CNAME record> (Mutual exclusive with txt-suffix)",
+            "default": ""
+        },
+        "txtSuffix": {
+            "type": "string",
+            "description": "When using the TXT registry, a suffix for ownership records that avoids collision with CNAME entries (optional)<CNAME record>.suffix (Mutual exclusive with txt-prefix)",
+            "default": ""
+        },
+        "txtOwnerId": {
+            "type": "string",
+            "description": "A name that identifies this instance of ExternalDNS. Currently used by registry types: txt & aws-sd (optional)",
+            "default": ""
+        },
+        "forceTxtOwnerId": {
+            "type": "boolean",
+            "description": "(backward compatibility) When using the non-TXT registry, it will pass the value defined by `txtOwnerId` down to the application (optional)",
+            "default": false
+        },
+        "extraArgs": {
+            "type": "object",
+            "description": "Extra arguments to be passed to external-dns",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra env vars",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Desired number of ExternalDNS replicas",
+            "default": 1
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional annotations to apply to the pod.",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional labels to be added to pods",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "priorityClassName",
+            "default": ""
+        },
+        "secretAnnotations": {
+            "type": "object",
+            "description": "Additional annotations to apply to the secret",
+            "default": {}
+        },
+        "crd": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Install and use the integrated DNSEndpoint CRD",
+                    "default": false
+                },
+                "apiversion": {
+                    "type": "string",
+                    "description": "Sets the API version for the CRD to watch",
+                    "default": ""
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Sets the kind for the CRD to watch",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to create Service resource or not",
+                    "default": true
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "ExternalDNS client port",
+                            "default": 7979
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Port to bind to for NodePort service type (client port)",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "IP address to assign to service",
+                    "default": ""
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "Service external IP addresses",
+                    "default": [],
+                    "items": {}
+                },
+                "externalName": {
+                    "type": "string",
+                    "description": "Service external name",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "IP address to assign to load balancer (if supported)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "List of IP CIDRs allowed access to load balancer (if supported)",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to service",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Provide any additional labels which may be required.",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Determine whether a Service Account should be created or it should reuse a exiting one.",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "ServiceAccount to use. A name is generated using the external-dns.fullname template if it is not set",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account.",
+                    "default": true
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create & use RBAC resources or not",
+                    "default": true
+                },
+                "clusterRole": {
+                    "type": "boolean",
+                    "description": "Whether to create Cluster Role. When set to false creates a Role in `namespace`",
+                    "default": true
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Version of the RBAC API",
+                    "default": "v1"
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "description": "Security context for the container",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable pod security context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the container",
+                    "default": 1001
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the container",
+                    "default": 1001
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 2
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "A list of volumes to be added to the pod",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "A list of volume mounts to be added to the pod",
+            "default": [],
+            "items": {}
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "description": "Configure PodDisruptionBudget",
+            "default": {}
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable prometheus to access external-dns metrics endpoint",
+                    "default": false
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for enabling prometheus to access the metrics endpoint",
+                    "default": {}
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor object",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Additional labels for ServiceMonitor object",
+                            "default": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify Metric Relabelings to add to the scrape endpoint",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Prometheus relabeling rules",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Used to pass Labels that are required by the installed Prometheus Operator",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "googlePodMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create Google Managed Prometheus PodMonitoring object",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which PodMonitoring created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped by Google Managed Prometheus",
+                            "default": "60s"
+                        },
+                        "endpoint": {
+                            "type": "string",
+                            "description": "The endpoint for Google Managed Prometheus scraping the metrics",
+                            "default": "/metrics"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/flink/values.schema.json
+++ b/bitnami/flink/values.schema.json
@@ -1,0 +1,1068 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects (sub-charts are not considered)",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Apache Flink image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Apache Flink image repository",
+                    "default": "bitnami/flink"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Apache Flink image tag (immutable tags are recommended)",
+                    "default": "1.17.1-debian-11-r75"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Apache Flink image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Apache Flink image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "jobmanager": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Command for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on flink container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Apache Flink Jobmanager replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Jobmanager nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Jobmanager containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Apache Flink containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Apache Flink containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for flink container",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "rpc": {
+                            "type": "number",
+                            "description": "Port for RPC",
+                            "default": 6123
+                        },
+                        "http": {
+                            "type": "number",
+                            "description": "Port for http UI",
+                            "default": 8081
+                        },
+                        "blob": {
+                            "type": "number",
+                            "description": "Port for blob server",
+                            "default": 6124
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Apache Flink service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "rpc": {
+                                    "type": "number",
+                                    "description": "Port for RPC",
+                                    "default": 6123
+                                },
+                                "http": {
+                                    "type": "number",
+                                    "description": "Port for http UI",
+                                    "default": 8081
+                                },
+                                "blob": {
+                                    "type": "number",
+                                    "description": "Port for blob server",
+                                    "default": 6124
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "rpc": {
+                                    "type": "string",
+                                    "description": "Node port for RPC",
+                                    "default": ""
+                                },
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for http UI",
+                                    "default": ""
+                                },
+                                "blob": {
+                                    "type": "string",
+                                    "description": "Port for blob server",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enables ServiceAccount",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "ServiceAccount name",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations to add to all deployed objects",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Apache Flink pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Apache Flink pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Rules specifying actions to take based on the requested syscall",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Apache Flink containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Apache Flink container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non root",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Allows privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "List of capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Apache Flink jobmanager deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Apache Flink jobmanager deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for flink container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the flink pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the flink pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "taskmanager": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Command for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on flink container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Apache Flink replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on taskmanager nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on taskmanager containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Apache Flink containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Apache Flink containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for flink container",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "number",
+                            "description": "data exchange port",
+                            "default": 6121
+                        },
+                        "rpc": {
+                            "type": "number",
+                            "description": "Port for RPC",
+                            "default": 6122
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Apache Flink service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "number",
+                                    "description": "data exchange port",
+                                    "default": 6121
+                                },
+                                "rpc": {
+                                    "type": "number",
+                                    "description": "Port for RPC",
+                                    "default": 6122
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "string",
+                                    "description": "data exchange port",
+                                    "default": ""
+                                },
+                                "rpc": {
+                                    "type": "string",
+                                    "description": "Port for RPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enables ServiceAccount",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "ServiceAccount name",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations to add to all deployed objects",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Apache Flink pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Apache Flink pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Rules specifying actions to take based on the requested syscall",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Apache Flink containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Apache Flink container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non root",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Allows privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "List of capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Apache Flink taskmanager deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Apache Flink taskmanager deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for flink container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the flink pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the flink pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/fluent-bit/values.schema.json
+++ b/bitnami/fluent-bit/values.schema.json
@@ -1,0 +1,967 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects (sub-charts are not considered)",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Fluent Bit image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Fluent Bit image repository",
+                    "default": "bitnami/fluent-bit"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Fluent Bit image tag (immutable tags are recommended)",
+                    "default": "2.1.9-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Fluent Bit image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Fluent Bit image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "daemonset": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Use a daemonset instead of a deployment. `replicaCount` will not take effect.",
+                    "default": false
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for daemonset pods",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for daemonset containers",
+                            "default": 0
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for daemonset containers",
+                            "default": 0
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for daemonset containers filesystem",
+                            "default": 0
+                        }
+                    }
+                },
+                "hostPaths": {
+                    "type": "object",
+                    "properties": {
+                        "logs": {
+                            "type": "string",
+                            "description": "Path to the node logs dir",
+                            "default": "/var/log"
+                        },
+                        "containerLogs": {
+                            "type": "string",
+                            "description": "Path to the container logs dir",
+                            "default": "/var/lib/docker/containers"
+                        },
+                        "machineId": {
+                            "type": "string",
+                            "description": "Path to the machine-id file",
+                            "default": "/etc/machine-id"
+                        }
+                    }
+                }
+            }
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Enable HOST Network",
+            "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Command for running the container (set to default if not set). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Args for running the container (set to default if not set). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on fluent-bit container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "existingConfigMap": {
+            "type": "string",
+            "description": "Name of an existing ConfigMap with the Fluent Bit config file",
+            "default": ""
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Fluent Bit replicas",
+            "default": 1
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on nodes",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for Fluent Bit containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for Fluent Bit containers",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for fluent-bit container",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Port for HTTP port",
+                    "default": 2020
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Fluent Bit service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Port for HTTP port",
+                            "default": 2020
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP port",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations which may be required.",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enables ServiceAccount",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "ServiceAccount name",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to all deployed objects",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account.",
+                    "default": true
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Fluent Bit pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Fluent Bit pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Fluent Bit containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Fluent Bit container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Force the container to be run as non root",
+                    "default": true
+                }
+            }
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional pod labels",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Server priorityClassName",
+            "default": ""
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Fluent Bit deployment strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Fluent Bit deployment rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for fluent-bit container",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the fluent-bit pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the fluent-bit pods",
+            "default": [],
+            "items": {}
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "flush": {
+                    "type": "number",
+                    "description": "Interval to flush output (seconds)",
+                    "default": 1
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Diagnostic level (error/warning/info/debug/trace)",
+                    "default": "info"
+                },
+                "service": {
+                    "type": "string",
+                    "description": "Defines the global behaviour of the Fluent Bit engine.",
+                    "default": "[SERVICE]\n    Flush        {{ .Values.config.flush }}\n    Daemon       Off\n    LogLevel     {{ .Values.config.logLevel }}\n    Config_Watch On\n    HTTP_Server  On\n    HTTP_Listen  0.0.0.0\n    HTTP_Port    {{ .Values.containerPorts.http }}\n"
+                },
+                "inputs": {
+                    "type": "string",
+                    "description": "Defines the source from where Fluent Bit can collect data",
+                    "default": "[INPUT]\n    Name cpu\n"
+                },
+                "filters": {
+                    "type": "string",
+                    "description": "Set of plugins that can be used to filter, modify, or enrich log data that is processed by Fluent Bit.",
+                    "default": ""
+                },
+                "outputs": {
+                    "type": "string",
+                    "description": "Outputs to send the collected data to different destinations",
+                    "default": "[OUTPUT]\n    Name  stdout\n    Match *\n"
+                },
+                "upstream": {
+                    "type": "object",
+                    "description": "This configuration is deprecated, please use `extraFiles` instead.",
+                    "default": {}
+                },
+                "customParsers": {
+                    "type": "string",
+                    "description": "Custom parsers",
+                    "default": "[PARSER]\n    Name docker_no_time\n    Format json\n    Time_Keep Off\n    Time_Key time\n    Time_Format %Y-%m-%dT%H:%M:%S.%L\n"
+                },
+                "extraFiles": {
+                    "type": "object",
+                    "description": "Extra config files",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create Role and RoleBinding",
+                    "default": false
+                },
+                "nodeAccess": {
+                    "type": "boolean",
+                    "description": "RBAC node access",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "vpa": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable VPA",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for VPA resource",
+                            "default": {}
+                        },
+                        "controlledResources": {
+                            "type": "array",
+                            "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                            "default": [],
+                            "items": {}
+                        },
+                        "maxAllowed": {
+                            "type": "object",
+                            "description": "VPA Max allowed resources for the pod",
+                            "default": {}
+                        },
+                        "minAllowed": {
+                            "type": "object",
+                            "description": "VPA Min allowed resources for the pod",
+                            "default": {}
+                        },
+                        "updatePolicy": {
+                            "type": "object",
+                            "properties": {
+                                "updateMode": {
+                                    "type": "string",
+                                    "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                    "default": "Auto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "hpa": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for HPA resource",
+                            "default": {}
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable HPA",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Min replicas",
+                            "default": 1
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Max replicas",
+                            "default": 3
+                        },
+                        "targetCPUUtilizationPercentage": {
+                            "type": "number",
+                            "description": "Target CPU utilization percentage",
+                            "default": 75
+                        },
+                        "targetMemoryUtilizationPercentage": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        },
+                        "customRules": {
+                            "type": "array",
+                            "description": "Custom rules",
+                            "default": [],
+                            "items": {}
+                        },
+                        "behavior": {
+                            "type": "object",
+                            "description": "HPA Behavior",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource for fluentBit Console",
+                    "default": false
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "fluent-bit.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to fluentBit&reg;. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Deploy a PodDisruptionBudget object for Fluent Bit deployment",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum available Fluent Bit replicas (expressed in percentage)",
+                    "default": ""
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum unavailable Fluent Bit replicas (expressed in percentage)",
+                    "default": "50%"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.service.ports.http }}"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        }
+    }
+}

--- a/bitnami/fluentd/values.schema.json
+++ b/bitnami/fluentd/values.schema.json
@@ -1,0 +1,1829 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Fluentd image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Fluentd image repository",
+                    "default": "bitnami/fluentd"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Fluentd image tag (immutable tags are recommended)",
+                    "default": "1.16.2-debian-11-r46"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Fluentd image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Fluentd image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "forwarder": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable forwarder daemonset",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Fluentd forwarder image registry override",
+                            "default": ""
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Fluentd forwarder image repository override",
+                            "default": ""
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Fluentd forwarder image tag override (immutable tags are recommended)",
+                            "default": ""
+                        }
+                    }
+                },
+                "daemonUser": {
+                    "type": "string",
+                    "description": "Forwarder daemon user and group (set to root by default because it reads from host paths)",
+                    "default": "root"
+                },
+                "daemonGroup": {
+                    "type": "string",
+                    "description": "Fluentd forwarder daemon system group",
+                    "default": "root"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for forwarder pods",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for forwarder's containers",
+                            "default": 0
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for forwarder's containers",
+                            "default": 0
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for forwarder's containers filesystem",
+                            "default": 0
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the forwarder container",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Run as privileged",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Allow Privilege Escalation",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Require the use of a read only root file system",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Drop capabilities for the securityContext",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Enable use of host network",
+                    "default": false
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Pod-specific DNS policy",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "Duration in seconds the pod needs to terminate gracefully",
+                    "default": 30
+                },
+                "configFile": {
+                    "type": "string",
+                    "description": "Name of the config file that will be used by Fluentd at launch under the `/opt/bitnami/fluentd/conf` directory",
+                    "default": "fluentd.conf"
+                },
+                "configMap": {
+                    "type": "string",
+                    "description": "Name of the config map that contains the Fluentd configuration files",
+                    "default": ""
+                },
+                "configMapFiles": {
+                    "type": "object",
+                    "properties": {
+                        "fluentd": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# Ignore fluentd own events\n<match fluent.**>\n  @type null\n</match>\n\n@include fluentd-inputs.conf\n@include fluentd-output.conf\n{{- if .Values.metrics.enabled }}\n@include metrics.conf\n{{- end }}\n"
+                                }
+                            }
+                        },
+                        "fluentd-inputs": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# HTTP input for the liveness and readiness probes\n<source>\n  @type http\n  port 9880\n</source>\n# Get the logs from the containers running in the node\n<source>\n  @type tail\n  path /var/log/containers/*.log\n  # exclude Fluentd logs\n  exclude_path /var/log/containers/*fluentd*.log\n  pos_file /opt/bitnami/fluentd/logs/buffers/fluentd-docker.pos\n  tag kubernetes.*\n  read_from_head true\n  <parse>\n    @type json\n    time_key time\n    time_format %Y-%m-%dT%H:%M:%S.%NZ\n  </parse>\n</source>\n# enrich with kubernetes metadata\n{{- if or .Values.forwarder.serviceAccount.create .Values.forwarder.serviceAccount.name }}\n<filter kubernetes.**>\n  @type kubernetes_metadata\n</filter>\n{{- end }}\n"
+                                }
+                            }
+                        },
+                        "fluentd-output": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# Throw the healthcheck to the standard output instead of forwarding it\n<match fluentd.healthcheck>\n  @type stdout\n</match>\n{{- if .Values.aggregator.enabled }}\n# Forward all logs to the aggregators\n<match **>\n  @type forward\n  {{- if .Values.tls.enabled }}\n  transport tls\n  tls_cert_path /opt/bitnami/fluentd/certs/out_forward/ca.crt\n  tls_client_cert_path /opt/bitnami/fluentd/certs/out_forward/tls.crt\n  tls_client_private_key_path /opt/bitnami/fluentd/certs/out_forward/tls.key\n  {{- end }}\n\n  {{- $fullName := (include \"common.names.fullname\" .) }}\n  {{- $global := . }}\n  {{- $domain := default \"cluster.local\" .Values.clusterDomain }}\n  {{- $port := .Values.aggregator.port | int }}\n  {{- range $i, $e := until (.Values.aggregator.replicaCount | int) }}\n  <server>\n    {{ printf \"host %s-%d.%s-headless.%s.svc.%s\" $fullName $i $fullName $global.Release.Namespace $domain }}\n    {{ printf \"port %d\" $port }}\n    {{- if ne $i 0 }}\n    standby\n    {{- end }}\n  </server>\n  {{- end }}\n  <buffer>\n    @type file\n    path /opt/bitnami/fluentd/logs/buffers/logs.buffer\n    flush_thread_count 2\n    flush_interval 5s\n  </buffer>\n</match>\n{{- else }}\n# Send the logs to the standard output\n<match **>\n  @type stdout\n</match>\n{{- end }}\n"
+                                }
+                            }
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# Prometheus Exporter Plugin\n# input plugin that exports metrics\n<source>\n  @type prometheus\n  port {{ .Values.metrics.service.port }}\n</source>\n# input plugin that collects metrics from MonitorAgent\n<source>\n  @type prometheus_monitor\n  <labels>\n    host ${hostname}\n  </labels>\n</source>\n# input plugin that collects metrics for output plugin\n<source>\n  @type prometheus_output_monitor\n  <labels>\n    host ${hostname}\n  </labels>\n</source>\n# input plugin that collects metrics for in_tail plugin\n<source>\n  @type prometheus_tail_monitor\n  <labels>\n    host ${hostname}\n  </labels>\n</source>\n"
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "string",
+                    "description": "Extra arguments for the Fluentd command line",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to pass to the container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Fluentd Forwarder nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Fluentd Forwarder nodes",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "containerPort": {
+                                "type": "number",
+                                "description": ""
+                            },
+                            "protocol": {
+                                "type": "string",
+                                "description": ""
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "number",
+                                            "description": "",
+                                            "default": 9880
+                                        },
+                                        "targetPort": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "http"
+                                        },
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "TCP"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type (`ClusterIP`, `NodePort`, or `LoadBalancer`) for the forwarders",
+                            "default": "ClusterIP"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer` (optional, cloud specific)",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Fluentd Forwarder service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Request path for startupProbe",
+                                    "default": "/fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D"
+                                },
+                                "port": {
+                                    "type": "string",
+                                    "description": "Port for startupProbe",
+                                    "default": "http"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Request path for livenessProbe",
+                                    "default": "/fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D"
+                                },
+                                "port": {
+                                    "type": "string",
+                                    "description": "Port for livenessProbe",
+                                    "default": "http"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Request path for readinessProbe",
+                                    "default": "/fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D"
+                                },
+                                "port": {
+                                    "type": "string",
+                                    "description": "Port for readinessProbe",
+                                    "default": "http"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Fluend Forwarder",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Fluend Forwarder",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom rediness probe for the Fluend Forwarder",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set up update strategy.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Set Priority Class Name to allow priority control over other pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Forwarder Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Forwarder Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Forwarder Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Forwarder Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Forwarder Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Forwarder Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Forwarder Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Forwarder Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels to add to Pod",
+                    "default": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specify whether a ServiceAccount should be created.",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to create",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specify whether RBAC resources should be created and used, allowing the get, watch and list of pods/namespaces",
+                            "default": true
+                        },
+                        "pspEnabled": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy and bound it with RBAC. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": false
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence volume for the forwarder",
+                            "default": false
+                        },
+                        "hostPath": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Directory from the host node's filesystem to mount as hostPath volume for persistence.",
+                                    "default": "/opt/bitnami/fluentd/logs/buffers"
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Additional lifecycles to add to the pods",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Additional init containers to add to the pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to forwarder pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Mount extra volume(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initScripts": {
+                    "type": "object",
+                    "description": "Dictionary of init scripts. Evaluated as a template.",
+                    "default": {}
+                },
+                "initScriptsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with the init scripts. Evaluated as a template.",
+                    "default": ""
+                },
+                "initScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+                    "default": ""
+                }
+            }
+        },
+        "aggregator": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Fluentd aggregator statefulset",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Fluentd aggregator image registry override",
+                            "default": ""
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Fluentd aggregator image repository override",
+                            "default": ""
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Fluentd aggregator image tag override (immutable tags are recommended)",
+                            "default": ""
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of aggregator pods to deploy in the Stateful Set",
+                    "default": 1
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for aggregator pods",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for aggregator's containers",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for aggregator's containers",
+                            "default": 1001
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for aggregator's containers filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the aggregator container",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Run as privileged",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Allow Privilege Escalation",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Require the use of a read only root file system",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Drop capabilities for the securityContext",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "Duration in seconds the pod needs to terminate gracefully",
+                    "default": 30
+                },
+                "configMapFiles": {
+                    "type": "object",
+                    "properties": {
+                        "fluentd": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# Ignore fluentd own events\n<match fluent.**>\n  @type null\n</match>\n\n@include fluentd-inputs.conf\n@include fluentd-output.conf\n{{- if .Values.metrics.enabled }}\n@include metrics.conf\n{{- end }}\n"
+                                }
+                            }
+                        },
+                        "fluentd-inputs": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# TCP input to receive logs from\n{{- if .Values.aggregator.port }}\n<source>\n  @type forward\n  bind 0.0.0.0\n  port {{ .Values.aggregator.port }}\n  {{- if .Values.tls.enabled }}\n  <transport tls>\n    ca_path /opt/bitnami/fluentd/certs/in_forward/ca.crt\n    cert_path /opt/bitnami/fluentd/certs/in_forward/tls.crt\n    private_key_path /opt/bitnami/fluentd/certs/in_forward/tls.key\n    client_cert_auth true\n  </transport>\n  {{- end }}\n</source>\n{{- end }}\n\n# HTTP input for the liveness and readiness probes\n<source>\n  @type http\n  bind 0.0.0.0\n  port 9880\n</source>\n"
+                                }
+                            }
+                        },
+                        "fluentd-output": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# Throw the healthcheck to the standard output\n<match fluentd.healthcheck>\n  @type stdout\n</match>\n\n# Send the logs to the standard output\n<match **>\n  @type stdout\n</match>\n"
+                                }
+                            }
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "properties": {
+                                "conf": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "# Prometheus Exporter Plugin\n# input plugin that exports metrics\n<source>\n  @type prometheus\n  port {{ .Values.metrics.service.port }}\n</source>\n\n# input plugin that collects metrics from MonitorAgent\n<source>\n  @type prometheus_monitor\n  <labels>\n    host ${hostname}\n  </labels>\n</source>\n\n# input plugin that collects metrics for output plugin\n<source>\n  @type prometheus_output_monitor\n  <labels>\n    host ${hostname}\n  </labels>\n</source>\n"
+                                }
+                            }
+                        }
+                    }
+                },
+                "configFile": {
+                    "type": "string",
+                    "description": "Name of the config file that will be used by Fluentd at launch under the `/opt/bitnami/fluentd/conf` directory",
+                    "default": "fluentd.conf"
+                },
+                "configMap": {
+                    "type": "string",
+                    "description": "Name of the config map that contains the Fluentd configuration files",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port the Aggregator container will listen for logs. Leave it blank to ignore.",
+                    "default": 24224
+                },
+                "extraArgs": {
+                    "type": "string",
+                    "description": "Extra arguments for the Fluentd command line",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "containerPort": {
+                                "type": "number",
+                                "description": ""
+                            },
+                            "protocol": {
+                                "type": "string",
+                                "description": ""
+                            }
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to pass to the container",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "number",
+                                            "description": "",
+                                            "default": 9880
+                                        },
+                                        "targetPort": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "http"
+                                        },
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "TCP"
+                                        }
+                                    }
+                                },
+                                "tcp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "number",
+                                            "description": "",
+                                            "default": 24224
+                                        },
+                                        "targetPort": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "tcp"
+                                        },
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "TCP"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type (`ClusterIP`, `NodePort`, or `LoadBalancer`) for the aggregators",
+                            "default": "ClusterIP"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer` (optional, cloud specific)",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required",
+                            "default": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Fluentd Aggregator service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "annotationsHeadless": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required on headless service",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Fluentd Aggregator nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Fluentd Aggregator nodes",
+                    "default": ""
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set to true to enable ingress record generation",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress Path type. How the path matching is interpreted",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Override API Version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "fluentd.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress resource",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Request path for startupProbe",
+                                    "default": "/fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D"
+                                },
+                                "port": {
+                                    "type": "string",
+                                    "description": "Port for startupProbe",
+                                    "default": "http"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Request path for livenessProbe",
+                                    "default": "/fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D"
+                                },
+                                "port": {
+                                    "type": "string",
+                                    "description": "Port for livenessProbe",
+                                    "default": "http"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "description": "Request path for readinessProbe",
+                                    "default": "/fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D"
+                                },
+                                "port": {
+                                    "type": "string",
+                                    "description": "Port for readinessProbe",
+                                    "default": "http"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Fluentd Aggregator",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Fluentd Aggregator",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom rediness probe for the Fluentd Aggregator",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set up update strategy.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Fluentd Aggregator pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Fluentd Aggregator pods",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Aggregator Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Aggregator Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Aggregator Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Aggregator Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Aggregator Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Aggregator Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Aggregator Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Aggregator Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels to add to Pod",
+                    "default": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specify whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to create",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "resource": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": ""
+                                            },
+                                            "target": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": ""
+                                                    },
+                                                    "averageUtilization": {
+                                                        "type": "number",
+                                                        "description": ""
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create an Horizontal Pod Autoscaler",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Minimum number of replicas for the HPA",
+                            "default": 2
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Maximum number of replicas for the HPA",
+                            "default": 5
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence volume for the aggregator",
+                            "default": false
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "10Gi"
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Additional lifecycles to add to the pods",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to aggregator pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to aggregator pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Mount extra volume(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeClaimTemplates": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volume claim templates for the Fluentd Aggregator pods in StatefulSet",
+                    "default": [],
+                    "items": {}
+                },
+                "initScripts": {
+                    "type": "object",
+                    "description": "Dictionary of init scripts. Evaluated as a template.",
+                    "default": {}
+                },
+                "initScriptsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with the init scripts. Evaluated as a template.",
+                    "default": ""
+                },
+                "initScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "24231"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus metrics service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Prometheus metrics service port",
+                            "default": 24231
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Prometheus metrics service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Prometheus metrics service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Prometheus metrics service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "ServiceMonitor extra labels",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "ServiceMonitor annotations",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "path defines the path that promethues will use to pull metrics from the container",
+                            "default": "/metrics"
+                        }
+                    }
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS/SSL encrytion for internal communications",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates.",
+                    "default": false
+                },
+                "forwarder": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for the Fluentd forwarder",
+                            "default": ""
+                        }
+                    }
+                },
+                "aggregator": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for the Fluentd aggregator",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/flux/values.schema.json
+++ b/bitnami/flux/values.schema.json
@@ -1,0 +1,4481 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "kustomizeController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Kustomize Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Kustomize Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Kustomize Controller image repository",
+                            "default": "bitnami/fluxcd-kustomize-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Kustomize Controller image tag (immutable tags are recommended)",
+                            "default": "0.35.1-debian-11-r139"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Kustomize Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Kustomize Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Kustomize Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Kustomize Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Kustomize Controller replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Kustomize Controller metrics container port",
+                            "default": 8080
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Kustomize Controller health container port",
+                            "default": 9440
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Kustomize Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Kustomize Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Kustomize Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Kustomize Controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Kustomize Controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Kustomize Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Kustomize Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Kustomize Controller container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Kustomize Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Kustomize Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Kustomize Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Kustomize Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Kustomize Controller container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Kustomize Controller container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Kustomize Controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Kustomize Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Kustomize Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `kustomizeController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `kustomizeController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for kustomizeController",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of kustomizeController replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of kustomizeController replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `kustomizeController.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `kustomizeController.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `kustomizeController.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Kustomize Controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Kustomize Controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Kustomize Controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kustomize Controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Kustomize Controller pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Kustomize Controller pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Kustomize Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Kustomize Controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Kustomize Controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Kustomize Controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Kustomize Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Kustomize Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Kustomize Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Kustomize Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": true
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Kustomize Controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Kustomize Controller service metrics port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Kustomize Controller service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Kustomize Controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Kustomize Controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Kustomize Controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.kustomizeController.metrics.service.ports.metrics }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Kustomize Controller service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "helmController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Helm Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Helm Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Helm Controller image repository",
+                            "default": "bitnami/fluxcd-helm-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Helm Controller image tag (immutable tags are recommended)",
+                            "default": "0.35.0-debian-11-r44"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Helm Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Helm Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Helm Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Helm Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Helm Controller replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Helm Controller metrics container port",
+                            "default": 8080
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Helm Controller health container port",
+                            "default": 9440
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Helm Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Helm Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Helm Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Helm Controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Helm Controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Helm Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Helm Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Helm Controller container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Helm Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Helm Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Helm Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Helm Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Helm Controller container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Helm Controller container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Helm Controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Helm Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Helm Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `helmController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `helmController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for helmController",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of helmController replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of helmController replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `helmController.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `helmController.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `helmController.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Helm Controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Helm Controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Helm Controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Helm Controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Helm Controller pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Helm Controller pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Helm Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Helm Controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Helm Controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Helm Controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Helm Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Helm Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Helm Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Helm Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": true
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Helm Controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Helm Controller service metrics port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Helm Controller service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Helm Controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Helm Controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Helm Controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.helmController.metrics.service.ports.metrics }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Helm Controller service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "sourceController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Source Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Source Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Source Controller image repository",
+                            "default": "bitnami/fluxcd-source-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Source Controller image tag (immutable tags are recommended)",
+                            "default": "0.36.1-debian-11-r138"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Source Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Source Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Source Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Source Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Source Controller replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Source Controller http container port",
+                            "default": 9090
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Source Controller metrics container port",
+                            "default": 8080
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Source Controller health container port",
+                            "default": 9440
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Source Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Source Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Source Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Source Controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Source Controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Source Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Source Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Source Controller container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Source Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Source Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Source Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Source Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Source Controller container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Source Controller container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Source Controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Source Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Source Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `sourceController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `sourceController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for sourceController",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of sourceController replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of sourceController replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `sourceController.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `sourceController.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `sourceController.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Source Controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Source Controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Source Controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Source Controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Source Controller pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Source Controller pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Source Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Source Controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Source Controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Source Controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Source Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Source Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Source Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Source Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Source Controller service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Source Controller service metrics port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Source Controller service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Source Controller service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Source Controller service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.sourceController.service.ports }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Source Controller service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Source Controller service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the default NetworkPolicy policy",
+                            "default": false
+                        },
+                        "allowExternal": {
+                            "type": "boolean",
+                            "description": "Don't require client label for connections",
+                            "default": true
+                        },
+                        "extraFromClauses": {
+                            "type": "array",
+                            "description": "Allows to add extra 'from' clauses to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraIngress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEgress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using Persistent Volume Claims",
+                            "default": false
+                        },
+                        "resourcePolicy": {
+                            "type": "string",
+                            "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Persistent Volume mount root path",
+                            "default": "/bitnami/fluxcd-source-controller/data"
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "10Gi"
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "The name of an existing PVC to use for persistence",
+                            "default": ""
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": true
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Source Controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Source Controller service metrics port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Source Controller service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Source Controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.sourceController.metrics.service.ports.metrics }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Source Controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Source Controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Source Controller service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "notificationController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Notification Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Notification Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Notification Controller image repository",
+                            "default": "bitnami/fluxcd-notification-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Notification Controller image tag (immutable tags are recommended)",
+                            "default": "0.33.0-debian-11-r139"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Notification Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Notification Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Notification Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Notification Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Notification Controller replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Notification Controller metrics container port",
+                            "default": 8080
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Notification Controller health container port",
+                            "default": 9440
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Notification Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Notification Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Notification Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Notification Controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Notification Controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Notification Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Notification Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Notification Controller container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Notification Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Notification Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Notification Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Notification Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Notification Controller container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Notification Controller container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Notification Controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Notification Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Notification Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `notificationController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `notificationController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for notificationController",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of notificationController replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of notificationController replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `notificationController.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `notificationController.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `notificationController.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Notification Controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Notification Controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Notification Controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Notification Controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Notification Controller pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Notification Controller pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Notification Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Notification Controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Notification Controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Notification Controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Notification Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Notification Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Notification Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Notification Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": true
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Notification Controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Notification Controller service metrics port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Notification Controller service Cluster IP",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.notificationController.metrics.service.ports.metrics }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Notification Controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Notification Controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Notification Controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Notification Controller service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "imageAutomationController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Image Automation Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Image Automation Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Image Automation Controller image repository",
+                            "default": "bitnami/fluxcd-image-automation-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Image Automation Controller image tag (immutable tags are recommended)",
+                            "default": "0.31.0-debian-11-r83"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Image Automation Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image Automation Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Image Automation Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Image Automation Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Image Automation Controller replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Image Automation Controller metrics container port",
+                            "default": 8080
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Image Automation Controller health container port",
+                            "default": 9440
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Image Automation Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Image Automation Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Image Automation Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Image Automation Controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Image Automation Controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Image Automation Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Image Automation Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Image Automation Controller container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Image Automation Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Image Automation Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Image Automation Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Image Automation Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Image Automation Controller container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Image Automation Controller container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Image Automation Controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Image Automation Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Image Automation Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `imageAutomationController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `imageAutomationController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for imageAutomationController",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of imageAutomationController replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of imageAutomationController replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `imageAutomationController.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `imageAutomationController.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `imageAutomationController.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Image Automation Controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Image Automation Controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Image Automation Controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Image Automation Controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Image Automation Controller pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Image Automation Controller pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Image Automation Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Image Automation Controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Image Automation Controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Image Automation Controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Image Automation Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Image Automation Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Image Automation Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Image Automation Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": true
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Image Automation Controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Image Automation Controller service metrics port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.imageAutomationController.metrics.service.ports.metrics }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Image Automation Controller service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Image Automation Controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Image Automation Controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Image Automation Controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Image Automation Controller service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "imageReflectorController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Image Reflector Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Image Reflector Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Image Reflector Controller image repository",
+                            "default": "bitnami/fluxcd-image-reflector-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Image Reflector Controller image tag (immutable tags are recommended)",
+                            "default": "0.29.1-debian-11-r38"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Image Reflector Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image Reflector Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Image Reflector Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Image Reflector Controller image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Image Reflector Controller replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Image Reflector Controller metrics container port",
+                            "default": 8080
+                        },
+                        "health": {
+                            "type": "number",
+                            "description": "Image Reflector Controller health container port",
+                            "default": 9440
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Image Reflector Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Image Reflector Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Image Reflector Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Image Reflector Controller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Image Reflector Controller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Image Reflector Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Image Reflector Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Image Reflector Controller container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Image Reflector Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Image Reflector Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Image Reflector Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Image Reflector Controller containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Image Reflector Controller container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Image Reflector Controller container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Image Reflector Controller pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Image Reflector Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Image Reflector Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `imageReflectorController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `imageReflectorController.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for imageReflectorController",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of imageReflectorController replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of imageReflectorController replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `imageReflectorController.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `imageReflectorController.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `imageReflectorController.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Image Reflector Controller pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Image Reflector Controller pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Image Reflector Controller pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Image Reflector Controller statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Image Reflector Controller pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Image Reflector Controller pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Image Reflector Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Image Reflector Controller nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Image Reflector Controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Image Reflector Controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Image Reflector Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Image Reflector Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Image Reflector Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Image Reflector Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using Persistent Volume Claims",
+                            "default": false
+                        },
+                        "resourcePolicy": {
+                            "type": "string",
+                            "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Persistent Volume mount root path",
+                            "default": "/bitnami/fluxcd-image-reflector-controller/data"
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "10Gi"
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "The name of an existing PVC to use for persistence",
+                            "default": ""
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": true
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Image Reflector Controller service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Image Reflector Controller service metrics port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.imageReflectorController.metrics.service.ports.metrics }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Image Reflector Controller service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Image Reflector Controller service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Image Reflector Controller service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Image Reflector Controller service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Image Reflector Controller service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable init container's Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/ghost/values.schema.json
+++ b/bitnami/ghost/values.schema.json
@@ -1,186 +1,1063 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "ghostUsername": {
-      "type": "string",
-      "title": "User",
-      "form": true
-    },
-    "ghostPassword": {
-      "type": "string",
-      "title": "Password",
-      "form": true,
-      "description": "Defaults to a random 10-character alphanumeric string if not set"
-    },
-    "ghostEmail": {
-      "type": "string",
-      "title": "Admin email",
-      "form": true
-    },
-    "ghostBlogTitle": {
-      "type": "string",
-      "title": "Blog Name",
-      "form": true
-    },
-    "ghostHost": {
-      "type": "string",
-      "title": "Host",
-      "form": true,
-      "description": "Hostname used to generate application URLs"
-    },
-    "persistence": {
-      "type": "object",
-      "properties": {
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi"
-        }
-      }
-    },
-    "mysql": {
-      "type": "object",
-      "form": true,
-      "title": "MySQL Details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MySQL database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a mysql server to satisfy the applications database requirements. To use an external database switch this off and configure the external database parameters"
-        },
-        "primary": {
-          "type": "object",
-          "properties": {
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "title": "Volume Size",
-                  "form": true,
-                  "hidden": {
-                    "value": false,
-                    "path": "mysql/enabled"
-                  },
-                  "render": "slider",
-                  "sliderMin": 1,
-                  "sliderMax": 100,
-                  "sliderUnit": "Gi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MySQL is disabled. Use this section to specify the external database details",
-      "form": true,
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host",
-          "hidden": "mysql/enabled"
         },
-        "user": {
-          "type": "string",
-          "form": true,
-          "title": "Database Username",
-          "hidden": "mysql/enabled"
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
         },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password",
-          "hidden": "mysql/enabled"
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
         },
-        "database": {
-          "type": "string",
-          "form": true,
-          "title": "Database Name",
-          "hidden": "mysql/enabled"
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
         },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port",
-          "hidden": "mysql/enabled"
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
         },
-        "ssl": {
-          "type": "boolean",
-          "form": true,
-          "title": "Database SSL",
-          "hidden": "mysql/enabled"
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
         },
-        "sslCaFile": {
-          "type": "string",
-          "form": true,
-          "title": "Database SSL CA filepath",
-          "hidden": "mysql/enabled"
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Required Resources",
-      "description": "Configure resource requests",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
-          }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Ghost image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Ghost image repository",
+                    "default": "bitnami/ghost"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Ghost image tag (immutable tags are recommended)",
+                    "default": "5.61.3-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Ghost image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Ghost image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Ghost image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "ghostUsername": {
+            "type": "string",
+            "description": "Ghost user name",
+            "default": "user"
+        },
+        "ghostPassword": {
+            "type": "string",
+            "description": "Ghost user password",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing Ghost credentials",
+            "default": ""
+        },
+        "ghostEmail": {
+            "type": "string",
+            "description": "Ghost user email",
+            "default": "user@example.com"
+        },
+        "ghostBlogTitle": {
+            "type": "string",
+            "description": "Ghost Blog title",
+            "default": "User's Blog"
+        },
+        "ghostHost": {
+            "type": "string",
+            "description": "Ghost host to create application URLs",
+            "default": ""
+        },
+        "ghostPath": {
+            "type": "string",
+            "description": "URL sub path where to server the Ghost application",
+            "default": "/"
+        },
+        "ghostEnableHttps": {
+            "type": "boolean",
+            "description": "Configure Ghost to build application URLs using https",
+            "default": false
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP server host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP server port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP username",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP user password",
+            "default": ""
+        },
+        "smtpService": {
+            "type": "string",
+            "description": "SMTP service",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol (ssl or tls)",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow the container to be started with blank passwords",
+            "default": true
+        },
+        "ghostSkipInstall": {
+            "type": "boolean",
+            "description": "Skip performing the initial bootstrapping for Ghost",
+            "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the Ghost container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Ghost replicas to deploy",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Ghost deployment strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Ghost pod priority class name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Ghost pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Ghost pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Ghost container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Ghost pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Ghost pods",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Add lifecycle hooks to the Ghost deployment",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Ghost pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Ghost pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Ghost container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the Ghost container",
+                    "default": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Ghost HTTP container port",
+                    "default": 2368
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Ghost HTTPS container port",
+                    "default": 2368
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Ghost pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Ghost pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Ghost containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Ghost container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Ghost container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Ghost service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Ghost service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Ghost service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Ghost service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Ghost service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Ghost service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Ghost service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Ghost service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Ghost service",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Ghost",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "ghost.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the PVC",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The name of a volume's sub path to mount for persistence",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "mysql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a MySQL server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MySQL architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "MySQL root password",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "MySQL custom database",
+                            "default": "bitnami_ghost"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "MySQL custom user name",
+                            "default": "bn_ghost"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MySQL custom user password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret with MySQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable persistence on MySQL using PVC(s)",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "Persistent Volume storage class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Persistent Volume access modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Persistent Volume size",
+                                    "default": "8Gi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External Database server host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Database server port",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "External Database username",
+                    "default": "bn_ghost"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External Database user password",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "External Database database name",
+                    "default": "bitnami_ghost"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of an existing secret with database credentials",
+                    "default": ""
+                },
+                "ssl": {
+                    "type": "boolean",
+                    "description": "External Database ssl",
+                    "default": false
+                },
+                "sslCaFile": {
+                    "type": "string",
+                    "description": "External Database ssl CA filepath",
+                    "default": ""
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mysql) only accessible by Ghost's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Ghost only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Ghost. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Ghost. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
         }
-      }
-    },
-    "securityContext": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Pod Security Context",
-          "description": "When disabled, an initContainer will be used to set required folder permissions",
-          "form": true
-        }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "Service Account Name",
-          "description": "Service Account Name to use",
-          "form": true
-        }
-      }
     }
-  }
 }

--- a/bitnami/gitea/values.schema.json
+++ b/bitnami/gitea/values.schema.json
@@ -1,0 +1,918 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override gitea.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override gitea.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Gitea resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Gitea resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Gitea image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Gitea Image name",
+                    "default": "bitnami/gitea"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Gitea Image tag",
+                    "default": "1.20.4-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Gitea image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Gitea image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Gitea Pods to run (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "adminUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "bn_user"
+        },
+        "adminPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "adminEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "appName": {
+            "type": "string",
+            "description": "Gitea application name",
+            "default": "example"
+        },
+        "runMode": {
+            "type": "string",
+            "description": "Gitea application host",
+            "default": "prod"
+        },
+        "exposeSSH": {
+            "type": "boolean",
+            "description": "Make the SSH server accesible",
+            "default": true
+        },
+        "rootURL": {
+            "type": "string",
+            "description": "UI Root URL (for link generation)",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Gitea pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "existingSecretKey": {
+            "type": "string",
+            "description": "Key inside the existing secret containing the password",
+            "default": "admin-password"
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 3000
+                },
+                "ssh": {
+                    "type": "number",
+                    "description": "",
+                    "default": 2222
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Gitea volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Gitea volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Gitea volume",
+                    "default": "8Gi"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume Claim",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "If defined, the gitea-data volume will mount to the specified hostPath.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for Gitea data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the init container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Gitea pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Gitea pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Gitea containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Gitea containers' Security Context",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Controller container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "ssh": {
+                            "type": "number",
+                            "description": "Service SSH port",
+                            "default": 22
+                        }
+                    }
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the Gitea Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "ssh": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Gitea service Cluster IP",
+                    "default": ""
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Gitea service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "gitea.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Gitea. You may need to set this to '/*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Gitea pod",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_gitea"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_gitea"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for JupyterHub",
+                    "default": "postgres"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for JupyterHub",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "JupyterHub database name",
+                    "default": "gitea"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": "db-password"
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/grafana-loki/values.schema.json
+++ b/bitnami/grafana-loki/values.schema.json
@@ -1,0 +1,5732 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployments/statefulsets",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployments/statefulsets",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "loki": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Loki image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Loki image repository",
+                            "default": "bitnami/grafana-loki"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Loki image tag (immutable tags are recommended)",
+                            "default": "2.8.4-debian-11-r7"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Loki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Loki image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana Loki image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Loki components configuration",
+                    "default": "auth_enabled: false\n\nserver:\n  http_listen_port: {{ .Values.loki.containerPorts.http }}\n\ncommon:\n  compactor_address: http://{{ include \"grafana-loki.compactor.fullname\" . }}:{{ .Values.compactor.service.ports.http }}\n\ndistributor:\n  ring:\n    kvstore:\n      store: memberlist\n\nmemberlist:\n  join_members:\n    - {{ include \"grafana-loki.gossip-ring.fullname\" . }}\n\ningester:\n  lifecycler:\n    ring:\n      kvstore:\n        store: memberlist\n      replication_factor: 1\n  chunk_idle_period: 30m\n  chunk_block_size: 262144\n  chunk_encoding: snappy\n  chunk_retain_period: 1m\n  max_transfer_retries: 0\n  wal:\n    dir: {{ .Values.loki.dataDir }}/wal\n\nlimits_config:\n  enforce_metric_name: false\n  reject_old_samples: true\n  reject_old_samples_max_age: 168h\n  max_cache_freshness_per_query: 10m\n  split_queries_by_interval: 15m\n\nschema_config:\n  configs:\n  - from: 2020-10-24\n    store: boltdb-shipper\n    object_store: filesystem\n    schema: v11\n    index:\n      prefix: index_\n      period: 24h\n\nstorage_config:\n  boltdb_shipper:\n    shared_store: filesystem\n    active_index_directory: {{ .Values.loki.dataDir }}/loki/index\n    cache_location: {{ .Values.loki.dataDir }}/loki/cache\n    cache_ttl: 168h\n    {{- if .Values.indexGateway.enabled }}\n    index_gateway_client:\n      server_address: {{ (printf \"dns:///%s:9095\" (include \"grafana-loki.index-gateway.fullname\" .)) }}\n    {{- end }}\n  filesystem:\n    directory: {{ .Values.loki.dataDir }}/chunks\n  index_queries_cache_config:\n    {{- if .Values.memcachedindexqueries.enabled }}\n    memcached:\n      batch_size: 100\n      parallelism: 100\n    memcached_client:\n      consistent_hash: true\n      addresses: dns+{{ include \"grafana-loki.memcached-index-queries.host\" . }}\n      service: http\n    {{- end }}\n\nchunk_store_config:\n  max_look_back_period: 0s\n  {{- if .Values.memcachedchunks.enabled }}\n  chunk_cache_config:\n    memcached:\n      batch_size: 100\n      parallelism: 100\n    memcached_client:\n      consistent_hash: true\n      addresses: dns+{{ include \"grafana-loki.memcached-chunks.host\" . }}\n  {{- end }}\n  {{- if .Values.memcachedindexwrites.enabled }}\n  write_dedupe_cache_config:\n    memcached:\n      batch_size: 100\n      parallelism: 100\n    memcached_client:\n      consistent_hash: true\n      addresses: dns+{{ include \"grafana-loki.memcached-index-writes.host\" . }}\n  {{- end }}\n\ntable_manager:\n  retention_deletes_enabled: false\n  retention_period: 0s\n\nquery_range:\n  align_queries_with_step: true\n  max_retries: 5\n  cache_results: true\n  results_cache:\n    cache:\n      {{- if .Values.memcachedfrontend.enabled }}\n      memcached_client:\n        consistent_hash: true\n        addresses: dns+{{ include \"grafana-loki.memcached-frontend.host\" . }}\n        max_idle_conns: 16\n        timeout: 500ms\n        update_interval: 1m\n      {{- else }}\n      embedded-cache:\n        enabled: true\n        max_size_items: 1024\n        validity: 24h\n      {{- end }}\n{{- if not .Values.queryScheduler.enabled }}\nfrontend_worker:\n  frontend_address: {{ include \"grafana-loki.query-frontend.fullname\" . }}:{{ .Values.queryFrontend.service.ports.grpc }}\n{{- end }}\n\nfrontend:\n  log_queries_longer_than: 5s\n  compress_responses: true\n  tail_proxy_url: http://{{ include \"grafana-loki.querier.fullname\" . }}:{{ .Values.querier.service.ports.http }}\n\ncompactor:\n  shared_store: filesystem\n\nruler:\n  storage:\n    type: local\n    local:\n      directory: {{ .Values.loki.dataDir }}/conf/rules\n  ring:\n    kvstore:\n      store: memberlist\n  rule_path: /tmp/loki/scratch\n  alertmanager_url: https://alertmanager.xx\n  external_url: https://alertmanager.xx\n"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap with the Loki configuration",
+                    "default": ""
+                },
+                "dataDir": {
+                    "type": "string",
+                    "description": "path to the Loki data directory",
+                    "default": "/bitnami/grafana-loki"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Loki components web container port",
+                            "default": 3100
+                        },
+                        "grpc": {
+                            "type": "number",
+                            "description": "Loki components GRPC container port",
+                            "default": 9095
+                        },
+                        "gossipRing": {
+                            "type": "number",
+                            "description": "Loki components Gossip Ring container port",
+                            "default": 7946
+                        }
+                    }
+                },
+                "gossipRing": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Gossip Ring HTTP headless service port",
+                                            "default": 7946
+                                        }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Gossip Ring headless service",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "compactor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Compactor deployment",
+                    "default": true
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to compactor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for compactor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for compactor nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Compactor replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Compactor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Compactor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Compactor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the compactor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the compactor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Compactor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Compactor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Compactor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Compactor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Compactor containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the compactor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "compactor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for compactor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for compactor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `compactor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `compactor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Compactor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Compactor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Compactor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Compactor pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Compactor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Compactor statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Compactor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Compactor instances",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Memcached data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Memcached data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Compactor's data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Compactor service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Compactor HTTP service port",
+                                    "default": 3100
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Compactor service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Compactor service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Compactor service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Compactor service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Compactor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Compactor service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Gateway deployment",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Nginx image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Nginx image repository",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Nginx image tag (immutable tags are recommended)",
+                            "default": "1.25.2-debian-11-r2"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Nginx image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Nginx image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Nginx image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable debugging in the initialization process",
+                            "default": false
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to gateway nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for gateway nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for gateway nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "verboseLogging": {
+                    "type": "boolean",
+                    "description": "Show the gateway access_log",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Gateway replicas to deploy",
+                    "default": 1
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable basic auth",
+                            "default": false
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Basic auth username",
+                            "default": "user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Basic auth password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of a secret containing the Basic auth password",
+                            "default": ""
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Gateway containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Gateway HTTP port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the gateway containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the gateway containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Gateway pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Gateway pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Gateway containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Gateway containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Gateway containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the gateway container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "gateway pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for gateway pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for gateway pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `gateway.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `gateway.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Gateway pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Gateway pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Gateway pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Gateway pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Gateway statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Gateway statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Gateway container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Gateway service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Gateway HTTP service port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Gateway service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Gateway service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Gateway service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Gateway service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Gateway service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Gateway service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Loki Gateway",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "grafana-loki.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "indexGateway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable index-gateway deployment",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to indexGateway nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for indexGateway nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for indexGateway nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of index-gateway replicas to deploy",
+                    "default": 1
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation",
+                    "default": ""
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on index-gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on index-gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on index-gateway containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the indexGateway containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the indexGateway containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled index-gateway pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set index-gateway pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled index-gateway containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set index-gateway containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set index-gateway containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the indexGateway container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "indexGateway pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for indexGateway pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for indexGateway pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `indexGateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `indexGateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `indexGateway.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `indexGateway.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `indexGateway.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for index-gateway pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for index-gateway pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for index-gateway pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "index-gateway pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "index-gateway statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "index-gateway statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the index-gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the index-gateway container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the index-gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the index-gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "index-gateway service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "index-gateway HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "index-gateway GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "index-gateway service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "index-gateway service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "index-gateway service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "index-gateway service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for index-gateway service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the index-gateway service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "distributor": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to distributor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for distributor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for distributor nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Distributor replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Distributor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Distributor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Distributor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the distributor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the distributor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Distributor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Distributor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Distributor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Distributor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Distributor containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the distributor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "distributor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for distributor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for distributor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `distributor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `distributor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Distributor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Distributor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Distributor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Distributor pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Distributor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Distributor statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Distributor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Distributor service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Distributor HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Distributor GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Distributor service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Distributor service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Distributor service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Distributor service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Distributor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Distributor service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingester": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingester nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Ingester replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Ingester nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Ingester nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Ingester containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Ingester containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Ingester containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ingester pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Ingester pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ingester containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Ingester containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Ingester containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ingester.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ingester.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for ingester pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Ingester pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Ingester pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation",
+                    "default": ""
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Ingester pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingester statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Ingester statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the ingester container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Ingester instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Memcached data volume",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Memcached data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Ingester's data PVC",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingester service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Ingester HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Ingester GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Ingester service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Ingester service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Ingester service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Ingester service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Ingester service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Ingester service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "querier": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Querier replicas to deploy",
+                    "default": 1
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Querier nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Querier nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Querier nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation",
+                    "default": ""
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Querier nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Querier nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Querier containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Querier containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Querier containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Querier pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Querier pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Querier containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Querier containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Querier containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Querier container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "querier pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for querier pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for querier pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `querier.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `querier.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Querier pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Querier pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Querier pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Querier pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Querier statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Querier statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the querier container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Querier instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Memcached data volume",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Memcached data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Querier's data PVC",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Querier service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Querier HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Querier GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Querier service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Querier service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Querier service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Querier service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Querier service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Querier service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "queryFrontend": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to queryFrontend nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for queryFrontend nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for queryFrontend nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of queryFrontend replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on queryFrontend nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on queryFrontend nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on queryFrontend containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the queryFrontend containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the queryFrontend containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled queryFrontend pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set queryFrontend pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled queryFrontend containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set queryFrontend containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set queryFrontend containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the queryFrontend container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "queryFrontend pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for queryFrontend pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for queryFrontend pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `queryFrontend.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `queryFrontend.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for queryFrontend pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for queryFrontend pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for queryFrontend pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "queryFrontend pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "queryFrontend statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "queryFrontend statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the queryFrontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the queryFrontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the queryFrontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "queryFrontend service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "queryFrontend HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "queryFrontend GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "queryFrontend service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "queryFrontend service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "queryFrontend service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "queryFrontend service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for queryFrontend service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the queryFrontend service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "queryScheduler": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to queryScheduler nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for queryScheduler nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for queryScheduler nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of queryScheduler replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on queryScheduler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "minReadySeconds": {
+                    "type": "number",
+                    "description": "Minimum time to wait before performing readiness check",
+                    "default": 10
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on queryScheduler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on queryScheduler containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the queryScheduler containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the queryScheduler containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled queryScheduler pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set queryScheduler pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled queryScheduler containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set queryScheduler containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set queryScheduler containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the queryScheduler container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "queryScheduler pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for queryScheduler pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for queryScheduler pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `queryScheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `queryScheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `queryScheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `queryScheduler.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `queryScheduler.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for queryScheduler pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for queryScheduler pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for queryScheduler pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "queryScheduler pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "queryScheduler statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "queryScheduler statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the queryScheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the queryScheduler container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the queryScheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the queryScheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "queryScheduler service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "queryScheduler HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "queryScheduler GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "queryScheduler service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "queryScheduler service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "queryScheduler service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "queryScheduler service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for queryScheduler service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the queryScheduler service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ruler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy ruler component",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ruler nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ruler nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ruler nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Ruler replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Ruler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Ruler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Ruler containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ruler container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Ruler containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Ruler containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ruler pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Ruler pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ruler containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Ruler containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Ruler containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ruler pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ruler pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ruler pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ruler.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ruler.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for ruler pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Ruler pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Ruler pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Ruler pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ruler statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Ruler statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Ruler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the ruler container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Ruler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Ruler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Ruler instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Memcached data volume",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Memcached data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Ruler's data PVC",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ruler service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Ruler HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Ruler GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Ruler service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Ruler service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Ruler service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Ruler service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Ruler service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Ruler service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "tableManager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy table-manager",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to tableManager nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for tableManager nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for tableManager nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of table-manager replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on table-manager nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on table-manager nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on table-manager containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the tableManager containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the tableManager containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled table-manager pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set table-manager pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled table-manager containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set table-manager containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set table-manager containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the tableManager container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "tableManager pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for tableManager pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for tableManager pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `tableManager.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `tableManager.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `tableManager.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `tableManager.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `tableManager.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for table-manager pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for table-manager pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for table-manager pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "table-manager pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "table-manager statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "table-manager statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the table-manager pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the table-manager container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the table-manager pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the table-manager pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "table-manager service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "table-manager HTTP service port",
+                                    "default": 3100
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "table-manager GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "table-manager service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "table-manager service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "table-manager service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "table-manager service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for table-manager service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the table-manager service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "promtail": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy promtail",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Promtail image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Promtail image repository",
+                            "default": "bitnami/promtail"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Promtail image tag (immutable tags are recommended)",
+                            "default": "2.8.4-debian-11-r5"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Promtail image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Promtail image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana Promtail image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to promtail nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for promtail nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for promtail nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional container args (will be concatenated to args, unless diagnosticMode is enabled)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Promtail HTTP port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Promtail nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Promtail nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Promtail containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the promtail container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Promtail containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Promtail containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Promtail pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Promtail pod's Security Context fsGroup",
+                            "default": 0
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Promtail containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Promtail containers' Security Context runAsUser",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Promtail containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "promtail pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for promtail pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for promtail pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `promtail.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `promtail.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for promtail pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Promtail pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Promtail pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Promtail pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Promtail statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Promtail statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Promtail pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the promtail container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Promtail pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Promtail pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Promtail configuration",
+                    "default": "server:\n  log_level: {{ .Values.promtail.logLevel }}\n  http_listen_port: {{ .Values.promtail.containerPorts.http }}\n\nclients:\n  - url: http://{{ include \"grafana-loki.gateway.fullname\" . }}:{{ .Values.gateway.service.ports.http }}/loki/api/v1/push\n    {{- if .Values.gateway.auth.enabled }}\n    basic_auth:\n      # The username to use for basic auth\n      username: {{ .Values.gateway.auth.username }}\n      password_file: /bitnami/promtail/conf/secrets/password\n    {{- end }}\npositions:\n  filename: /run/promtail/positions.yaml\n\nscrape_configs:\n  # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference\n  - job_name: kubernetes-pods\n    pipeline_stages:\n      - cri: {}\n    kubernetes_sd_configs:\n      - role: pod\n    relabel_configs:\n      - source_labels:\n          - __meta_kubernetes_pod_controller_name\n        regex: ([0-9a-z-.]+?)(-[0-9a-f]{8,10})?\n        action: replace\n        target_label: __tmp_controller_name\n      - source_labels:\n          - __meta_kubernetes_pod_label_app_kubernetes_io_name\n          - __meta_kubernetes_pod_label_app\n          - __tmp_controller_name\n          - __meta_kubernetes_pod_name\n        regex: ^;*([^;]+)(;.*)?$\n        action: replace\n        target_label: app\n      - source_labels:\n          - __meta_kubernetes_pod_label_app_kubernetes_io_component\n          - __meta_kubernetes_pod_label_component\n        regex: ^;*([^;]+)(;.*)?$\n        action: replace\n        target_label: component\n      - action: replace\n        source_labels:\n        - __meta_kubernetes_pod_node_name\n        target_label: node_name\n      - action: replace\n        source_labels:\n        - __meta_kubernetes_namespace\n        target_label: namespace\n      - action: replace\n        replacement: $1\n        separator: /\n        source_labels:\n        - namespace\n        - app\n        target_label: job\n      - action: replace\n        source_labels:\n        - __meta_kubernetes_pod_name\n        target_label: pod\n      - action: replace\n        source_labels:\n        - __meta_kubernetes_pod_container_name\n        target_label: container\n      - action: replace\n        replacement: /var/log/pods/*$1/*.log\n        separator: /\n        source_labels:\n        - __meta_kubernetes_pod_uid\n        - __meta_kubernetes_pod_container_name\n        target_label: __path__\n      - action: replace\n        regex: true/(.*)\n        replacement: /var/log/pods/*$1/*.log\n        separator: /\n        source_labels:\n        - __meta_kubernetes_pod_annotationpresent_kubernetes_io_config_hash\n        - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash\n        - __meta_kubernetes_pod_container_name\n        target_label: __path__\n"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a Secret that contains the Promtail configuration",
+                    "default": ""
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Promtail logging level",
+                    "default": "info"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Promtail service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Promtail HTTP service port",
+                                    "default": 3100
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Promtail service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Promtail service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Promtail service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Promtail service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Promtail service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Promtail service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create RBAC rules",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable creation of ServiceAccount for Promtail pods",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the promtail.serviceAccount.created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Loki pods",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable metrics",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedChunks": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedchunks": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r61"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedFrontend": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedfrontend": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r61"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedIndexQueries": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedindexqueries": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r61"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedIndexWrites": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedindexwrites": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r61"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/grafana-mimir/values.schema.json
+++ b/bitnami/grafana-mimir/values.schema.json
@@ -1,0 +1,6203 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "mimir": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Mimir image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Mimir image repository",
+                            "default": "bitnami/grafana-mimir"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Mimir image tag (immutable tags are recommended)",
+                            "default": "2.9.0-debian-11-r72"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Mimir image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Mimir image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana Mimir image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "dataDir": {
+                    "type": "string",
+                    "description": "path to the Mimir data directory",
+                    "default": "/bitnami/grafana-mimir"
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Mimir components configuration",
+                    "default": "usage_stats:\n  installation_mode: helm\nactivity_tracker:\n  filepath: {{ .Values.mimir.dataDir }}/activity.log\nalertmanager_storage:\n  {{- if .Values.minio.enabled }}\n  backend: s3\n  s3:\n    access_key_id: ${MIMIR_MINIO_ACCESS_KEY_ID}\n    secret_access_key: ${MIMIR_MINIO_SECRET_ACCESS_KEY}\n    bucket_name: alertmanager\n    endpoint: \"{{ include \"grafana-mimir.minio.fullname\" . }}:{{ .Values.minio.service.ports.api }}\"\n    insecure: {{ not .Values.minio.tls.enabled }}\n  {{- else }}\n  backend: {{ .Values.alertmanager.blockStorage.backend }}\n  {{ .Values.alertmanager.blockStorage.backend }}:\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.alertmanager.blockStorage.config \"context\" $) | nindent 4 }}\n  {{- end }}\n# This configures how the store-gateway synchronizes blocks stored in the bucket. It uses Minio by default for getting started (configured via flags) but this should be changed for production deployments.\nblocks_storage:\n  bucket_store:\n    max_chunk_pool_bytes: 12884901888 # 12GiB\n    sync_dir: {{ .Values.mimir.dataDir }}/tsdb-sync\n    {{- if .Values.memcachedchunks.enabled }}\n    chunks_cache:\n      backend: memcached\n      memcached:\n        addresses: {{ include \"grafana-mimir.memcached-chunks.host\" . }}\n        timeout: 450ms\n    {{- end }}\n    {{- if .Values.memcachedindex.enabled }}\n    index_cache:\n      backend: memcached\n      memcached:\n        addresses: {{ include \"grafana-mimir.memcached-index.host\" . }}\n        timeout: 450ms\n    {{- end }}\n    {{- if .Values.memcachedmetadata.enabled }}\n    metadata_cache:\n      backend: memcached\n      memcached:\n        addresses: {{ include \"grafana-mimir.memcached-metadata.host\" . }}\n        timeout: 450ms\n    {{- end }}\n  {{- if .Values.minio.enabled }}\n  backend: s3\n  s3:\n    access_key_id: ${MIMIR_MINIO_ACCESS_KEY_ID}\n    secret_access_key: ${MIMIR_MINIO_SECRET_ACCESS_KEY}\n    bucket_name: mimir\n    endpoint: \"{{ include \"grafana-mimir.minio.fullname\" . }}:{{ .Values.minio.service.ports.api }}\"\n    insecure: {{ not .Values.minio.tls.enabled }}\n  {{- else }}\n  backend: {{ .Values.mimir.blockStorage.backend }}\n  {{ .Values.mimir.blockStorage.backend }}:\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.mimir.blockStorage.config \"context\" $) | nindent 4 }}\n  {{- end }}\n  tsdb:\n    dir: {{ .Values.mimir.dataDir }}/tsdb\ningester:\n  compaction_interval: 30m\n  deletion_delay: 2h\n  max_closing_blocks_concurrency: 2\n  max_opening_blocks_concurrency: 4\n  symbols_flushers_concurrency: 4\n  data_dir: {{ .Values.mimir.dataDir }}/ingester\n  sharding_ring:\n    wait_stability_min_duration: 1m\ncompactor:\n  data_dir: {{ .Values.mimir.dataDir }}/compactor\nfrontend:\n  parallelize_shardable_queries: true\n  {{- if .Values.memcachedfrontend.enabled }}\n  results_cache:\n    backend: memcached\n    memcached:\n      timeout: 500ms\n      addresses: {{ include \"grafana-mimir.memcached-frontend.host\" . }}\n  cache_results: true\n  {{- end }}\n  {{- if .Values.queryScheduler.enabled }}\n  scheduler_address: {{ template \"grafana-mimir.query-scheduler.fullname\" . }}-headless.{{ .Release.Namespace }}.svc:{{ .Values.queryScheduler.service.ports.grpc }}\n  {{- end }}\nfrontend_worker:\n  grpc_client_config:\n    max_send_msg_size: 419430400 # 400MiB\n  {{- if .Values.queryScheduler.enabled }}\n  scheduler_address: {{ template \"grafana-mimir.query-scheduler.fullname\" . }}-headless.{{ .Release.Namespace }}.svc:{{ .Values.queryScheduler.service.ports.grpc }}\n  {{- else }}\n  frontend_address: {{ template \"grafana-mimir.query-frontend.fullname\" . }}-headless.{{ .Release.Namespace }}.svc:{{ .Values.queryFrontend.service.ports.grpc }}\n  {{- end }}\ningester:\n  ring:\n    final_sleep: 0s\n    num_tokens: 512\n    tokens_file_path: {{ .Values.mimir.dataDir }}/tokens\n    unregister_on_shutdown: false\ningester_client:\n  grpc_client_config:\n    max_recv_msg_size: 104857600\n    max_send_msg_size: 104857600\nlimits:\n  # Limit queries to 500 days. You can override this on a per-tenant basis.\n  max_total_query_length: 12000h\n  # Adjust max query parallelism to 16x sharding, without sharding we can run 15d queries fully in parallel.\n  # With sharding we can further shard each day another 16 times. 15 days * 16 shards = 240 subqueries.\n  max_query_parallelism: 240\n  # Avoid caching results newer than 10m because some samples can be delayed\n  # This presents caching incomplete results\n  max_cache_freshness: 10m\nmemberlist:\n  abort_if_cluster_join_fails: false\n  compression_enabled: false\n  advertise_port: {{ .Values.mimir.containerPorts.gossipRing }}\n  bind_port: {{ .Values.mimir.containerPorts.gossipRing }}\n  join_members:\n  - dns+{{ include \"grafana-mimir.gossip-ring.fullname\" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.mimir.gossipRing.service.ports.http }}\nquerier:\n  # With query sharding we run more but smaller queries. We must strike a balance\n  # which allows us to process more sharded queries in parallel when requested, but not overload\n  # queriers during non-sharded queries.\n  max_concurrent: 16\nquery_scheduler:\n  # Increase from default of 100 to account for queries created by query sharding\n  max_outstanding_requests_per_tenant: 800\nserver:\n  grpc_server_max_concurrent_streams: 1000\n  grpc_server_max_connection_age: 2m\n  grpc_server_max_connection_age_grace: 5m\n  grpc_server_max_connection_idle: 1m\n  http_listen_port: {{ .Values.mimir.containerPorts.http }}\n  grpc_listen_port: {{ .Values.mimir.containerPorts.grpc }}\napi:\n  alertmanager_http_prefix: {{ .Values.mimir.httpPrefix.alertmanager }}\n  prometheus_http_prefix: {{ .Values.mimir.httpPrefix.prometheus }}\nstore_gateway:\n  sharding_ring:\n    wait_stability_min_duration: 1m\n    tokens_file_path: {{ .Values.mimir.dataDir }}/tokens\n{{- if .Values.ruler.enabled }}\nruler:\n  alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.{{ include \"grafana-mimir.alertmanager.fullname\" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}/alertmanager\n  enable_api: true\n  rule_path: {{ .Values.mimir.dataDir }}/ruler\nruler_storage:\n  {{- if .Values.minio.enabled }}\n  backend: s3\n  s3:\n    access_key_id: ${MIMIR_MINIO_ACCESS_KEY_ID}\n    secret_access_key: ${MIMIR_MINIO_SECRET_ACCESS_KEY}\n    bucket_name: ruler\n    endpoint: \"{{ include \"grafana-mimir.minio.fullname\" . }}:{{ .Values.minio.service.ports.api }}\"\n    insecure: {{ not .Values.minio.tls.enabled }}\n  {{- else }}\n  backend: {{ .Values.ruler.blockStorage.backend }}\n  {{ .Values.ruler.blockStorage.backend }}:\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.ruler.blockStorage.config \"context\" $) | nindent 4 }}\n  {{- end }}\n{{- end }}\n{{- if .Values.alertmanager.enabled }}\nalertmanager:\n  data_dir: {{ .Values.mimir.dataDir }}/alert-manager\n  enable_api: true\n  external_url: {{ .Values.mimir.httpPrefix.prometheus }}\n{{- if .Values.minio.enabled }}\nalertmanager_storage:\n  backend: s3\n  s3:\n    access_key_id: ${MIMIR_MINIO_ACCESS_KEY_ID}\n    secret_access_key: ${MIMIR_MINIO_SECRET_ACCESS_KEY}\n    bucket_name: ruler\n    endpoint: \"{{ include \"grafana-mimir.minio.fullname\" . }}:{{ .Values.minio.service.ports.api }}\"\n    insecure: {{ not .Values.minio.tls.enabled }}\n{{- end }}\n{{- end }}\n"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap with the Mimir configuration",
+                    "default": ""
+                },
+                "httpPrefix": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "string",
+                            "description": "HTTP URL path under which the Prometheus api will be served.",
+                            "default": "/prometheus"
+                        },
+                        "alertmanager": {
+                            "type": "string",
+                            "description": "HTTP URL path under which the Alertmanager ui and api will be served.",
+                            "default": "/alertmanager"
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Grafana Mimir HTTP container port. This configuration is set mimir.yaml config file and is common for all Grafana Mimir components.",
+                            "default": 8080
+                        },
+                        "grpc": {
+                            "type": "number",
+                            "description": "Grafana Mimir GRPC container port. This configuration is set mimir.yaml config file and is common for all Grafana Mimircomponents.",
+                            "default": 9095
+                        },
+                        "gossipRing": {
+                            "type": "number",
+                            "description": "Grafana Mimir memberlist container port. This configuration is set mimir.yaml config file and is common for all Grafana Mimir components.",
+                            "default": 7946
+                        }
+                    }
+                },
+                "gossipRing": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Gossip Ring HTTP headless service port",
+                                            "default": 7946
+                                        }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Gossip Ring headless service",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "blockStorage": {
+                    "type": "object",
+                    "properties": {
+                        "backend": {
+                            "type": "string",
+                            "description": "Backend storage to use. NOTE: if minio.enable == true, this configuration will be ignored.",
+                            "default": "s3"
+                        },
+                        "config": {
+                            "type": "object",
+                            "description": "Configures connection to the backend store. NOTE: if minio.enable == true, this configuration will be ignored.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "alertmanager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable alertmanager deployment",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to alertmanager nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for alertmanager nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for alertmanager nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Alertmanager replicas to deploy",
+                    "default": 1
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+                    "default": "OrderedReady"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Alertmanager nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Alertmanager nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Alertmanager containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the alertmanager containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the alertmanager containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Alertmanager pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Alertmanager pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Alertmanager containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Alertmanager containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Alertmanager containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `alertmanager.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `alertmanager.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `alertmanager.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `alertmanager.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `alertmanager.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Alertmanager pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Alertmanager pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Alertmanager pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Alertmanager pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Alertmanager statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Alertmanager statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Alertmanager pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Alertmanager container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Alertmanager pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Alertmanager pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in alertmanager instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for alertmanager data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for alertmanager data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for alertmanager's data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Alertmanager service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Alertmanager HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Alertmanager GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Alertmanager service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Alertmanager service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Alertmanager service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Alertmanager service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Alertmanager service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Alertmanager service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "blockStorage": {
+                    "type": "object",
+                    "properties": {
+                        "backend": {
+                            "type": "string",
+                            "description": "Backend storage to use. NOTE: if minio.enable == true, this configuration will be ignored.",
+                            "default": "s3"
+                        },
+                        "config": {
+                            "type": "object",
+                            "description": "Configures connection to the backend store. NOTE: if minio.enable == true, this configuration will be ignored.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "compactor": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to compactor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for compactor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for compactor nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Compactor replicas to deploy",
+                    "default": 1
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+                    "default": "OrderedReady"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Compactor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Compactor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Compactor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the compactor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the compactor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Compactor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Compactor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Compactor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Compactor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Compactor containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the compactor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "compactor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for compactor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for compactor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `compactor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `compactor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Compactor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Compactor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Compactor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Compactor pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Compactor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Compactor statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Compactor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Compactor instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Compactor data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Compactor data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Compactor's data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Compactor service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Compactor HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Compactor GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Compactor service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Compactor service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Compactor service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Compactor service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Compactor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Compactor service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "distributor": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to distributor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for distributor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for distributor nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Distributor replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Distributor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Distributor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Distributor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the distributor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the distributor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Distributor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Distributor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Distributor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Distributor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Distributor containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the distributor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "distributor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for distributor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for distributor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `distributor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `distributor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Distributor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Distributor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Distributor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Distributor pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Distributor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Distributor statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Distributor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Distributor service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Distributor HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Distributor GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Distributor service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Distributor service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Distributor service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Distributor service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Distributor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Distributor service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Gateway deployment",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Nginx image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Nginx image repository",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Nginx image tag (immutable tags are recommended)",
+                            "default": "1.25.2-debian-11-r17"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Nginx image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Nginx image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Nginx image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable debugging in the initialization process",
+                            "default": false
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to gateway nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for gateway nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for gateway nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "verboseLogging": {
+                    "type": "boolean",
+                    "description": "Show the gateway access_log",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Gateway replicas to deploy",
+                    "default": 1
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable basic auth",
+                            "default": false
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Basic auth username",
+                            "default": "user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Basic auth password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of a secret containing the Basic auth password",
+                            "default": ""
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Gateway containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Gateway HTTP port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the gateway containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the gateway containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Gateway pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Gateway pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Gateway containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Gateway containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Gateway containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the gateway container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "gateway pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for gateway pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for gateway pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `gateway.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `gateway.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Gateway pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Gateway pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Gateway pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Gateway pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Gateway statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Gateway statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Gateway container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Gateway service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Gateway HTTP service port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Gateway service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Gateway service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Gateway service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Gateway service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Gateway service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Gateway service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Mimir Gateway",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "grafana-mimir.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "ingester": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingester nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Ingester replicas to deploy",
+                    "default": 2
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+                    "default": "OrderedReady"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Ingester nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Ingester nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Ingester containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the ingester containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the ingester containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ingester pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Ingester pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ingester containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Ingester containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Ingester containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ingester.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ingester.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Ingester pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Ingester pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Ingester pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Ingester pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingester statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Ingester statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Ingester container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Ingester instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Ingester data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Ingester data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Ingester's data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingester service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Ingester HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Ingester GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Ingester service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Ingester service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Ingester service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Ingester service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Ingester service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Ingester service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "overridesExporter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable overrides-exporter deployment",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to overrides-exporter nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for overrides-exporter nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for overrides-exporter nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Overrides Exporter replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Overrides Exporter nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Overrides Exporter nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Overrides Exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the overrides-exporter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the overrides-exporter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Overrides Exporter pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Overrides Exporter pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Overrides Exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Overrides Exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Overrides Exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `overridesExporter.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `overridesExporter.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `overridesExporter.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `overridesExporter.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `overridesExporter.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Overrides Exporter pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Overrides Exporter pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Overrides Exporter pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Overrides Exporter pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Overrides Exporter statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Overrides Exporter statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Overrides Exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Overrides Exporter container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Overrides Exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Overrides Exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Overrides Exporter service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Overrides Exporter HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Overrides Exporter GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Overrides Exporter service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Overrides Exporter service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Overrides Exporter service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Overrides Exporter service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Overrides Exporter service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Overrides Export service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "querier": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to querier nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for querier nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for querier nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Querier replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Querier nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Querier nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Querier containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the querier containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the querier containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Querier pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Querier pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Querier containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Querier containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Querier containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `querier.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `querier.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Querier pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Querier pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Querier pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Querier pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Querier statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Querier statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Querier container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Querier service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Querier HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Querier GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Querier service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Querier service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Querier service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Querier service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Querier service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Querier service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "queryFrontend": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingester nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Query Frontend replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Query Frontend nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Query Frontend nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Query Frontend containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the ingester containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the ingester containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Query Frontend pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Query Frontend pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Query Frontend containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Query Frontend containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Query Frontend containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `queryFrontend.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `queryFrontend.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Query Frontend pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Query Frontend pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Query Frontend pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Query Frontend pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Query Frontend statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Query Frontend statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Query Frontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Query Frontend container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Query Frontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Query Frontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Query Frontend service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Query Frontend HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Query Frontend GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Query Frontend service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Query Frontend service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Query Frontend service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Query Frontend service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Query Frontend service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Query Frontend service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "queryScheduler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable query-scheduler deployment",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to query-scheduler nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for query-scheduler nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for query-scheduler nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Query Scheduler replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Query Scheduler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Query Scheduler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Query Scheduler containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the query-scheduler containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the query-scheduler containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Query Scheduler pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Query Scheduler pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Query Scheduler containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Query Scheduler containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Query Scheduler containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `queryScheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `queryScheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `queryScheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `queryScheduler.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `queryScheduler.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Query Scheduler pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Query Scheduler pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Query Scheduler pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Query Scheduler pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Query Scheduler statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Query Scheduler statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Query Scheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Query Scheduler container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Query Scheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Query Scheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Query Scheduler service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Query Scheduler HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Query Scheduler GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Query Scheduler service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Query Scheduler service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Query Scheduler service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Query Scheduler service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Query Scheduler service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Query Scheduler service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "storeGateway": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingester nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Store Gateway replicas to deploy",
+                    "default": 1
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+                    "default": "OrderedReady"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Store Gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Store Gateway nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Store Gateway containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the ingester containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the ingester containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Store Gateway pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Store Gateway pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Store Gateway containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Store Gateway containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Store Gateway containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `storeGateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `storeGateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `storeGateway.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `storeGateway.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `storeGateway.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Store Gateway pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Store Gateway pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Store Gateway pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Store Gateway pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Store Gateway statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Store Gateway statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Store Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Store Gateway container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Store Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Store Gateway pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Store Gateway instances",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Store Gateway data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Store Gateway data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Store Gateway's data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Store Gateway service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Store Gateway HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Store Gateway GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Node port for GRPC",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Store Gateway service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Store Gateway service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Store Gateway service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Store Gateway service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Store Gateway service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Store Gateway service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "ruler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy ruler component",
+                    "default": false
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ruler nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ruler nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ruler nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Add additional args to the default container args (useful to override configuration)",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Ruler replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Ruler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Ruler nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Ruler containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ruler container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Ruler containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Ruler containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ruler pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Ruler pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ruler containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Ruler containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Ruler containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ruler pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ruler pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ruler pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ruler.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ruler.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for ruler pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Ruler pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Ruler pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Ruler pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ruler statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Ruler statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Ruler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the ruler container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Ruler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Ruler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Ruler instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Ruler data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Ruler data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Ruler's data PVC",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ruler service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Ruler HTTP service port",
+                                    "default": 8080
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Ruler GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Ruler service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Ruler service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Ruler service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Ruler service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Ruler service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Ruler service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "blockStorage": {
+                    "type": "object",
+                    "properties": {
+                        "backend": {
+                            "type": "string",
+                            "description": "Backend storage to use. NOTE: if minio.enable == true, this configuration will be ignored.",
+                            "default": "s3"
+                        },
+                        "config": {
+                            "type": "object",
+                            "description": "Configures connection to the backend store. NOTE: if minio.enable == true, this configuration will be ignored.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "minio": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable MinIO&reg; chart installation",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootUser": {
+                            "type": "string",
+                            "description": "MinIO&reg; root username",
+                            "default": "admin"
+                        },
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for MinIO&reg; root user",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret containing the MinIO&reg; credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "defaultBuckets": {
+                    "type": "string",
+                    "description": "Comma, semi-colon or space separated list of MinIO&reg; buckets to create",
+                    "default": "mimir, ruler, alertmanager"
+                },
+                "provisioning": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable MinIO&reg; provisioning job",
+                            "default": true
+                        },
+                        "extraCommands": {
+                            "type": "array",
+                            "description": "Extra commands to run on MinIO&reg; provisioning job",
+                            "default": [
+                                "mc anonymous set download provisioning/mimir",
+                                "mc anonymous set download provisioning/ruler",
+                                "mc anonymous set download provisioning/alertmanager"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable MinIO&reg; TLS support",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MinIO&reg; service type",
+                            "default": "ClusterIP"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "MinIO&reg; service LoadBalancer IP",
+                            "default": ""
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "api": {
+                                    "type": "number",
+                                    "description": "MinIO&reg; service port",
+                                    "default": 80
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedChunks": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedchunks": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r76"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedFrontend": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedfrontend": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r76"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedIndex": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedindex": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r76"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcachedMetadata": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcachedmetadata": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached image repository",
+                            "default": "bitnami/memcached"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached image tag (immutable tags are recommended)",
+                            "default": "1.6.21-debian-11-r76"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Memcached architecture",
+                    "default": "high-availability"
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "override the subchart name",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/grafana-operator/values.schema.json
+++ b/bitnami/grafana-operator/values.schema.json
@@ -1,0 +1,1119 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template with a string",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common Labels which are applied to every resource deployed",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common Annotations which are applied to every ressource deployed",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "operator": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the deployment of the Grafana Operator",
+                    "default": true
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the grafana-operator container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of grafana-operator Pod replicas",
+                    "default": 1
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Grafana Operator pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Grafana Operator container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Grafana Operator pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Grafana Operator pods",
+                    "default": [],
+                    "items": {}
+                },
+                "namespaceScope": {
+                    "type": "boolean",
+                    "description": "If the operator should run in namespace-scope mode or not,",
+                    "default": false
+                },
+                "watchNamespace": {
+                    "type": "string",
+                    "description": "Override the namespace to watch",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "%%MAIN_CONTAINER_NAME%% pods' priorityClassName",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set up update strategy for Grafana Operator installation.",
+                            "default": "Recreate"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Operator image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Operator image name",
+                            "default": "bitnami/grafana-operator"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Operator image tag",
+                            "default": "5.4.0-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Operator image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Operator image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana Operator image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "leaderElect": {
+                    "type": "boolean",
+                    "description": "Enables or disables the operator leader Election.",
+                    "default": true
+                },
+                "zapDevel": {
+                    "type": "boolean",
+                    "description": "Enable zap development mode (changes defaults to console encoder, debug log level, disables sampling and stacktrace from 'warning' level)",
+                    "default": false
+                },
+                "zapEncoder": {
+                    "type": "string",
+                    "description": "Zap log encoding ('json' or 'console')",
+                    "default": ""
+                },
+                "zapLevel": {
+                    "type": "string",
+                    "description": "Zap log level (one of 'debug', 'info', 'error' or any integer value > 0) (default info)",
+                    "default": ""
+                },
+                "zapSample": {
+                    "type": "string",
+                    "description": "Enable zap log sampling. Sampling will be disabled for integer log levels > 1",
+                    "default": ""
+                },
+                "zapStacktraceLevel": {
+                    "type": "string",
+                    "description": "Set the minimum log level that triggers stacktrace generation (default error)",
+                    "default": ""
+                },
+                "zapTimeEncoding": {
+                    "type": "string",
+                    "description": "Sets the zap time format ('epoch', 'millis', 'nano', or 'iso8601') (default )",
+                    "default": ""
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Extra arguments for the grafana operator (Evaluated as a template)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create specifies whether to install and use RBAC rules",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a service account should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Add annotations",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable pods security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the pods",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "User ID for the pods",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Grafana Operator must run as nonRoot",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pods",
+                            "default": 1001
+                        },
+                        "supplementalGroups": {
+                            "type": "array",
+                            "description": "Which group IDs containers add",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the operator container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "User ID for the operator container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non-root",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Decide if the container runs privileged.",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "ReadOnlyRootFilesystem fot the operator container",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Allow Privilege Escalation for the operator container",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Container resource requests and limits",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Grafana Operator container port (used for metrics)",
+                            "default": 8080
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to RabbitMQ Cluster Operator nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for RabbitMQ Cluster Operator nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for RabbitMQ Cluster Operator nodes",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Set nodeAffinity preset key",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Set nodeAffinity preset values",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for controller pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for controller pod assignment",
+                    "default": {}
+                },
+                "prometheus": {
+                    "type": "object",
+                    "properties": {
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Specify if a ServiceMonitor will be deployed for prometheus-operator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "Specify the jobLabel to use for the prometheus-operator",
+                                    "default": "app.kubernetes.io/name"
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Scrape interval. If not set, the Prometheus default scrape interval is used",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                }
+            }
+        },
+        "grafana": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled the deployment of the Grafana CRD object into the cluster",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana image name",
+                            "default": "bitnami/grafana"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana image tag",
+                            "default": "10.1.1-debian-11-r2"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "description": "Additional service account configuration",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable pods security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the pods",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "User ID for the pods",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Grafana Operator must run as nonRoot",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pods",
+                            "default": 1001
+                        },
+                        "supplementalGroups": {
+                            "type": "array",
+                            "description": "Which group IDs containers add",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable containers security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the containers",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the containers",
+                            "default": 0
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Decide if the container runs privileged.",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to run as non-root",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Don't allow privilege escalation for the containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Mount / (root) as a readonly filesystem",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Specify the amount of replicas running",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set nodeAffinity preset type",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Set nodeAffinity preset key",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Set nodeAffinity preset values",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for controller pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for controller pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for controller pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "envFrom": {
+                    "type": "array",
+                    "description": "Extra environment variable to pass to the running container",
+                    "default": [],
+                    "items": {}
+                },
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "timeout": {
+                            "type": "number",
+                            "description": "The timeout in seconds for the Grafana Rest API on that instance",
+                            "default": 5
+                        }
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Add additional labels to the grafana deployment, service and ingress resources",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Grafana service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Grafana service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If an ingress or OpenShift Route should be created",
+                            "default": false
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "host": {
+                            "type": "string",
+                            "description": "The host under which the grafana instance should be reachable. If empty the parameter will not be set.",
+                            "default": "grafana.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The path for the ingress instance to forward to the grafana app",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "The pathType for the ingress instance to forward to the grafana app",
+                            "default": "ImplementationSpecific"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional Labels for the ingress resource",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Annotations for the ingress resource",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "This enables tls support for the ingress resource",
+                            "default": false
+                        },
+                        "tlsSecret": {
+                            "type": "string",
+                            "description": "The name for the secret to use for the tls termination",
+                            "default": "grafana.local-tls"
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistent storage for the grafana deployment",
+                            "default": false
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Define the storageClass for the persistent storage if not defined default is used",
+                            "default": ""
+                        },
+                        "existingVolume": {
+                            "type": "string",
+                            "description": "Define the existingVolume for the persistent storage provisioned outside this chart",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Define the accessModes for the persistent storage",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Add annotations to the persistent volume",
+                            "default": {}
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Define the size of the PersistentVolumeClaim to request for",
+                            "default": "10Gi"
+                        }
+                    }
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "root_url": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{- if .Values.grafana.ingress.enabled }}\n{{ if .Values.grafana.ingress.tls }}https{{ else }}http{{ end }}://{{ include \"common.tplvalues.render\" (dict \"value\" .Values.grafana.ingress.host \"context\" $) }}\n{{- else }}\nhttp://localhost:3000\n{{- end }}"
+                                }
+                            }
+                        },
+                        "log": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "console"
+                                },
+                                "level": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "warn"
+                                }
+                            }
+                        },
+                        "database": {
+                            "type": "object",
+                            "properties": {
+                                "wal": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                }
+                            }
+                        },
+                        "analytics": {
+                            "type": "object",
+                            "properties": {
+                                "reporting_enabled": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "false"
+                                },
+                                "check_for_updates": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "false"
+                                }
+                            }
+                        },
+                        "security": {
+                            "type": "object",
+                            "properties": {
+                                "disable_gravatar": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "false"
+                                }
+                            }
+                        }
+                    }
+                },
+                "jsonnetLibrarySelector": {
+                    "type": "object",
+                    "properties": {
+                        "matchLabels": {
+                            "type": "object",
+                            "properties": {
+                                "app": {
+                                    "type": "object",
+                                    "properties": {
+                                        "kubernetes": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/instance": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Release.Name }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "description": "Set up update strategy for Grafana installation.",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the grafana pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the grafana container",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Optionally specify a list of secrets to be mounted to the grafana pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the grafana pod(s)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/grafana-tempo/values.schema.json
+++ b/bitnami/grafana-tempo/values.schema.json
@@ -1,0 +1,3734 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployments/statefulsets",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployments/statefulsets",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "tempo": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Tempo image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Tempo image repository",
+                            "default": "bitnami/grafana-tempo"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Tempo image tag (immutable tags are recommended)",
+                            "default": "2.1.1-debian-11-r84"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Tempo image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Tempo image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana Tempo image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "memBallastSizeMbs": {
+                    "type": "number",
+                    "description": "Tempo components memory ballast size in MB",
+                    "default": 1024
+                },
+                "dataDir": {
+                    "type": "string",
+                    "description": "Tempo components data directory",
+                    "default": "/bitnami/grafana-tempo/data"
+                },
+                "traces": {
+                    "type": "object",
+                    "properties": {
+                        "jaeger": {
+                            "type": "object",
+                            "properties": {
+                                "grpc": {
+                                    "type": "boolean",
+                                    "description": "Enable Tempo to ingest Jaeger GRPC traces",
+                                    "default": true
+                                },
+                                "thriftBinary": {
+                                    "type": "boolean",
+                                    "description": "Enable Tempo to ingest Jaeger Thrift Binary traces",
+                                    "default": false
+                                },
+                                "thriftCompact": {
+                                    "type": "boolean",
+                                    "description": "Enable Tempo to ingest Jaeger Thrift Compact traces",
+                                    "default": false
+                                },
+                                "thriftHttp": {
+                                    "type": "boolean",
+                                    "description": "Enable Tempo to ingest Jaeger Thrift HTTP traces",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "otlp": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "boolean",
+                                    "description": "Enable Tempo to ingest Open Telemetry HTTP traces",
+                                    "default": false
+                                },
+                                "grpc": {
+                                    "type": "boolean",
+                                    "description": "Enable Tempo to ingest Open Telemetry GRPC traces",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "opencensus": {
+                            "type": "boolean",
+                            "description": "Enable Tempo to ingest Open Census traces",
+                            "default": false
+                        },
+                        "zipkin": {
+                            "type": "boolean",
+                            "description": "Enable Tempo to ingest Zipkin traces",
+                            "default": false
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Tempo components configuration",
+                    "default": "multitenancy_enabled: false\ncompactor:\n  compaction:\n    block_retention: 48h\n  ring:\n    kvstore:\n      store: memberlist\ndistributor:\n  ring:\n    kvstore:\n      store: memberlist\n  receivers:\n    {{- if  or (.Values.tempo.traces.jaeger.thriftCompact) (.Values.tempo.traces.jaeger.thriftBinary) (.Values.tempo.traces.jaeger.thriftHttp) (.Values.tempo.traces.jaeger.grpc) }}\n    jaeger:\n      protocols:\n        {{- if .Values.tempo.traces.jaeger.thriftCompact }}\n        thrift_compact:\n          endpoint: 0.0.0.0:6831\n        {{- end }}\n        {{- if .Values.tempo.traces.jaeger.thriftBinary }}\n        thrift_binary:\n          endpoint: 0.0.0.0:6832\n        {{- end }}\n        {{- if .Values.tempo.traces.jaeger.thriftHttp }}\n        thrift_http:\n          endpoint: 0.0.0.0:14268\n        {{- end }}\n        {{- if .Values.tempo.traces.jaeger.grpc }}\n        grpc:\n          endpoint: 0.0.0.0:14250\n        {{- end }}\n    {{- end }}\n    {{- if .Values.tempo.traces.zipkin }}\n    zipkin:\n      endpoint: 0.0.0.0:9411\n    {{- end }}\n    {{- if or (.Values.tempo.traces.otlp.http) (.Values.tempo.traces.otlp.grpc) }}\n    otlp:\n      protocols:\n        {{- if .Values.tempo.traces.otlp.http }}\n        http:\n          endpoint: 0.0.0.0:55681\n        {{- end }}\n        {{- if .Values.tempo.traces.otlp.grpc }}\n        grpc:\n          endpoint: 0.0.0.0:4317\n        {{- end }}\n    {{- end }}\n    {{- if .Values.tempo.traces.opencensus }}\n    opencensus:\n      endpoint: 0.0.0.0:55678\n    {{- end }}\nquerier:\n  frontend_worker:\n    frontend_address: {{ include \"grafana-tempo.query-frontend.fullname\" . }}-headless:{{ .Values.queryFrontend.service.ports.grpc }}\ningester:\n  lifecycler:\n    ring:\n      replication_factor: 1\n      kvstore:\n        store: memberlist\n    tokens_file_path: {{ .Values.tempo.dataDir }}/tokens.json\nmetrics_generator:\n  ring:\n    kvstore:\n      store: memberlist\n  storage:\n    path: {{ .Values.tempo.dataDir }}/wal\n    remote_write: {{ include \"common.tplvalues.render\" (dict \"value\" .Values.metricsGenerator.remoteWrite \"context\" $) | nindent 6 }}\nmemberlist:\n  abort_if_cluster_join_fails: false\n  join_members:\n    - {{ include \"grafana-tempo.gossip-ring.fullname\" . }}\noverrides:\n  per_tenant_override_config: /bitnami/grafana-tempo/conf/overrides.yaml\nserver:\n  http_listen_port: {{ .Values.tempo.containerPorts.web }}\nstorage:\n  trace:\n    backend: local\n    blocklist_poll: 5m\n    local:\n      path: {{ .Values.tempo.dataDir }}/traces\n    wal:\n      path: {{ .Values.tempo.dataDir }}/wal\n    cache: memcached\n    memcached:\n      consistent_hash: true\n      host: {{ include \"grafana-tempo.memcached.url\" . }}\n      service: memcache\n      timeout: 500ms\n"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap with the Tempo configuration",
+                    "default": ""
+                },
+                "overridesConfiguration": {
+                    "type": "string",
+                    "description": "Tempo components overrides configuration settings",
+                    "default": "overrides: {}\n"
+                },
+                "existingOverridesConfigmap": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap with the tempo overrides configuration",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "web": {
+                            "type": "number",
+                            "description": "Tempo components web container port",
+                            "default": 3200
+                        },
+                        "grpc": {
+                            "type": "number",
+                            "description": "Tempo components GRPC container port",
+                            "default": 9095
+                        },
+                        "gossipRing": {
+                            "type": "number",
+                            "description": "Tempo components Gossip Ring container port",
+                            "default": 7946
+                        }
+                    }
+                },
+                "gossipRing": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Gossip Ring HTTP headless service port",
+                                            "default": 7946
+                                        }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Gossip Ring headless service",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "compactor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Compactor deployment",
+                    "default": true
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to compactor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for compactor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for compactor nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Compactor replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Compactor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 80
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Compactor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 80
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Compactor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the compactor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the compactor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Compactor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Compactor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Compactor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Compactor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Compactor containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the compactor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "compactor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for compactor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for compactor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `compactor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `compactor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Compactor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Compactor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Compactor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Compactor pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Compactor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Compactor statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Compactor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Compactor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Compactor service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Compactor HTTP service port",
+                                    "default": 3200
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Compactor service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Compactor service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Compactor service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Compactor service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Compactor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Compactor service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "distributor": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to distributor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for distributor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for distributor nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Distributor replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Distributor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Distributor nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Distributor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the distributor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the distributor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Distributor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Distributor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Distributor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Distributor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Distributor containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the distributor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "distributor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for distributor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for distributor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `distributor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `distributor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Distributor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Distributor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Distributor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Distributor pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Distributor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Distributor statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Distributor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Distributor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Distributor service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Distributor HTTP service port",
+                                    "default": 3200
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Distributor GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Distributor service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Distributor service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Distributor service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Distributor service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Distributor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Distributor service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metricsGenerator": {
+            "type": "object",
+            "properties": {
+                "remoteWrite": {
+                    "type": "array",
+                    "description": "remoteWrite configuration for metricsGenerator",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to metricsGenerator nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for metricsGenerator nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for metricsGenerator nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of metricsGenerator replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on metricsGenerator nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on metricsGenerator nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on metricsGenerator containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the metricsGenerator containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the metricsGenerator containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled metricsGenerator pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set metricsGenerator pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled metricsGenerator containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set metricsGenerator containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set metricsGenerator containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the metricsGenerator container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "metricsGenerator pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for metricsGenerator pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for metricsGenerator pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `metricsGenerator.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `metricsGenerator.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `metricsGenerator.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `metricsGenerator.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `metricsGenerator.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for metricsGenerator pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for metricsGenerator pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for metricsGenerator pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "object",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "metricsGenerator pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "metricsGenerator statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "metricsGenerator statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the metricsGenerator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the metricsGenerator container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the metricsGenerator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the metricsGenerator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "metricsGenerator service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "metricsGenerator HTTP service port",
+                                    "default": 3200
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "metricsGenerator GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "metricsGenerator service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "metricsGenerator service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "metricsGenerator service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "metricsGenerator service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for metricsGenerator service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the metricsGenerator service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingester": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingester nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingester nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Ingester replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Ingester nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Ingester nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Ingester containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingester container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Ingester containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Ingester containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ingester pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Ingester pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Ingester containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Ingester containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Ingester containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingester pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingester pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingester pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ingester.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ingester.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for ingester pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Ingester pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Ingester pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Ingester pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingester statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Ingester statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the ingester container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Ingester pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence in Ingester instances",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Memcached data volume",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Memcached data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional PVC annotations",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Ingester's data PVC",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingester service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Ingester HTTP service port",
+                                    "default": 3200
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Ingester GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Ingester service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Ingester service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Ingester service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Ingester service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Ingester service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Ingester service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "querier": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Querier replicas to deploy",
+                    "default": 1
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Querier nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Querier nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Querier nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Querier nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Querier nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Querier containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Querier containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Querier containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Querier pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Querier pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Querier containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Querier containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Querier containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Querier container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "querier pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for querier pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for querier pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `querier.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `querier.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Querier pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Querier pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Querier pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Querier pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Querier statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Querier statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the querier container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Querier pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Querier service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Querier HTTP service port",
+                                    "default": 3200
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Querier GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Querier service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Querier service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Querier service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Querier service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Querier service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Querier service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "queryFrontend": {
+            "type": "object",
+            "properties": {
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to queryFrontend nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for queryFrontend nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for queryFrontend nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of queryFrontend replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on queryFrontend nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on queryFrontend nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on queryFrontend containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the queryFrontend containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the queryFrontend containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled queryFrontend pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set queryFrontend pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled queryFrontend containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set queryFrontend containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set queryFrontend containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the queryFrontend container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "queryFrontend pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for queryFrontend pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for queryFrontend pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `queryFrontend.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `queryFrontend.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for queryFrontend pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for queryFrontend pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for queryFrontend pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "queryFrontend pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "queryFrontend statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "queryFrontend statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the queryFrontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the queryFrontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the queryFrontend pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "query": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Grafana Tempo Query image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Grafana Tempo Query image repository",
+                                    "default": "bitnami/grafana-tempo-query"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Grafana Tempo Query image tag (immutable tags are recommended)",
+                                    "default": "2.1.1-debian-11-r87"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Grafana Tempo Query image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Grafana Tempo Query image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Grafana Tempo Query image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "configuration": {
+                            "type": "string",
+                            "description": "Query sidecar configuration",
+                            "default": "backend: 127.0.0.1:{{ .Values.tempo.containerPorts.web }}\n"
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "jaegerMetrics": {
+                                    "type": "number",
+                                    "description": "queryFrontend query sidecar Jaeger metrics container port",
+                                    "default": 16687
+                                },
+                                "jaegerUI": {
+                                    "type": "number",
+                                    "description": "queryFrontend query sidecar Jaeger UI container port",
+                                    "default": 16686
+                                }
+                            }
+                        },
+                        "existingConfigmap": {
+                            "type": "string",
+                            "description": "Name of a configmap with the query configuration",
+                            "default": ""
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add to queryFrontend nodes",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "Name of existing ConfigMap containing extra env vars for queryFrontend nodes",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Name of existing Secret containing extra env vars for queryFrontend nodes",
+                            "default": ""
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on Query sidecar nodes",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 3
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on Query sidecar nodes",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 3
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on Query sidecar containers",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 30
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 15
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "for the query sidecar container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled queryFrontend query sidecar containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set queryFrontend query sidecar containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set queryFrontend query sidecar containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the query sidecar containers",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the query sidecar containers",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "queryFrontend service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "queryFrontend HTTP service port",
+                                    "default": 3200
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "queryFrontend GRPC service port",
+                                    "default": 9095
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Node port for GRPC",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "queryFrontend service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "queryFrontend service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "queryFrontend service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "queryFrontend service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for queryFrontend service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the queryFrontend service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "vulture": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable vulture deployment",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Vulture image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Vulture image repository",
+                            "default": "bitnami/grafana-tempo-vulture"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Vulture image tag (immutable tags are recommended)",
+                            "default": "2.1.1-debian-11-r84"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Vulture image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Vulture image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana Vulture image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to vulture nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for vulture nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for vulture nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Vulture replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Vulture nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Vulture nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Vulture containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Vulture containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Vulture containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Vulture pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Vulture pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Vulture containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Vulture containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Vulture containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the vulture container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "vulture pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for vulture pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for vulture pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `vulture.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `vulture.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Vulture components HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Vulture pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Vulture pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Vulture pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Vulture pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Vulture statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Vulture statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Vulture pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Vulture container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Vulture pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Vulture pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Vulture service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Vulture HTTP service port",
+                                    "default": 3200
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Vulture service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Vulture service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Vulture service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Vulture service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Vulture service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Vulture service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r16"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Tempo pods",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable metrics",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "externalMemcached": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a running external memcached instance",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of a running external memcached instance",
+                    "default": 11211
+                }
+            }
+        },
+        "memcached": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy memcached sub-chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Memcached authentication",
+                            "default": false
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Memcached admin user",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Memcached admin password",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "memcached": {
+                                    "type": "number",
+                                    "description": "Memcached service port",
+                                    "default": 11211
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/grafana/values.schema.json
+++ b/bitnami/grafana/values.schema.json
@@ -1,0 +1,1631 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override grafana.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override grafana.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Grafana image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Grafana image repository",
+                    "default": "bitnami/grafana"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Grafana image tag (immutable tags are recommended)",
+                    "default": "10.1.1-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Grafana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Grafana image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Grafana image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "admin": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string",
+                    "description": "Grafana admin username",
+                    "default": "admin"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Admin password. If a password is not provided a random password will be generated",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing admin password",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Password key on the existing secret",
+                    "default": "password"
+                }
+            }
+        },
+        "smtp": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable SMTP configuration",
+                    "default": false
+                },
+                "user": {
+                    "type": "string",
+                    "description": "SMTP user",
+                    "default": "user"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "SMTP password",
+                    "default": "password"
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Custom host for the smtp server",
+                    "default": ""
+                },
+                "fromAddress": {
+                    "type": "string",
+                    "description": "From address",
+                    "default": ""
+                },
+                "fromName": {
+                    "type": "string",
+                    "description": "From name",
+                    "default": ""
+                },
+                "skipVerify": {
+                    "type": "string",
+                    "description": "Enable skip verify",
+                    "default": "false"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of existing secret containing SMTP credentials (user and password)",
+                    "default": ""
+                },
+                "existingSecretUserKey": {
+                    "type": "string",
+                    "description": "User key on the existing secret",
+                    "default": "user"
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Password key on the existing secret",
+                    "default": "password"
+                }
+            }
+        },
+        "plugins": {
+            "type": "string",
+            "description": "Grafana plugins to be installed in deployment time separated by commas",
+            "default": ""
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP for Grafana",
+                    "default": false
+                },
+                "allowSignUp": {
+                    "type": "boolean",
+                    "description": "Allows LDAP sign up for Grafana",
+                    "default": false
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Specify content for ldap.toml configuration file",
+                    "default": ""
+                },
+                "configMapName": {
+                    "type": "string",
+                    "description": "Name of the ConfigMap with the ldap.toml configuration file for Grafana",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Name of the Secret with the ldap.toml configuration file for Grafana",
+                    "default": ""
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "Server URI, eg. ldap://ldap_server:389",
+                    "default": ""
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "DN of the account used to search in the LDAP server.",
+                    "default": ""
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "Password for binddn account.",
+                    "default": ""
+                },
+                "basedn": {
+                    "type": "string",
+                    "description": "Base DN path where binddn account will search for the users.",
+                    "default": ""
+                },
+                "searchAttribute": {
+                    "type": "string",
+                    "description": "Field used to match with the user name (uid, samAccountName, cn, etc). This value will be ignored if 'ldap.searchFilter' is set",
+                    "default": "uid"
+                },
+                "searchFilter": {
+                    "type": "string",
+                    "description": "User search filter, for example \"(cn=%s)\" or \"(sAMAccountName=%s)\" or \"(|(sAMAccountName=%s)(userPrincipalName=%s)\"",
+                    "default": ""
+                },
+                "extraConfiguration": {
+                    "type": "string",
+                    "description": "Extra ldap configuration.",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled TLS configuration.",
+                            "default": false
+                        },
+                        "startTls": {
+                            "type": "boolean",
+                            "description": "Use STARTTLS instead of LDAPS.",
+                            "default": false
+                        },
+                        "skipVerify": {
+                            "type": "boolean",
+                            "description": "Skip any SSL verification (hostanames or certificates)",
+                            "default": false
+                        },
+                        "certificatesMountPath": {
+                            "type": "string",
+                            "description": "Where LDAP certifcates are mounted.",
+                            "default": "/opt/bitnami/grafana/conf/ldap/"
+                        },
+                        "certificatesSecret": {
+                            "type": "string",
+                            "description": "Secret with LDAP certificates.",
+                            "default": ""
+                        },
+                        "CAFilename": {
+                            "type": "string",
+                            "description": "CA certificate filename. Should match with the CA entry key in the ldap.tls.certificatesSecret.",
+                            "default": ""
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "Client certificate filename to authenticate against the LDAP server. Should match with certificate the entry key in the ldap.tls.certificatesSecret.",
+                            "default": ""
+                        },
+                        "certKeyFilename": {
+                            "type": "string",
+                            "description": "Client Key filename to authenticate against the LDAP server. Should match with certificate the entry key in the ldap.tls.certificatesSecret.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "useGrafanaIniFile": {
+                    "type": "boolean",
+                    "description": "Allows to load a `grafana.ini` file",
+                    "default": false
+                },
+                "grafanaIniConfigMap": {
+                    "type": "string",
+                    "description": "Name of the ConfigMap containing the `grafana.ini` file",
+                    "default": ""
+                },
+                "grafanaIniSecret": {
+                    "type": "string",
+                    "description": "Name of the Secret containing the `grafana.ini` file",
+                    "default": ""
+                }
+            }
+        },
+        "dashboardsProvider": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the use of a Grafana dashboard provider",
+                    "default": false
+                },
+                "configMapName": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing a custom dashboard provider",
+                    "default": ""
+                }
+            }
+        },
+        "dashboardsConfigMaps": {
+            "type": "array",
+            "description": "Array with the names of a series of ConfigMaps containing dashboards files",
+            "default": [],
+            "items": {}
+        },
+        "datasources": {
+            "type": "object",
+            "properties": {
+                "secretName": {
+                    "type": "string",
+                    "description": "The name of an externally-managed secret containing custom datasource files.",
+                    "default": ""
+                },
+                "secretDefinition": {
+                    "type": "object",
+                    "description": "The contents of a secret defining a custom datasource file. Only used if datasources.secretName is empty or not defined.",
+                    "default": {}
+                }
+            }
+        },
+        "notifiers": {
+            "type": "object",
+            "properties": {
+                "configMapName": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing Grafana notifiers configuration",
+                    "default": ""
+                }
+            }
+        },
+        "grafana": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Grafana nodes",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set up update strategy for Grafana installation.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Grafana pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class name",
+                    "default": ""
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Grafana pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Grafana Pod annotations",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "grafana": {
+                            "type": "number",
+                            "description": "Grafana container port",
+                            "default": 3000
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable securityContext on for Grafana deployment",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group to configure permissions for volumes",
+                            "default": 1001
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User for the security context",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Run containers as non-root users",
+                            "default": true
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Grafana Image Renderer containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Grafana Image Renderer containers' Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Grafana containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Grafana containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path for livenessProbe",
+                            "default": "/api/health"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "Scheme for livenessProbe",
+                            "default": "HTTP"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path for readinessProbe",
+                            "default": "/api/health"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "Scheme for readinessProbe",
+                            "default": "HTTP"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path for readinessProbe",
+                            "default": "/api/health"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "Scheme for readinessProbe",
+                            "default": "HTTP"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Grafana container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Attach additional sidecar containers to the Grafana pod",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Grafana pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Additional volumes for the Grafana pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Additional volume mounts for the Grafana container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Grafana nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Grafana nodes",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure Grafana",
+                    "default": [],
+                    "items": {}
+                },
+                "extraConfigmaps": {
+                    "type": "array",
+                    "description": "Array to mount extra ConfigMaps to configure Grafana",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessMode": {
+                    "type": "string",
+                    "description": "Persistent Volume Access Mode",
+                    "default": "ReadWriteOnce"
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Storage class to use with the PVC",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "If you want to reuse an existing claim, you can pass the name of the PVC using the existingClaim variable",
+                    "default": ""
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size for the PV",
+                    "default": "10Gi"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the ServiceAccount Metadata",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the application controller service account",
+                    "default": false
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Grafana service Cluster IP",
+                    "default": ""
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "grafana": {
+                            "type": "number",
+                            "description": "Grafana service port",
+                            "default": 3000
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "grafana": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        }
+                    }
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP if Grafana service type is `LoadBalancer` (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "loadBalancerSourceRanges if Grafana service type is `LoadBalancer` (optional, cloud specific)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations which may be required.",
+                    "default": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Grafana service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Redmine service",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the ingress is enabled, a host pointing to this will be created",
+                    "default": "grafana.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress resource",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "It is also possible to create and manage the certificates outside of this helm chart",
+                    "default": [],
+                    "items": {}
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "3000"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Labels to honor to add to the scrape endpoint",
+                            "default": false
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional custom labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "PrometheusRule rules to configure",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "imageRenderer": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable using a remote rendering service to render PNG images",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Grafana Image Renderer image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Grafana Image Renderer image repository",
+                            "default": "bitnami/grafana-image-renderer"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Grafana Image Renderer image tag (immutable tags are recommended)",
+                            "default": "3.8.0-debian-11-r5"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Grafana Image Renderer image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Grafana Image Renderer image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Grafana image Renderer pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Grafana Image Renderer Pod replicas",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Grafana Image Renderer deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Grafana Image Renderer Pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Grafana Image Renderer pods",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Grafana Image Renderer pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Grafana Image Renderer pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Grafana Image Renderer pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure Grafana",
+                    "default": [],
+                    "items": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Grafana containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Grafana containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable securityContext on for Grafana Image Renderer deployment",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group to configure permissions for volumes",
+                            "default": 1001
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User for the security context",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Run containers as non-root users",
+                            "default": true
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Grafana Image Renderer containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Grafana Image Renderer containers' Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Grafana service Cluster IP",
+                            "default": ""
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "imageRenderer": {
+                                    "type": "number",
+                                    "description": "Grafana Image Renderer metrics port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "grafana": {
+                                    "type": "string",
+                                    "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if Grafana service type is `LoadBalancer` (optional, cloud specific)",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "loadBalancerSourceRanges if Grafana service type is `LoadBalancer` (optional, cloud specific)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required.",
+                            "default": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Grafana service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on Redmine service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "8080"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": false
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "prometheusRule": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                                    "default": ""
+                                },
+                                "additionalLabels": {
+                                    "type": "object",
+                                    "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                                    "default": {}
+                                },
+                                "rules": {
+                                    "type": "array",
+                                    "description": "Prometheus Rule definitions",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Grafana Image Renderer pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Grafana Image Renderer pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Grafana Image Renderer nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Grafana Image Renderer nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Grafana Image Renderer pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Grafana Image Renderer container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Grafana Image Renderer container(s) to automate configuration before or after startup",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r54"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/haproxy/values.schema.json
+++ b/bitnami/haproxy/values.schema.json
@@ -1,0 +1,708 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "haproxy service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "protocol": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": ""
+                            },
+                            "targetPort": {
+                                "type": "string",
+                                "description": ""
+                            }
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "haproxy service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "haproxy service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "haproxy service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "haproxy service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for haproxy service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Additional custom labels for haproxy service",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for haproxy",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "haproxy.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "HAProxy image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "HAProxy image repository",
+                    "default": "bitnami/haproxy"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "HAProxy image tag (immutable tags are recommended)",
+                    "default": "2.8.3-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "HAProxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "HAProxy image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "HAProxy image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of haproxy replicas to deploy",
+            "default": 1
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on haproxy nodes",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 15
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on haproxy nodes",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 15
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on haproxy nodes",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 15
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the haproxy containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the haproxy containers",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled haproxy pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set haproxy pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled haproxy containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set haproxy containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set haproxy container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for HAProxy",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of HAProxy replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of HAProxy replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "haproxy pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for haproxy pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for haproxy pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "configuration": {
+            "type": "string",
+            "description": "haproxy configuration",
+            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n  log global\n  timeout client 60s\n  timeout connect 60s\n  timeout server 60s\nfrontend fe_main\n  bind :8080\n  default_backend be_main\nbackend be_main\n  server web1 10.0.0.1:8080 check\n"
+        },
+        "containerPorts": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "containerPort": {
+                        "type": "number",
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "configmap with HAProxy configuration",
+            "default": ""
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for haproxy pods assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for haproxy pods assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for haproxy pods assignment",
+            "default": [],
+            "items": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "haproxy statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "haproxy pods' priorityClassName",
+            "default": ""
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the haproxy container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to haproxy nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for haproxy nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for haproxy nodes",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the haproxy pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the haproxy container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the haproxy pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the haproxy pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/harbor/values.schema.json
+++ b/bitnami/harbor/values.schema.json
@@ -1,0 +1,5863 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template with a string",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "adminPassword": {
+            "type": "string",
+            "description": "The initial password of Harbor admin. Change it from portal after launching Harbor",
+            "default": ""
+        },
+        "externalURL": {
+            "type": "string",
+            "description": "The external URL for Harbor Core service",
+            "default": "https://core.harbor.domain"
+        },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "httpProxy": {
+                    "type": "string",
+                    "description": "The URL of the HTTP proxy server",
+                    "default": ""
+                },
+                "httpsProxy": {
+                    "type": "string",
+                    "description": "The URL of the HTTPS proxy server",
+                    "default": ""
+                },
+                "noProxy": {
+                    "type": "string",
+                    "description": "The URLs that the proxy settings not apply to",
+                    "default": "127.0.0.1,localhost,.local,.internal"
+                },
+                "components": {
+                    "type": "array",
+                    "description": "The component list that the proxy settings apply to",
+                    "default": [
+                        "core",
+                        "jobservice",
+                        "trivy"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "logLevel": {
+            "type": "string",
+            "description": "The log level used for Harbor services. Allowed values are [ fatal \\| error \\| warn \\| info \\| debug \\| trace ]",
+            "default": "debug"
+        },
+        "internalTLS": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Use TLS in all the supported containers: core, jobservice, portal, registry and trivy",
+                    "default": false
+                },
+                "caBundleSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret with a custom CA that will be injected into the trust store for core, jobservice, registry, trivy components",
+                    "default": ""
+                }
+            }
+        },
+        "ipFamily": {
+            "type": "object",
+            "properties": {
+                "ipv6": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable listening on IPv6 ([::]) for NGINX-based components (NGINX,portal)",
+                            "default": true
+                        }
+                    }
+                },
+                "ipv4": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable listening on IPv4 for NGINX-based components (NGINX,portal)",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "exposureType": {
+            "type": "string",
+            "description": "The way to expose Harbor. Allowed values are [ ingress \\| proxy ]",
+            "default": "proxy"
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "NGINX proxy service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "NGINX proxy service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "NGINX proxy service HTTPS port",
+                            "default": 443
+                        },
+                        "notary": {
+                            "type": "number",
+                            "description": "Notary service port",
+                            "default": 4443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        },
+                        "notary": {
+                            "type": "string",
+                            "description": "Node port for Notary",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "NGINX proxy service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "NGINX proxy service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "NGINX proxy service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "NGINX proxy service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for NGINX proxy service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on NGINX proxy service",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "core": {
+                    "type": "object",
+                    "properties": {
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "controller": {
+                            "type": "string",
+                            "description": "The ingress controller type. Currently supports `default`, `gce` and `ncp`",
+                            "default": "default"
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "core.harbor.domain"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "ingress": {
+                                    "type": "object",
+                                    "properties": {
+                                        "kubernetes": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/ssl-redirect": {
+                                                    "type": "object",
+                                                    "description": "",
+                                                    "default": {
+                                                        "ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "ingress.kubernetes.io/proxy-body-size": "0",
+                                                        "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                    }
+                                                },
+                                                "io/proxy-body-size": {
+                                                    "type": "object",
+                                                    "description": "",
+                                                    "default": {
+                                                        "ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "ingress.kubernetes.io/proxy-body-size": "0",
+                                                        "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "nginx": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ingress": {
+                                            "type": "object",
+                                            "properties": {
+                                                "kubernetes": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "io/ssl-redirect": {
+                                                            "type": "object",
+                                                            "description": "",
+                                                            "default": {
+                                                                "ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "ingress.kubernetes.io/proxy-body-size": "0",
+                                                                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                            }
+                                                        },
+                                                        "io/proxy-body-size": {
+                                                            "type": "object",
+                                                            "description": "",
+                                                            "default": {
+                                                                "ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "ingress.kubernetes.io/proxy-body-size": "0",
+                                                                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.core.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "notary": {
+                    "type": "object",
+                    "properties": {
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "controller": {
+                            "type": "string",
+                            "description": "The ingress controller type. Currently supports `default`, `gce` and `ncp`",
+                            "default": "default"
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "notary.harbor.domain"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "ingress": {
+                                    "type": "object",
+                                    "properties": {
+                                        "kubernetes": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/ssl-redirect": {
+                                                    "type": "object",
+                                                    "description": "",
+                                                    "default": {
+                                                        "ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "ingress.kubernetes.io/proxy-body-size": "0",
+                                                        "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                    }
+                                                },
+                                                "io/proxy-body-size": {
+                                                    "type": "object",
+                                                    "description": "",
+                                                    "default": {
+                                                        "ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "ingress.kubernetes.io/proxy-body-size": "0",
+                                                        "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                        "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "nginx": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ingress": {
+                                            "type": "object",
+                                            "properties": {
+                                                "kubernetes": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "io/ssl-redirect": {
+                                                            "type": "object",
+                                                            "description": "",
+                                                            "default": {
+                                                                "ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "ingress.kubernetes.io/proxy-body-size": "0",
+                                                                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                            }
+                                                        },
+                                                        "io/proxy-body-size": {
+                                                            "type": "object",
+                                                            "description": "",
+                                                            "default": {
+                                                                "ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "ingress.kubernetes.io/proxy-body-size": "0",
+                                                                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                                                                "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the data persistence or not",
+                    "default": true
+                },
+                "resourcePolicy": {
+                    "type": "string",
+                    "description": "Setting it to `keep` to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                    "default": "keep"
+                },
+                "persistentVolumeClaim": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "object",
+                            "properties": {
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing PVC to use",
+                                    "default": ""
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class for Harbor Registry data volume",
+                                    "default": ""
+                                },
+                                "subPath": {
+                                    "type": "string",
+                                    "description": "The sub path used in the volume",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "The access mode of the volume",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "The size of the volume",
+                                    "default": "5Gi"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the PVC",
+                                    "default": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Selector to match an existing Persistent Volume",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "jobservice": {
+                            "type": "object",
+                            "properties": {
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing PVC to use",
+                                    "default": ""
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class for Harbor Jobservice data volume",
+                                    "default": ""
+                                },
+                                "subPath": {
+                                    "type": "string",
+                                    "description": "The sub path used in the volume",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "The access mode of the volume",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "The size of the volume",
+                                    "default": "1Gi"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the PVC",
+                                    "default": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Selector to match an existing Persistent Volume",
+                                    "default": {}
+                                },
+                                "scanData": {
+                                    "type": "object",
+                                    "properties": {
+                                        "existingClaim": {
+                                            "type": "string",
+                                            "description": "Name of an existing PVC to use",
+                                            "default": ""
+                                        },
+                                        "storageClass": {
+                                            "type": "string",
+                                            "description": "PVC Storage Class for Harbor Jobservice scan data volume",
+                                            "default": ""
+                                        },
+                                        "subPath": {
+                                            "type": "string",
+                                            "description": "The sub path used in the volume",
+                                            "default": ""
+                                        },
+                                        "accessModes": {
+                                            "type": "array",
+                                            "description": "The access mode of the volume",
+                                            "default": [
+                                                "ReadWriteOnce"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "size": {
+                                            "type": "string",
+                                            "description": "The size of the volume",
+                                            "default": "1Gi"
+                                        },
+                                        "annotations": {
+                                            "type": "object",
+                                            "description": "Annotations for the PVC",
+                                            "default": {}
+                                        },
+                                        "selector": {
+                                            "type": "object",
+                                            "description": "Selector to match an existing Persistent Volume",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trivy": {
+                            "type": "object",
+                            "properties": {
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class for Trivy data volume",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "The access mode of the volume",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "The size of the volume",
+                                    "default": "5Gi"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the PVC",
+                                    "default": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Selector to match an existing Persistent Volume",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "imageChartStorage": {
+                    "type": "object",
+                    "properties": {
+                        "caBundleSecret": {
+                            "type": "string",
+                            "description": "Specify the `caBundleSecret` if the storage service uses a self-signed certificate. The secret must contain keys named `ca.crt` which will be injected into the trust store  of registry's containers.",
+                            "default": ""
+                        },
+                        "disableredirect": {
+                            "type": "boolean",
+                            "description": "The configuration for managing redirects from content backends. For backends which do not supported it (such as using MinIO&reg; for `s3` storage type), please set it to `true` to disable redirects. Refer to the [guide](https://github.com/docker/distribution/blob/master/docs/configuration.md#redirect) for more information about the detail",
+                            "default": false
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "The type of storage for images and charts: `filesystem`, `azure`, `gcs`, `s3`, `swift` or `oss`. The type must be `filesystem` if you want to use persistent volumes for registry. Refer to the [guide](https://github.com/docker/distribution/blob/master/docs/configuration.md#storage) for more information about the detail",
+                            "default": "filesystem"
+                        },
+                        "filesystem": {
+                            "type": "object",
+                            "properties": {
+                                "rootdirectory": {
+                                    "type": "string",
+                                    "description": "Filesystem storage type setting: Storage root directory",
+                                    "default": "/storage"
+                                },
+                                "maxthreads": {
+                                    "type": "string",
+                                    "description": "Filesystem storage type setting: Maximum threads directory",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "azure": {
+                            "type": "object",
+                            "properties": {
+                                "accountname": {
+                                    "type": "string",
+                                    "description": "Azure storage type setting: Name of the Azure account",
+                                    "default": "accountname"
+                                },
+                                "accountkey": {
+                                    "type": "string",
+                                    "description": "Azure storage type setting: Key of the Azure account",
+                                    "default": "base64encodedaccountkey"
+                                },
+                                "container": {
+                                    "type": "string",
+                                    "description": "Azure storage type setting: Container",
+                                    "default": "containername"
+                                },
+                                "storagePrefix": {
+                                    "type": "string",
+                                    "description": "Azure storage type setting: Storage prefix",
+                                    "default": "/azure/harbor/charts"
+                                },
+                                "realm": {
+                                    "type": "string",
+                                    "description": "Azure storage type setting: Realm of the Azure account",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "gcs": {
+                            "type": "object",
+                            "properties": {
+                                "bucket": {
+                                    "type": "string",
+                                    "description": "GCS storage type setting: Bucket name",
+                                    "default": "bucketname"
+                                },
+                                "encodedkey": {
+                                    "type": "string",
+                                    "description": "GCS storage type setting: Base64 encoded key",
+                                    "default": ""
+                                },
+                                "rootdirectory": {
+                                    "type": "string",
+                                    "description": "GCS storage type setting: Root directory name",
+                                    "default": ""
+                                },
+                                "chunksize": {
+                                    "type": "string",
+                                    "description": "GCS storage type setting: Chunk size name",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "s3": {
+                            "type": "object",
+                            "properties": {
+                                "region": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Region",
+                                    "default": "us-west-1"
+                                },
+                                "bucket": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Bucket name",
+                                    "default": "bucketname"
+                                },
+                                "accesskey": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Access key name",
+                                    "default": ""
+                                },
+                                "secretkey": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Secret Key name",
+                                    "default": ""
+                                },
+                                "regionendpoint": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Region Endpoint",
+                                    "default": ""
+                                },
+                                "encrypt": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Encrypt",
+                                    "default": ""
+                                },
+                                "keyid": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Key ID",
+                                    "default": ""
+                                },
+                                "secure": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Secure",
+                                    "default": ""
+                                },
+                                "skipverify": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: TLS skip verification",
+                                    "default": ""
+                                },
+                                "v4auth": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: V4 authorization",
+                                    "default": ""
+                                },
+                                "chunksize": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: V4 authorization",
+                                    "default": ""
+                                },
+                                "rootdirectory": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Root directory name",
+                                    "default": ""
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: Storage class",
+                                    "default": ""
+                                },
+                                "sse": {
+                                    "type": "string",
+                                    "description": "S3 storage type setting: SSE name",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "swift": {
+                            "type": "object",
+                            "properties": {
+                                "authurl": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Authentication url",
+                                    "default": "https://storage.myprovider.com/v3/auth"
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Authentication url",
+                                    "default": ""
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Password",
+                                    "default": ""
+                                },
+                                "container": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Container",
+                                    "default": ""
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Region",
+                                    "default": ""
+                                },
+                                "tenant": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Tenant",
+                                    "default": ""
+                                },
+                                "tenantid": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: TenantID",
+                                    "default": ""
+                                },
+                                "domain": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Domain",
+                                    "default": ""
+                                },
+                                "domainid": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: DomainID",
+                                    "default": ""
+                                },
+                                "trustid": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: TrustID",
+                                    "default": ""
+                                },
+                                "insecureskipverify": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Verification",
+                                    "default": ""
+                                },
+                                "chunksize": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Chunk",
+                                    "default": ""
+                                },
+                                "prefix": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Prefix",
+                                    "default": ""
+                                },
+                                "secretkey": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Secre Key",
+                                    "default": ""
+                                },
+                                "accesskey": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Access Key",
+                                    "default": ""
+                                },
+                                "authversion": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Auth",
+                                    "default": ""
+                                },
+                                "endpointtype": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Endpoint",
+                                    "default": ""
+                                },
+                                "tempurlcontainerkey": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Temp URL container key",
+                                    "default": ""
+                                },
+                                "tempurlmethods": {
+                                    "type": "string",
+                                    "description": "Swift storage type setting: Temp URL methods",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "oss": {
+                            "type": "object",
+                            "properties": {
+                                "accesskeyid": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Access key ID",
+                                    "default": ""
+                                },
+                                "accesskeysecret": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Access key secret name containing the token",
+                                    "default": ""
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Region name",
+                                    "default": ""
+                                },
+                                "bucket": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Bucket name",
+                                    "default": ""
+                                },
+                                "endpoint": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Endpoint",
+                                    "default": ""
+                                },
+                                "internal": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Internal",
+                                    "default": ""
+                                },
+                                "encrypt": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Encrypt",
+                                    "default": ""
+                                },
+                                "secure": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Secure",
+                                    "default": ""
+                                },
+                                "chunksize": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Chunk",
+                                    "default": ""
+                                },
+                                "rootdirectory": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Directory",
+                                    "default": ""
+                                },
+                                "secretkey": {
+                                    "type": "string",
+                                    "description": "OSS storage type setting: Secret key",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "tracing": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable tracing",
+                    "default": false
+                },
+                "sampleRate": {
+                    "type": "number",
+                    "description": "Tracing sample rate from 0 to 1",
+                    "default": 1
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Used to differentiate traces between different harbor services",
+                    "default": ""
+                },
+                "attributes": {
+                    "type": "object",
+                    "description": "A key value dict containing user defined attributes used to initialize the trace provider",
+                    "default": {}
+                },
+                "jaeger": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable jaeger export",
+                            "default": false
+                        },
+                        "endpoint": {
+                            "type": "string",
+                            "description": "Jaeger endpoint",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Jaeger username",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Jaeger password",
+                            "default": ""
+                        },
+                        "agentHost": {
+                            "type": "string",
+                            "description": "Jaeger agent hostname",
+                            "default": ""
+                        },
+                        "agentPort": {
+                            "type": "string",
+                            "description": "Jaeger agent port",
+                            "default": ""
+                        }
+                    }
+                },
+                "otel": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable otel export",
+                            "default": false
+                        },
+                        "endpoint": {
+                            "type": "string",
+                            "description": "The hostname and port for an otel compatible backend",
+                            "default": "hostname:4318"
+                        },
+                        "urlpath": {
+                            "type": "string",
+                            "description": "Url path of otel endpoint",
+                            "default": "/v1/traces"
+                        },
+                        "compression": {
+                            "type": "boolean",
+                            "description": "Enable data compression",
+                            "default": false
+                        },
+                        "timeout": {
+                            "type": "string",
+                            "description": "The timeout for data transfer",
+                            "default": "10s"
+                        },
+                        "insecure": {
+                            "type": "boolean",
+                            "description": "Ignore cert verification for otel backend",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r28"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable init container Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "nginx": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "NGINX image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "NGINX image repository",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "NGINX image tag (immutable tags are recommended)",
+                            "default": "1.25.1-debian-11-r48"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "NGINX image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "NGINX image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable NGINX image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS termination",
+                            "default": true
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret name containing your own TLS certificates.",
+                            "default": ""
+                        },
+                        "commonName": {
+                            "type": "string",
+                            "description": "The common name used to generate the self-signed TLS certificates",
+                            "default": "core.harbor.domain"
+                        }
+                    }
+                },
+                "behindReverseProxy": {
+                    "type": "boolean",
+                    "description": "If NGINX is behind another reverse proxy, set to true",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add NGINX pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for NGINX pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for NGINX pods",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "NGINX HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "NGINX HTTPS container port",
+                            "default": 8443
+                        },
+                        "notary": {
+                            "type": "number",
+                            "description": "NGINX container port where Notary svc is exposed",
+                            "default": 4443
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of NGINX replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on NGINX containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on NGINX containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on NGINX containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the NGINX containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the NGINX containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled NGINX pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set NGINX pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled NGINX containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set NGINX containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set NGINX containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "NGINX deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the NGINX container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "NGINX pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the NGINX pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the NGINX pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "NGINX Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "NGINX Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "NGINX Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "NGINX Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "NGINX Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "NGINX Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "NGINX Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "NGINX Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the NGINX pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the NGINX pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the NGINX pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the NGINX pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "portal": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Harbor Portal image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Harbor Portal image repository",
+                            "default": "bitnami/harbor-portal"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Harbor Portal image tag (immutable tags are recommended)",
+                            "default": "2.8.3-debian-11-r6"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Harbor Portal image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Harbor Portal image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Harbor Portal image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Harbor Portal image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret with the certificates for internal TLS access",
+                            "default": ""
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Harbor Portal pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Harbor Portal pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Portal pods",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Harbor Portal HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Harbor Portal HTTPS container port",
+                            "default": 8443
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Harbor Portal replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Harbor Portal containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Harbor Portal containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Harbor Portal containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Harbor Portal containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Harbor Portal containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Portal pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Harbor Portal pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Portal containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Harbor Portal containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Harbor Portal containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Portal deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the Harbor Portal container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Harbor Portal pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the Harbor Portal pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the Harbor Portal pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Portal Pod affinity preset. Ignored if `portal.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Portal Pod anti-affinity preset. Ignored if `portal.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Portal Node affinity preset type. Ignored if `portal.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Harbor Portal Node label key to match Ignored if `portal.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Harbor Portal Node label values to match. Ignored if `portal.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Harbor Portal Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Harbor Portal Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Harbor Portal Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Harbor Portal pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Harbor Portal pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Harbor Portal pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Harbor Portal pods",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Harbor Portal HTTP service port",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Harbor Portal HTTPS service port",
+                                    "default": 443
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "core": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Harbor Core image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Harbor Core image repository",
+                            "default": "bitnami/harbor-core"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Harbor Core image tag (immutable tags are recommended)",
+                            "default": "2.8.3-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Harbor Core image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Harbor Core image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Harbor Core image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Harbor Core image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "sessionLifetime": {
+                    "type": "string",
+                    "description": "Explicitly set a session timeout (in seconds) overriding the backend default.",
+                    "default": ""
+                },
+                "uaaSecret": {
+                    "type": "string",
+                    "description": "If using external UAA auth which has a self signed cert, you can provide a pre-created secret containing it under the key `ca.crt`.",
+                    "default": ""
+                },
+                "secretKey": {
+                    "type": "string",
+                    "description": "The key used for encryption. Must be a string of 16 chars",
+                    "default": ""
+                },
+                "secret": {
+                    "type": "string",
+                    "description": "Secret used when the core server communicates with other components. If a secret key is not specified, Helm will generate one. Must be a string of 16 chars.",
+                    "default": ""
+                },
+                "tokenKey": {
+                    "type": "string",
+                    "description": "Key of the certificate used for token encryption/decryption.",
+                    "default": ""
+                },
+                "tokenCert": {
+                    "type": "string",
+                    "description": "Certificate used for token encryption/decryption.",
+                    "default": ""
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Fill the name of a kubernetes secret if you want to use your own TLS certificate and private key for token encryption/decryption. The secret must contain two keys named: `tls.crt` - the certificate and `tls.key` - the private key. The default key pair will be used if it isn't set",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret for core",
+                    "default": ""
+                },
+                "existingEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Existing secret for core envvars",
+                    "default": ""
+                },
+                "csrfKey": {
+                    "type": "string",
+                    "description": "The CSRF key. Will be generated automatically if it isn't specified",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret with the certificates for internal TLS access",
+                            "default": ""
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Harbor Core pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Harbor Core pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Core pods",
+                    "default": ""
+                },
+                "configOverwriteJson": {
+                    "type": "string",
+                    "description": "String containing a JSON with configuration overrides",
+                    "default": ""
+                },
+                "configOverwriteJsonSecret": {
+                    "type": "string",
+                    "description": "Secret containing the JSON configuration overrides",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Harbor Core HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Harbor Core HTTPS container port",
+                            "default": 8443
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Harbor Core metrics container port",
+                            "default": 8001
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Harbor Core replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Harbor Core containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Harbor Core containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Harbor Core containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Harbor Core containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Harbor Core containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Core pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Harbor Core pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Core containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Harbor Core containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Harbor Core containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Core deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the Harbor Core container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Harbor Core pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the Harbor Core pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the Harbor Core pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Core Pod affinity preset. Ignored if `core.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Core Pod anti-affinity preset. Ignored if `core.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Core Node affinity preset type. Ignored if `core.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Harbor Core Node label key to match Ignored if `core.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Harbor Core Node label values to match. Ignored if `core.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Harbor Core Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Harbor Core Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Harbor Core Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Harbor Core pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Harbor Core pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Harbor Core pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Harbor Core pods",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Harbor Core HTTP service port",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Harbor Core HTTPS service port",
+                                    "default": 443
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Harbor Core metrics service port",
+                                    "default": 8001
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "jobservice": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Harbor Jobservice image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Harbor Jobservice image repository",
+                            "default": "bitnami/harbor-jobservice"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Harbor Jobservice image tag (immutable tags are recommended)",
+                            "default": "2.8.3-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Harbor Jobservice image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Harbor Jobservice image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Harbor Jobservice image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Harbor Jobservice image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "maxJobWorkers": {
+                    "type": "number",
+                    "description": "The max job workers",
+                    "default": 10
+                },
+                "redisNamespace": {
+                    "type": "string",
+                    "description": "Redis namespace for jobservice",
+                    "default": "harbor_job_service_namespace"
+                },
+                "jobLogger": {
+                    "type": "string",
+                    "description": "The logger for jobs: `file`, `database` or `stdout`",
+                    "default": "file"
+                },
+                "secret": {
+                    "type": "string",
+                    "description": "Secret used when the job service communicates with other components. If a secret key is not specified, Helm will generate one. Must be a string of 16 chars.",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret for jobservice",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret with the certificates for internal TLS access",
+                            "default": ""
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Harbor Jobservice pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Harbor Jobservice pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Jobservice pods",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Harbor Jobservice HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Harbor Jobservice HTTPS container port",
+                            "default": 8443
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Harbor Jobservice metrics container port",
+                            "default": 8001
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Harbor Jobservice replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Harbor Jobservice containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Harbor Jobservice containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Harbor Jobservice containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Harbor Jobservice containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Harbor Jobservice containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Jobservice pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Harbor Jobservice pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Jobservice containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Harbor Jobservice containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Harbor Jobservice containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Jobservice deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the Harbor Jobservice container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Harbor Jobservice pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the Harbor Jobservice pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the Harbor Jobservice pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Jobservice Pod affinity preset. Ignored if `jobservice.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Jobservice Pod anti-affinity preset. Ignored if `jobservice.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Jobservice Node affinity preset type. Ignored if `jobservice.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Harbor Jobservice Node label key to match Ignored if `jobservice.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Harbor Jobservice Node label values to match. Ignored if `jobservice.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Harbor Jobservice Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Harbor Jobservice Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Harbor Jobservice Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Harbor Jobservice pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Harbor Jobservice pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Harbor Jobservice pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Harbor Jobservice pods",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Harbor Jobservice HTTP service port",
+                                    "default": 80
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Harbor Jobservice HTTPS service port",
+                                    "default": 443
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Harbor Jobservice HTTPS service port",
+                                    "default": 8001
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "secret": {
+                    "type": "string",
+                    "description": "Secret is used to secure the upload state from client and registry storage backend. See: <https://github.com/docker/distribution/blob/master/docs/configuration.md>",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret for registry",
+                    "default": ""
+                },
+                "relativeurls": {
+                    "type": "boolean",
+                    "description": "Make the registry return relative URLs in Location headers. The client is responsible for resolving the correct URL.",
+                    "default": false
+                },
+                "credentials": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "The username for accessing the registry instance, which is hosted by htpasswd auth mode.  More details see [official docs](https://github.com/docker/distribution/blob/master/docs/configuration.md#htpasswd)",
+                            "default": "harbor_registry_user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "The password for accessing the registry instance, which is hosted by htpasswd auth mode.  More details see [official docs](https://github.com/docker/distribution/blob/master/docs/configuration.md#htpasswd). It is suggested you update this value before installation.",
+                            "default": "harbor_registry_password"
+                        },
+                        "htpasswd": {
+                            "type": "string",
+                            "description": "The content of htpasswd file based on the value of `registry.credentials.username` `registry.credentials.password`.  Currently `helm` does not support bcrypt in the template script, if the credential is updated you need to manually generated by calling",
+                            "default": "harbor_registry_user:$2y$10$9L4Tc0DJbFFMB6RdSCunrOpTHdwhid4ktBJmLD00bYgqkkGOvll3m"
+                        }
+                    }
+                },
+                "middleware": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Middleware is used to add support for a CDN between backend storage and `docker pull` recipient.  See",
+                            "default": false
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "CDN type for the middleware",
+                            "default": "cloudFront"
+                        },
+                        "cloudFront": {
+                            "type": "object",
+                            "properties": {
+                                "baseurl": {
+                                    "type": "string",
+                                    "description": "CloudFront CDN settings: Base URL",
+                                    "default": "example.cloudfront.net"
+                                },
+                                "keypairid": {
+                                    "type": "string",
+                                    "description": "CloudFront CDN settings: Keypair ID",
+                                    "default": "KEYPAIRID"
+                                },
+                                "duration": {
+                                    "type": "string",
+                                    "description": "CloudFront CDN settings: Duration",
+                                    "default": "3000s"
+                                },
+                                "ipfilteredby": {
+                                    "type": "string",
+                                    "description": "CloudFront CDN settings: IP filters",
+                                    "default": "none"
+                                },
+                                "privateKeySecret": {
+                                    "type": "string",
+                                    "description": "CloudFront CDN settings: Secret name with the private key",
+                                    "default": "my-secret"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret with the certificates for internal TLS access",
+                            "default": ""
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Harbor Registry replicas",
+                    "default": 1
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Harbor Registry pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Harbor Registry pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Registry deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Harbor Registry pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the Harbor Registry pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the Harbor Registry pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Registry Pod affinity preset. Ignored if `registry.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Registry Pod anti-affinity preset. Ignored if `registry.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Registry Node affinity preset type. Ignored if `registry.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Harbor Registry Node label key to match Ignored if `registry.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Harbor Registry Node label values to match. Ignored if `registry.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Harbor Registry Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Harbor Registry Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Harbor Registry Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Harbor Registry pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Harbor Registry pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Harbor Registry pods",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": false
+                },
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Harbor Registry image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Harbor Registry image repository",
+                                    "default": "bitnami/harbor-registry"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Harbor Registry image tag (immutable tags are recommended)",
+                                    "default": "2.8.3-debian-11-r8"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Harbor Registry image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Harbor Registry image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Harbor Registry image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "debug": {
+                                    "type": "boolean",
+                                    "description": "Enable Harbor Registry image debug mode",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add Harbor Registry main containers",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap containing extra environment variables for Harbor Registry main containers",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Registry main containers",
+                            "default": ""
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Harbor Registry HTTP container port",
+                                    "default": 5000
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Harbor Registry HTTPS container port",
+                                    "default": 5443
+                                },
+                                "debug": {
+                                    "type": "number",
+                                    "description": "Harbor Registry debug container port",
+                                    "default": 5001
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Harbor Registry metrics container port",
+                                    "default": 8001
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on Harbor Registry main containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on Harbor Registry main containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on Harbor Registry main containers",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 15
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the Harbor Registry main containers",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the Harbor Registry main containers",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled Harbor Registry main containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Harbor Registry main containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Harbor Registry main containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "LifecycleHook for the Harbor Registry main container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the Harbor Registry main pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Harbor Registry HTTP service port",
+                                            "default": 5000
+                                        },
+                                        "https": {
+                                            "type": "number",
+                                            "description": "Harbor Registry HTTPS service port",
+                                            "default": 5443
+                                        },
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Harbor Registry metrics service port",
+                                            "default": 8001
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Harbor Registryctl image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Harbor Registryctl image repository",
+                                    "default": "bitnami/harbor-registryctl"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Harbor Registryctl image tag (immutable tags are recommended)",
+                                    "default": "2.8.3-debian-11-r0"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Harbor Registryctl image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Harbor Registryctl image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Harbor Registryctl image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "debug": {
+                                    "type": "boolean",
+                                    "description": "Enable Harbor Registryctl image debug mode",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add Harbor Registryctl containers",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap containing extra environment variables for Harbor Registryctl containers",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Registryctl containers",
+                            "default": ""
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Harbor Registryctl HTTP container port",
+                                    "default": 8080
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Harbor Registryctl HTTPS container port",
+                                    "default": 8443
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on Harbor Registryctl containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on Harbor Registryctl containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on Harbor Registryctl containers",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 15
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the Harbor Registryctl containers",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the Harbor Registryctl containers",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled Harbor Registryctl containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Harbor Registryctl containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Harbor Registryctl containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "LifecycleHook for the Harbor Registryctl container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the Harbor Registryctl pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Harbor Registryctl HTTP service port",
+                                            "default": 8080
+                                        },
+                                        "https": {
+                                            "type": "number",
+                                            "description": "Harbor Registryctl HTTPS service port",
+                                            "default": 8443
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "notary": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Notary",
+                    "default": true
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "Fill the name of a kubernetes secret if you want to use your own TLS certificate authority, certificate and private key for notary communications. The secret must contain keys named `notary-signer-ca.crt`, `notary-signer.key` and `notary-signer.crt` that contain the CA, certificate and private key. They will be generated if not set.",
+                    "default": ""
+                },
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server image repository",
+                                    "default": "bitnami/harbor-notary-server"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server image tag (immutable tags are recommended)",
+                                    "default": "2.8.3-debian-11-r6"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Notary Server image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Harbor Notary Server image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "debug": {
+                                    "type": "boolean",
+                                    "description": "Enable Harbor Notary Server image debug mode",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add Harbor Notary Server pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap containing extra environment variables for Harbor Notary Server pods",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Notary Server pods",
+                            "default": ""
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "server": {
+                                    "type": "number",
+                                    "description": "Harbor Notary Server container port",
+                                    "default": 4443
+                                }
+                            }
+                        },
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Harbor Notary Server replicas",
+                            "default": 1
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on Harbor Notary Server containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on Harbor Notary Server containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on Harbor Notary Server containers",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 15
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the Harbor Notary Server containers",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the Harbor Notary Server containers",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled Harbor Notary Server pods' Security Context",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Set Harbor Notary Server pod's Security Context fsGroup",
+                                    "default": 1001
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled Harbor Notary Server containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Harbor Notary Server containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Harbor Notary Server containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                                    "default": "RollingUpdate"
+                                }
+                            }
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "LifecycleHook for the Harbor Notary Server container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "hostAliases": {
+                            "type": "array",
+                            "description": "Harbor Notary Server pods host aliases",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podLabels": {
+                            "type": "object",
+                            "description": "Add additional labels to the Harbor Notary Server pods (evaluated as a template)",
+                            "default": {}
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Annotations to add to the Harbor Notary Server pods (evaluated as a template)",
+                            "default": {}
+                        },
+                        "podAffinityPreset": {
+                            "type": "string",
+                            "description": "Harbor Notary Server Pod affinity preset. Ignored if `notary.server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "podAntiAffinityPreset": {
+                            "type": "string",
+                            "description": "Harbor Notary Server Pod anti-affinity preset. Ignored if `notary.server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": "soft"
+                        },
+                        "nodeAffinityPreset": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server Node affinity preset type. Ignored if `notary.server.affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Server Node label key to match Ignored if `notary.server.affinity` is set.",
+                                    "default": ""
+                                },
+                                "values": {
+                                    "type": "array",
+                                    "description": "Harbor Notary Server Node label values to match. Ignored if `notary.server.affinity` is set.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "affinity": {
+                            "type": "object",
+                            "description": "Harbor Notary Server Affinity for pod assignment",
+                            "default": {}
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "description": "Harbor Notary Server Node labels for pod assignment",
+                            "default": {}
+                        },
+                        "tolerations": {
+                            "type": "array",
+                            "description": "Harbor Notary Server Tolerations for pod assignment",
+                            "default": [],
+                            "items": {}
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array",
+                            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                            "default": [],
+                            "items": {}
+                        },
+                        "priorityClassName": {
+                            "type": "string",
+                            "description": "Priority Class Name",
+                            "default": ""
+                        },
+                        "schedulerName": {
+                            "type": "string",
+                            "description": "Use an alternate scheduler, e.g. \"stork\".",
+                            "default": ""
+                        },
+                        "sidecars": {
+                            "type": "array",
+                            "description": "Add additional sidecar containers to the Harbor Notary Server pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "initContainers": {
+                            "type": "array",
+                            "description": "Add additional init containers to the Harbor Notary Server pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the Harbor Notary Server pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumes": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumes for the Harbor Notary Server pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token",
+                            "default": false
+                        }
+                    }
+                },
+                "signer": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer image repository",
+                                    "default": "bitnami/harbor-notary-signer"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer image tag (immutable tags are recommended)",
+                                    "default": "2.8.3-debian-11-r6"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Harbor Notary Signer image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "debug": {
+                                    "type": "boolean",
+                                    "description": "Enable Harbor Notary Signer image debug mode",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add Harbor Notary Signer pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap containing extra environment variables for Harbor Notary Signer pods",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret containing extra environment variables (in case of sensitive data) for Harbor Notary Signer pods",
+                            "default": ""
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "signer": {
+                                    "type": "number",
+                                    "description": "Harbor Notary Signer container port",
+                                    "default": 7899
+                                }
+                            }
+                        },
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Harbor Notary Signer replicas",
+                            "default": 1
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on Harbor Notary Signer containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on Harbor Notary Signer containers",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 20
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on Harbor Notary Signer containers",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 1
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 15
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the Harbor Notary Signer containers",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the Harbor Notary Signer containers",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled Harbor Notary Signer pods' Security Context",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Set Harbor Notary Signer pod's Security Context fsGroup",
+                                    "default": 1001
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled Harbor Notary Signer containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Harbor Notary Signer containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Harbor Notary Signer containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                                    "default": "RollingUpdate"
+                                }
+                            }
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "LifecycleHook for the Harbor Notary Signer container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "hostAliases": {
+                            "type": "array",
+                            "description": "Harbor Notary Signer pods host aliases",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podLabels": {
+                            "type": "object",
+                            "description": "Add additional labels to the Harbor Notary Signer pods (evaluated as a template)",
+                            "default": {}
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Annotations to add to the Harbor Notary Signer pods (evaluated as a template)",
+                            "default": {}
+                        },
+                        "podAffinityPreset": {
+                            "type": "string",
+                            "description": "Harbor Notary Signer Pod affinity preset. Ignored if `notary.signer.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "podAntiAffinityPreset": {
+                            "type": "string",
+                            "description": "Harbor Notary Signer Pod anti-affinity preset. Ignored if `notary.signer.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": "soft"
+                        },
+                        "nodeAffinityPreset": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer Node affinity preset type. Ignored if `notary.signer.affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Harbor Notary Signer Node label key to match Ignored if `notary.signer.affinity` is set.",
+                                    "default": ""
+                                },
+                                "values": {
+                                    "type": "array",
+                                    "description": "Harbor Notary Signer Node label values to match. Ignored if `notary.signer.affinity` is set.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "affinity": {
+                            "type": "object",
+                            "description": "Harbor Notary Signer Affinity for pod assignment",
+                            "default": {}
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "description": "Harbor Notary Signer Node labels for pod assignment",
+                            "default": {}
+                        },
+                        "tolerations": {
+                            "type": "array",
+                            "description": "Harbor Notary Signer Tolerations for pod assignment",
+                            "default": [],
+                            "items": {}
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array",
+                            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                            "default": [],
+                            "items": {}
+                        },
+                        "priorityClassName": {
+                            "type": "string",
+                            "description": "Priority Class Name",
+                            "default": ""
+                        },
+                        "schedulerName": {
+                            "type": "string",
+                            "description": "Use an alternate scheduler, e.g. \"stork\".",
+                            "default": ""
+                        },
+                        "sidecars": {
+                            "type": "array",
+                            "description": "Add additional sidecar containers to the Harbor Notary Signer pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "initContainers": {
+                            "type": "array",
+                            "description": "Add additional init containers to the Harbor Notary Signer pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the Harbor Notary Signer pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumes": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumes for the Harbor Notary Signer pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "server": {
+                                    "type": "number",
+                                    "description": "Harbor Notary server service port",
+                                    "default": 4443
+                                },
+                                "signer": {
+                                    "type": "number",
+                                    "description": "Harbor Notary signer service port",
+                                    "default": 7899
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "trivy": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Harbor Adapter Trivy image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Harbor Adapter Trivy image repository",
+                            "default": "bitnami/harbor-adapter-trivy"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Harbor Adapter Trivy image tag (immutable tags are recommended)",
+                            "default": "2.8.3-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Harbor Adapter Trivy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Harbor Adapter Trivy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Harbor Adapter Trivy image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Harbor Adapter Trivy image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Trivy",
+                    "default": true
+                },
+                "debugMode": {
+                    "type": "boolean",
+                    "description": "The flag to enable Trivy debug mode",
+                    "default": false
+                },
+                "vulnType": {
+                    "type": "string",
+                    "description": "Comma-separated list of vulnerability types. Possible values `os` and `library`.",
+                    "default": "os,library"
+                },
+                "severity": {
+                    "type": "string",
+                    "description": "Comma-separated list of severities to be checked",
+                    "default": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+                },
+                "ignoreUnfixed": {
+                    "type": "boolean",
+                    "description": "The flag to display only fixed vulnerabilities",
+                    "default": false
+                },
+                "insecure": {
+                    "type": "boolean",
+                    "description": "The flag to skip verifying registry certificate",
+                    "default": false
+                },
+                "gitHubToken": {
+                    "type": "string",
+                    "description": "The GitHub access token to download Trivy DB",
+                    "default": ""
+                },
+                "skipUpdate": {
+                    "type": "boolean",
+                    "description": "The flag to disable Trivy DB downloads from GitHub",
+                    "default": false
+                },
+                "cacheDir": {
+                    "type": "string",
+                    "description": "Directory to store the cache",
+                    "default": "/bitnami/harbor-adapter-trivy/.cache"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret with the certificates for internal TLS access",
+                            "default": ""
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add Trivy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables for Trivy pods",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data) for Trivy pods",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Trivy HTTP container port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Trivy HTTPS container port",
+                            "default": 8443
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Trivy replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Trivy containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Trivy containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Trivy containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "200m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "512Mi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "number",
+                                    "description": "",
+                                    "default": 1
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "1Gi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Trivy pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Trivy pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Trivy containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Trivy containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Trivy containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Trivy deployment strategy type - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the Trivy container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Trivy pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the Trivy pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the Trivy pods (evaluated as a template)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Trivy Pod affinity preset. Ignored if `trivy.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Trivy Pod anti-affinity preset. Ignored if `trivy.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Trivy Node affinity preset type. Ignored if `trivy.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Trivy Node label key to match Ignored if `trivy.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Trivy Node label values to match. Ignored if `trivy.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Trivy Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Trivy Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Trivy Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Trivy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Trivy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Trivy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Trivy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Trivy HTTP service port",
+                                    "default": 8080
+                                },
+                                "https": {
+                                    "type": "number",
+                                    "description": "Trivy HTTPS service port",
+                                    "default": 8443
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "exporter": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Harbor Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Harbor Exporter image repository",
+                            "default": "bitnami/harbor-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Harbor Exporter image tag",
+                            "default": "2.8.3-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Harbor Exporter image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Harbor exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Specify if debug logs should be enabled",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Harbor Exporter HTTP container port",
+                            "default": 8001
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "The replica count",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Harbor Exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Harbor Exporter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Harbor Exporter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Exporter pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Exporter pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "The update strategy for deployments with persistent volumes: RollingUpdate or Recreate. Set it as Recreate when RWM for volumes isn't supported",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook to set additional configuration at startup, e.g. LDAP settings via REST API. Evaluated as a template",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Exporter pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add additional labels to the pod (evaluated as a template)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add to the exporter pod",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Exporter Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Harbor Exporter Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Harbor Exporter Node affinity preset type. Ignored if `exporter.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Harbor Exporter Node label key to match Ignored if `exporter.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Harbor Exporter Node label values to match. Ignored if `exporter.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Harbor Exporter Affinity for pod assignment",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Exporter pods Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "serviceAccountName": {
+                    "type": "string",
+                    "description": "Name of the serviceAccountName for Harbor Exporter pods",
+                    "default": ""
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Harbor Exporter Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Harbor Exporter Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the pod (evaluated as a template)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Attach additional containers to the pod (evaluated as a template)",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Exporter HTTP service port",
+                                    "default": 8001
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enablePostgresUser": {
+                            "type": "boolean",
+                            "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                            "default": true
+                        },
+                        "postgresPassword": {
+                            "type": "string",
+                            "description": "Password for the \"postgres\" admin user",
+                            "default": "not-secure-database-password"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "initdb": {
+                            "type": "object",
+                            "properties": {
+                                "scripts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "initial-notaryserver": {
+                                            "type": "object",
+                                            "properties": {
+                                                "sql": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "CREATE DATABASE notaryserver;\nCREATE USER server;\nalter user server with encrypted password 'password';\nGRANT ALL PRIVILEGES ON DATABASE notaryserver TO server;\n"
+                                                }
+                                            }
+                                        },
+                                        "initial-notarysigner": {
+                                            "type": "object",
+                                            "properties": {
+                                                "sql": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "CREATE DATABASE notarysigner;\nCREATE USER signer;\nalter user signer with encrypted password 'password';\nGRANT ALL PRIVILEGES ON DATABASE notarysigner TO signer;\n"
+                                                }
+                                            }
+                                        },
+                                        "initial-registry": {
+                                            "type": "object",
+                                            "properties": {
+                                                "sql": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "CREATE DATABASE registry ENCODING 'UTF8';\n\\c registry;\nCREATE TABLE schema_migrations(version bigint not null primary key, dirty boolean not null);\n"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "extendedConfiguration": {
+                            "type": "string",
+                            "description": "Extended PostgreSQL Primary configuration (appended to main or default configuration)",
+                            "default": "max_connections = 1024\n"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL image repository",
+                            "default": "bitnami/postgresql"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL image tag (immutable tags are recommended)",
+                            "default": "13.11.0-debian-11-r80"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Harbor",
+                    "default": "bn_harbor"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Harbor",
+                    "default": ""
+                },
+                "sslmode": {
+                    "type": "string",
+                    "description": "External database ssl mode",
+                    "default": "disable"
+                },
+                "coreDatabase": {
+                    "type": "string",
+                    "description": "External database name for core",
+                    "default": ""
+                },
+                "notaryServerDatabase": {
+                    "type": "string",
+                    "description": "External database name for notary server",
+                    "default": ""
+                },
+                "notaryServerUsername": {
+                    "type": "string",
+                    "description": "External database username for notary server",
+                    "default": ""
+                },
+                "notaryServerPassword": {
+                    "type": "string",
+                    "description": "External database password for notary server",
+                    "default": ""
+                },
+                "notarySignerDatabase": {
+                    "type": "string",
+                    "description": "External database name for notary signer",
+                    "default": ""
+                },
+                "notarySignerUsername": {
+                    "type": "string",
+                    "description": "External database username for notary signer",
+                    "default": ""
+                },
+                "notarySignerPassword": {
+                    "type": "string",
+                    "description": "External database password for notary signer",
+                    "default": ""
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the Redis&reg; helm",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable password authentication",
+                            "default": false
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Redis&reg; password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "The name of an existing secret with Redis&reg; credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Redis&reg; architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "sentinel": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use Redis&reg; Sentinel on Redis&reg; pods.",
+                            "default": false
+                        },
+                        "masterSet": {
+                            "type": "string",
+                            "description": "Master set name",
+                            "default": "mymaster"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "sentinel": {
+                                            "type": "number",
+                                            "description": "Redis&reg; service port for Redis&reg; Sentinel",
+                                            "default": 26379
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Redis&reg; host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Redis&reg; port number",
+                    "default": 6379
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Redis&reg; password",
+                    "default": ""
+                },
+                "coreDatabaseIndex": {
+                    "type": "string",
+                    "description": "Index for core database",
+                    "default": "0"
+                },
+                "jobserviceDatabaseIndex": {
+                    "type": "string",
+                    "description": "Index for jobservice database",
+                    "default": "1"
+                },
+                "registryDatabaseIndex": {
+                    "type": "string",
+                    "description": "Index for registry database",
+                    "default": "2"
+                },
+                "trivyAdapterDatabaseIndex": {
+                    "type": "string",
+                    "description": "Index for trivy adapter database",
+                    "default": "5"
+                },
+                "sentinel": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If external redis with sentinal is used, set it to `true`",
+                            "default": false
+                        },
+                        "masterSet": {
+                            "type": "string",
+                            "description": "Name of sentinel masterSet if sentinel is used",
+                            "default": "mymaster"
+                        },
+                        "hosts": {
+                            "type": "string",
+                            "description": "Sentinel hosts and ports in the format",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether or not to enable metrics for different",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path where metrics are exposed",
+                    "default": "/metrics"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/influxdb/values.schema.json
+++ b/bitnami/influxdb/values.schema.json
@@ -1,0 +1,1544 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global storage class for dynamic provisioning",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override influxdb.fullname template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override influxdb.fullname template with a string",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; image repository",
+                    "default": "bitnami/influxdb"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; image tag (immutable tags are recommended)",
+                    "default": "2.7.1-debian-11-r125"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable authentication (Variable to keep compatibility with InfluxDB&trade; v1, in v2 it will be ignored)",
+                    "default": true
+                },
+                "usePasswordFiles": {
+                    "type": "boolean",
+                    "description": "Whether to use files to provide secrets instead of env vars.",
+                    "default": false
+                },
+                "admin": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; admin user name",
+                            "default": "admin"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; admin user's password",
+                            "default": ""
+                        },
+                        "token": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; admin user's token. Only valid with InfluxDB&trade; v2",
+                            "default": ""
+                        },
+                        "org": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; admin user's org. Only valid with InfluxDB&trade; v2",
+                            "default": "primary"
+                        },
+                        "bucket": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; admin user's bucket. Only valid with InfluxDB&trade; v2",
+                            "default": "primary"
+                        },
+                        "retention": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; admin user's bucket retention. Only valid with InfluxDB&trade; v2",
+                            "default": ""
+                        }
+                    }
+                },
+                "createUserToken": {
+                    "type": "boolean",
+                    "description": "Whether to create tokens for the different users. Take into account these tokens are going to be created by CLI randomly and they will not be accessible from a secret. See more influxdb 2.0 [auth ref](https://docs.influxdata.com/influxdb/v2.0/security/tokens/)",
+                    "default": false
+                },
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for InfluxDB&trade; user with 'admin' privileges on the bucket specified at `auth.user.bucket` and `auth.user.org` or `auth.admin.org`",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; password for `user.name` user",
+                            "default": ""
+                        },
+                        "org": {
+                            "type": "string",
+                            "description": "Org to be created on first run",
+                            "default": ""
+                        },
+                        "bucket": {
+                            "type": "string",
+                            "description": "Bucket to be created on first run",
+                            "default": ""
+                        }
+                    }
+                },
+                "readUser": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for InfluxDB&trade; user with 'read' privileges on the bucket specified at `auth.user.bucket`",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; password for `auth.readUser.username` user",
+                            "default": ""
+                        }
+                    }
+                },
+                "writeUser": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for InfluxDB&trade; user with 'read' privileges on the bucket specified at `auth.user.bucket`",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; password for `auth.writeUser.username` user",
+                            "default": ""
+                        }
+                    }
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret object with InfluxDB&trade; credentials (`auth.admin.password`, `auth.user.password`, `auth.readUser.password`, and `auth.writeUser.password` will be ignored and picked up from this secret)",
+                    "default": ""
+                }
+            }
+        },
+        "influxdb": {
+            "type": "object",
+            "properties": {
+                "configuration": {
+                    "type": "string",
+                    "description": "Specify content for influxdb.conf",
+                    "default": ""
+                },
+                "existingConfiguration": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap object with the InfluxDB&trade; configuration (`influxdb.configuration` will be ignored).",
+                    "default": ""
+                },
+                "initdbScripts": {
+                    "type": "object",
+                    "description": "Dictionary of initdb scripts",
+                    "default": {}
+                },
+                "initdbScriptsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap object with the initdb scripts (`influxdb.initdbScripts` will be ignored).",
+                    "default": ""
+                },
+                "initdbScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret with initdb scripts that contain sensitive information (Note: can be used with `initdbScriptsConfigMap` or `initdbScripts`)",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "InfluxDB&trade; Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "InfluxDB&trade; Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "InfluxDB&trade; Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "InfluxDB&trade; Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for InfluxDB&trade; pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for InfluxDB&trade; pods",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "InfluxDB&trade; pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; statefulset/deployment strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "InfluxDB&trade; pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of InfluxDB&trade; pods",
+                    "default": "OrderedReady"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled InfluxDB&trade; pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set InfluxDB&trade; pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled InfluxDB&trade; containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set InfluxDB&trade; containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set InfluxDB&trade; containers' Security Context runAsGroup",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Controller container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Controller container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Controller container's Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Controller container's Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the InfluxDB&trade; container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure InfluxDB&trade;",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for InfluxDB&trade; nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for InfluxDB&trade; nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting extraVolumeMounts",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with extraVolumes.",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "InfluxDB&trade; container HTTP port",
+                            "default": 8086
+                        },
+                        "rpc": {
+                            "type": "number",
+                            "description": "InfluxDB&trade; container RPC port",
+                            "default": 8088
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 45
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 45
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 45
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the InfluxDB&trade; pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the InfluxDB&trade; pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "InfluxDB&trade; HTTP port",
+                                    "default": 8086
+                                },
+                                "rpc": {
+                                    "type": "number",
+                                    "description": "InfluxDB&trade; RPC port",
+                                    "default": 8088
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                },
+                                "rpc": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "InfluxDB&trade; service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for InfluxDB&trade; service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "collectd": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "InfluxDB Collectd&trade; service enable",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "InfluxDB Collectd&trade; UDP port (should match with corresponding port in influxdb.conf)",
+                            "default": 25826
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "InfluxDB Collectd&trade; service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for InfluxDB Collectd&trade; service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Create TLS Secret",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource (evaluated as template)",
+                    "default": "influxdb.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Ingress path*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Additional arbitrary path/backend objects",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "InfluxDB&trade; Prometheus port",
+                            "default": 9122
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable NetworkPolicy",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable data persistence",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Use a existing PVC which must be created manually before bound",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Specify the `storageClass` used to provision the volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Access mode of data volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "psp": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create Role and RoleBinding (required for PSP to work)",
+                    "default": false
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container (when facing issues in OpenShift or uid unknown, try value \"auto\")",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "backup": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable InfluxDB&trade; backup",
+                    "default": false
+                },
+                "directory": {
+                    "type": "string",
+                    "description": "Directory where backups are stored",
+                    "default": "/backups"
+                },
+                "retentionDays": {
+                    "type": "number",
+                    "description": "Retention time in days for backups (older backups are deleted)",
+                    "default": 10
+                },
+                "cronjob": {
+                    "type": "object",
+                    "properties": {
+                        "schedule": {
+                            "type": "string",
+                            "description": "Schedule in Cron format to save snapshots",
+                            "default": "0 2 * * *"
+                        },
+                        "historyLimit": {
+                            "type": "number",
+                            "description": "Number of successful finished jobs to retain",
+                            "default": 1
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Pod annotations",
+                            "default": {}
+                        },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable security context for InfluxDB&trade; backup pods",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Group ID for the InfluxDB&trade; filesystem",
+                                    "default": 1001
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "User ID for the InfluxDB&trade; filesystem",
+                                    "default": 1001
+                                },
+                                "runAsGroup": {
+                                    "type": "number",
+                                    "description": "Group ID for the InfluxDB&trade; runAsGroup",
+                                    "default": 0
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Setting for the InfluxDB&trade; runAsNonRoot",
+                                    "default": true
+                                },
+                                "seccompProfile": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Setting for the InfluxDB&trade; seccompProfile.type",
+                                            "default": "RuntimeDefault"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable security context for InfluxDB&trade; backup containers",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "readOnlyRootFilesystem for InfluxDB&trade;",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "allowPrivilegeEscalation for InfluxDB&trade;",
+                                    "default": false
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Capabilities to drop for InfluxDB&trade;",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Backup &trade; Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Backup&trade; Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Backup&trade; Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Backup&trade; Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Backup&trade; Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Backup&trade; Affinity for backup pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Backup&trade; Node labels for backup pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Backup&trade; Tolerations for backup pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "uploadProviders": {
+                    "type": "object",
+                    "properties": {
+                        "google": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "enable upload to google storage bucket",
+                                    "default": false
+                                },
+                                "secret": {
+                                    "type": "string",
+                                    "description": "json secret with serviceaccount data to access Google storage bucket",
+                                    "default": ""
+                                },
+                                "secretKey": {
+                                    "type": "string",
+                                    "description": "service account secret key name",
+                                    "default": "key.json"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing secret object with Google serviceaccount json credentials",
+                                    "default": ""
+                                },
+                                "bucketName": {
+                                    "type": "string",
+                                    "description": "google storage bucket name name",
+                                    "default": "gs://bucket/influxdb"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string",
+                                            "description": "Google Cloud SDK image registry",
+                                            "default": "docker.io"
+                                        },
+                                        "repository": {
+                                            "type": "string",
+                                            "description": "Google Cloud SDK image name",
+                                            "default": "bitnami/google-cloud-sdk"
+                                        },
+                                        "tag": {
+                                            "type": "string",
+                                            "description": "Google Cloud SDK image tag",
+                                            "default": "0.444.0-debian-11-r11"
+                                        },
+                                        "digest": {
+                                            "type": "string",
+                                            "description": "Google Cloud SDK image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                            "default": ""
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string",
+                                            "description": "Google Cloud SDK image pull policy",
+                                            "default": "IfNotPresent"
+                                        },
+                                        "pullSecrets": {
+                                            "type": "array",
+                                            "description": "Specify docker-registry secret names as an array",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "azure": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable upload to azure storage container",
+                                    "default": false
+                                },
+                                "secret": {
+                                    "type": "string",
+                                    "description": "Secret with credentials to access Azure storage",
+                                    "default": ""
+                                },
+                                "secretKey": {
+                                    "type": "string",
+                                    "description": "Service account secret key name",
+                                    "default": "connection-string"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing secret object",
+                                    "default": ""
+                                },
+                                "containerName": {
+                                    "type": "string",
+                                    "description": "Destination container",
+                                    "default": "influxdb-container"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string",
+                                            "description": "Azure CLI image registry",
+                                            "default": "docker.io"
+                                        },
+                                        "repository": {
+                                            "type": "string",
+                                            "description": "Azure CLI image repository",
+                                            "default": "bitnami/azure-cli"
+                                        },
+                                        "tag": {
+                                            "type": "string",
+                                            "description": "Azure CLI image tag (immutable tags are recommended)",
+                                            "default": "2.52.0-debian-11-r0"
+                                        },
+                                        "digest": {
+                                            "type": "string",
+                                            "description": "Azure CLI image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                            "default": ""
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string",
+                                            "description": "Azure CLI image pull policy",
+                                            "default": "IfNotPresent"
+                                        },
+                                        "pullSecrets": {
+                                            "type": "array",
+                                            "description": "Specify docker-registry secret names as an array",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "aws": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable upload to aws s3 bucket",
+                                    "default": false
+                                },
+                                "accessKeyID": {
+                                    "type": "string",
+                                    "description": "Access Key ID to access aws s3",
+                                    "default": ""
+                                },
+                                "secretAccessKey": {
+                                    "type": "string",
+                                    "description": "Secret Access Key to access aws s3",
+                                    "default": ""
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "description": "Region of aws s3 bucket",
+                                    "default": "us-east-1"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing secret object",
+                                    "default": ""
+                                },
+                                "bucketName": {
+                                    "type": "string",
+                                    "description": "aws s3 bucket name",
+                                    "default": "s3://bucket/influxdb"
+                                },
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "registry": {
+                                            "type": "string",
+                                            "description": "AWS CLI image registry",
+                                            "default": "docker.io"
+                                        },
+                                        "repository": {
+                                            "type": "string",
+                                            "description": "AWS CLI image repository",
+                                            "default": "bitnami/aws-cli"
+                                        },
+                                        "tag": {
+                                            "type": "string",
+                                            "description": "AWS CLI image tag (immutable tags are recommended)",
+                                            "default": "2.13.13-debian-11-r8"
+                                        },
+                                        "digest": {
+                                            "type": "string",
+                                            "description": "AWS CLI image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                            "default": ""
+                                        },
+                                        "pullPolicy": {
+                                            "type": "string",
+                                            "description": "AWS CLI image pull policy",
+                                            "default": "IfNotPresent"
+                                        },
+                                        "pullSecrets": {
+                                            "type": "array",
+                                            "description": "Specify docker-registry secret names as an array",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/jaeger/values.schema.json
+++ b/bitnami/jaeger/values.schema.json
@@ -1,0 +1,1813 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects (sub-charts are not considered)",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Jaeger image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Jaeger image repository",
+                    "default": "bitnami/jaeger"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Jaeger image tag (immutable tags are recommended)",
+                    "default": "1.49.0-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Jaeger image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Jaeger image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "query": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Command for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Jaeger replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Query nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Query containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Jaeger containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Jaeger containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "number",
+                            "description": "Port for API",
+                            "default": 16686
+                        },
+                        "admin": {
+                            "type": "number",
+                            "description": "Port for admin",
+                            "default": 16687
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Jaeger service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "api": {
+                                    "type": "number",
+                                    "description": "Port for API",
+                                    "default": 16686
+                                },
+                                "admin": {
+                                    "type": "number",
+                                    "description": "Port for admin",
+                                    "default": 16687
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "api": {
+                                    "type": "string",
+                                    "description": "Node port for API",
+                                    "default": ""
+                                },
+                                "admin": {
+                                    "type": "string",
+                                    "description": "Node port for admin",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.query.service.ports.admin }}"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/metrics"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enables ServiceAccount",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "ServiceAccount name",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations to add to all deployed objects",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Jaeger pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Jaeger container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Jaeger query deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Jaeger query deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the jaeger pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the jaeger pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "collector": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Command for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Jaeger replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on collector nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on collector containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Jaeger containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Jaeger containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "zipkin": {
+                            "type": "number",
+                            "description": "can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)",
+                            "default": 9411
+                        },
+                        "grpc": {
+                            "type": "number",
+                            "description": "used by jaeger-agent to send spans in model.proto format",
+                            "default": 14250
+                        },
+                        "binary": {
+                            "type": "number",
+                            "description": "can accept spans directly from clients in jaeger.thrift format over binary thrift protocol",
+                            "default": 14268
+                        },
+                        "admin": {
+                            "type": "number",
+                            "description": "Admin port: health check at / and metrics at /metrics",
+                            "default": 14269
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Jaeger service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "zipkin": {
+                                    "type": "number",
+                                    "description": "can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)",
+                                    "default": 9411
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "used by jaeger-agent to send spans in model.proto format",
+                                    "default": 14250
+                                },
+                                "binary": {
+                                    "type": "number",
+                                    "description": "can accept spans directly from clients in jaeger.thrift format over binary thrift protocol",
+                                    "default": 14268
+                                },
+                                "admin": {
+                                    "type": "number",
+                                    "description": "Admin port: health check at / and metrics at /metrics",
+                                    "default": 14269
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "zipkin": {
+                                    "type": "string",
+                                    "description": "can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "used by jaeger-agent to send spans in model.proto format",
+                                    "default": ""
+                                },
+                                "binary": {
+                                    "type": "string",
+                                    "description": "can accept spans directly from clients in jaeger.thrift format over binary thrift protocol",
+                                    "default": ""
+                                },
+                                "admin": {
+                                    "type": "string",
+                                    "description": "Admin port: health check at / and metrics at /metrics",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.collector.service.ports.admin }}"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/metrics"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enables ServiceAccount",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "ServiceAccount name",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations to add to all deployed objects",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Jaeger pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Jaeger container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Jaeger collector deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Jaeger collector deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the jaeger pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the jaeger pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "agent": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Command for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Jaeger replicas",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on agent nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on agent containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Jaeger containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Jaeger containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "compact": {
+                            "type": "number",
+                            "description": "accept jaeger.thrift in compact Thrift protocol used by most current Jaeger clients",
+                            "default": 6831
+                        },
+                        "binary": {
+                            "type": "number",
+                            "description": "accept jaeger.thrift in binary Thrift protocol used by Node.js Jaeger client",
+                            "default": 6832
+                        },
+                        "config": {
+                            "type": "number",
+                            "description": "Serve configs, sampling strategies",
+                            "default": 5778
+                        },
+                        "zipkin": {
+                            "type": "number",
+                            "description": "Accept zipkin.thrift in compact Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)",
+                            "default": 5775
+                        },
+                        "admin": {
+                            "type": "number",
+                            "description": "Admin port: health check at / and metrics at /metrics",
+                            "default": 14271
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Jaeger service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "compact": {
+                                    "type": "number",
+                                    "description": "accept jaeger.thrift in compact Thrift protocol used by most current Jaeger clients",
+                                    "default": 6831
+                                },
+                                "binary": {
+                                    "type": "number",
+                                    "description": "accept jaeger.thrift in binary Thrift protocol used by Node.js Jaeger client",
+                                    "default": 6832
+                                },
+                                "config": {
+                                    "type": "number",
+                                    "description": "Serve configs, sampling strategies",
+                                    "default": 5778
+                                },
+                                "zipkin": {
+                                    "type": "number",
+                                    "description": "Accept zipkin.thrift in compact Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)",
+                                    "default": 5775
+                                },
+                                "admin": {
+                                    "type": "number",
+                                    "description": "Admin port: health check at / and metrics at /metrics",
+                                    "default": 14271
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "compact": {
+                                    "type": "string",
+                                    "description": "accept jaeger.thrift in compact Thrift protocol used by most current Jaeger clients",
+                                    "default": ""
+                                },
+                                "binary": {
+                                    "type": "string",
+                                    "description": "accept jaeger.thrift in binary Thrift protocol used by Node.js Jaeger client",
+                                    "default": ""
+                                },
+                                "config": {
+                                    "type": "string",
+                                    "description": "Serve configs, sampling strategies",
+                                    "default": ""
+                                },
+                                "zipkin": {
+                                    "type": "string",
+                                    "description": "Accept zipkin.thrift in compact Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)",
+                                    "default": ""
+                                },
+                                "admin": {
+                                    "type": "string",
+                                    "description": "Admin port: health check at / and metrics at /metrics",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "LoadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.agent.service.ports.admin }}"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/metrics"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enables ServiceAccount",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "ServiceAccount name",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations to add to all deployed objects",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Jaeger pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Jaeger container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to be run as non root",
+                            "default": true
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Jaeger agent deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Jaeger agent deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the jaeger pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the jaeger pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "migration": {
+            "type": "object",
+            "properties": {
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations which may be required.",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Jaeger pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Jaeger pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on jaeger migration container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for jaeger container",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Jaeger containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Jaeger containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for jaeger container",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "cqlshImage": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Cassandra image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Cassandra image repository",
+                    "default": "bitnami/cassandra"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Cassandra image tag (immutable tags are recommended)",
+                    "default": "4.0.11-debian-11-r49"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Cassandra image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External database port",
+                    "default": 9042
+                },
+                "dbUser": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "Cassandra admin user",
+                            "default": "bn_jaeger"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for `dbUser.user`. Randomly generated if empty",
+                            "default": ""
+                        }
+                    }
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of existing secret containing the database secret",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of existing secret key containing the database password secret key",
+                    "default": ""
+                },
+                "cluster": {
+                    "type": "object",
+                    "properties": {
+                        "datacenter": {
+                            "type": "string",
+                            "description": "Name for cassandra's jaeger datacenter",
+                            "default": "dc1"
+                        }
+                    }
+                },
+                "keyspace": {
+                    "type": "string",
+                    "description": "Name for cassandra's jaeger keyspace",
+                    "default": "bitnami_jaeger"
+                }
+            }
+        },
+        "cassandra": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enables cassandra storage pod",
+                    "default": true
+                },
+                "cluster": {
+                    "type": "object",
+                    "properties": {
+                        "datacenter": {
+                            "type": "string",
+                            "description": "Name for cassandra's jaeger datacenter",
+                            "default": "dc1"
+                        }
+                    }
+                },
+                "keyspace": {
+                    "type": "string",
+                    "description": "Name for cassandra's jaeger keyspace",
+                    "default": "bitnami_jaeger"
+                },
+                "dbUser": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "Cassandra admin user",
+                            "default": "bn_jaeger"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for `dbUser.user`. Randomly generated if empty",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "cql": {
+                                    "type": "number",
+                                    "description": "Cassandra cql port",
+                                    "default": 9042
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/jasperreports/values.schema.json
+++ b/bitnami/jasperreports/values.schema.json
@@ -1,0 +1,907 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "JasperReports image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "JasperReports image repository",
+                    "default": "bitnami/jasperreports"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "JasperReports image tag (immutable tags are recommended)",
+                    "default": "8.2.0-debian-11-r51"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "JasperReports image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "JasperReports image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "jasperreportsUsername": {
+            "type": "string",
+            "description": "JasperReports user",
+            "default": "jasperadmin"
+        },
+        "jasperreportsExistingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing the key `jasperreports-password`",
+            "default": ""
+        },
+        "jasperreportsPassword": {
+            "type": "string",
+            "description": "JasperReports password (Ignored if `jasperreportsExistingSecret` is provided)",
+            "default": ""
+        },
+        "jasperreportsEmail": {
+            "type": "string",
+            "description": "JasperReports user email",
+            "default": "user@example.com"
+        },
+        "allowEmptyPassword": {
+            "type": "string",
+            "description": "Set to `yes` to allow the container to be started with blank passwords",
+            "default": "no"
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpEmail": {
+            "type": "string",
+            "description": "SMTP email",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing the key `smtp-password`",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password (Ignored if `smtpExistingSecret` is provided)",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol [`ssl`, `none`]",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on Jasperreports container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "StrategyType",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "HTTP port to expose at container level",
+                    "default": 8080
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable pod's Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable container's Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Jasperreports container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/jasperserver/login.html"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 450
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/jasperserver/login.html"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 450
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/jasperserver/login.html"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Jasperreports pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Jasperreports pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "JasperReports pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHooks to set additional configuration at startup.",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Jasperreports pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Jasperreports container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Jasperreports pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Jasperreports pods",
+            "default": [],
+            "items": {}
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Jasperreports volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Mode",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Jasperreports volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name for Jasperreports volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes http node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Jarperreports service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Kubernetes LoadBalancerIP to request",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Jasperreports service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Jasperreports service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "jasperreports.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Ingress path",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to use the MariaDB chart",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_jasperreports"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_jasperreports"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Access mode of persistent volume",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Host mount path for MariaDB volume",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Enable persistence using an existing PVC",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the database existing Secret Object",
+                    "default": ""
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_jasperreports"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_jasperreports"
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Type of the existing database, allowed values: mariadb, mysql, postgresql",
+                    "default": "mariadb"
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by Jasperreports' pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Jasperreports only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Jasperreports. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Jasperreports. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/jenkins/values.schema.json
+++ b/bitnami/jenkins/values.schema.json
@@ -1,114 +1,1314 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "serviceAccountName": {
-      "type": "string",
-      "title": "ServiceAccount name",
-      "form": true,
-      "description": "Defaults to use default if not set"
-    },
-    "jenkinsUser": {
-      "type": "string",
-      "title": "Username",
-      "form": true
-    },
-    "jenkinsPassword": {
-      "type": "string",
-      "title": "Password",
-      "form": true,
-      "description": "Defaults to a random 10-character alphanumeric string if not set"
-    },
-    "persistence": {
-      "type": "object",
-      "title": "Persistence",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable persistence",
-          "description": "Enable persistence using Persistent Volume Claims"
-        },
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi",
-          "hidden": {
-            "value": false,
-            "path": "persistence/enabled"
-          }
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Required Resources",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
             }
-          }
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress Configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the Jenkins installation."
         },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Jenkins image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Jenkins image repository",
+                    "default": "bitnami/jenkins"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Jenkins image tag (immutable tags are recommended)",
+                    "default": "2.401.3-debian-11-r20"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Jenkins image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Jenkins image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Jenkins image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "jenkinsUser": {
+            "type": "string",
+            "description": "Jenkins username",
+            "default": "user"
+        },
+        "jenkinsPassword": {
+            "type": "string",
+            "description": "Jenkins user password",
+            "default": ""
+        },
+        "jenkinsHost": {
+            "type": "string",
+            "description": "Jenkins host to create application URLs",
+            "default": ""
+        },
+        "jenkinsHome": {
+            "type": "string",
+            "description": "Jenkins home directory",
+            "default": "/bitnami/jenkins/home"
+        },
+        "javaOpts": {
+            "type": "array",
+            "description": "Custom JVM parameters",
+            "default": [],
+            "items": {}
+        },
+        "disableInitialization": {
+            "type": "string",
+            "description": "Skip performing the initial bootstrapping for Jenkins",
+            "default": "no"
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the Jenkins container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "plugins": {
+            "type": "array",
+            "description": "List of plugins to be installed during Jenkins first boot.",
+            "default": [],
+            "items": {}
+        },
+        "extraPlugins": {
+            "type": "array",
+            "description": "List of plugins to install in addition to those listed in `plugins`",
+            "default": [],
+            "items": {}
+        },
+        "latestPlugins": {
+            "type": "boolean",
+            "description": "Set to true to download the latest version of all dependencies, even if the version(s) of the requested plugin(s) are not the latest.",
+            "default": true
+        },
+        "latestSpecifiedPlugins": {
+            "type": "boolean",
+            "description": "Set to true download the latest dependencies of any plugin that is requested to have the latest version.",
+            "default": false
+        },
+        "skipImagePlugins": {
+            "type": "boolean",
+            "description": "Set this value to true to skip installing plugins stored under /opt/bitnami/jenkins/plugins",
+            "default": false
+        },
+        "overridePlugins": {
+            "type": "boolean",
+            "description": "Setting this value to true will remove all plugins from the jenkinsHome directory and install new plugins from scratch.",
+            "default": false
+        },
+        "overridePaths": {
+            "type": "string",
+            "description": "Comma-separated list of relative paths to be removed from Jenkins home volume and/or mounted if present in the mounted content dir",
+            "default": ""
+        },
+        "initScripts": {
+            "type": "object",
+            "description": "Dictionary of scripts to be mounted at `/docker-entrypoint-initdb.d`. Evaluated as a template. Allows .sh and .groovy formats.",
+            "default": {}
+        },
+        "initScriptsCM": {
+            "type": "string",
+            "description": "ConfigMap containing the `/docker-entrypoint-initdb.d` scripts. Evaluated as a template.",
+            "default": ""
+        },
+        "initScriptsSecret": {
+            "type": "string",
+            "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+            "default": ""
+        },
+        "initHookScripts": {
+            "type": "object",
+            "description": "Dictionary of scripts to be mounted at `$JENKINS_HOME/init.groovy.d`. Evaluated as a template. Allows .sh and .groovy formats.",
+            "default": {}
+        },
+        "initHookScriptsCM": {
+            "type": "string",
+            "description": "ConfigMap containing the `$JENKINS_HOME/init.groovy.d` scripts. Evaluated as a template.",
+            "default": ""
+        },
+        "initHookScriptsSecret": {
+            "type": "string",
+            "description": "Secret containing `$JENKINS_HOME/init.groovy.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+            "default": ""
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Create self-signed TLS certificates. Currently only supports PEM certificates.",
+                    "default": false
+                },
+                "usePemCerts": {
+                    "type": "boolean",
+                    "description": "Use this variable if your secrets contain PEM certificates instead of PKCS12",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing the 'jenkins.jks' keystore, if usePemCerts is enabled, use keys 'tls.crt' and 'tls.key'.",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to access the JKS keystore when it is password-protected.",
+                    "default": ""
+                },
+                "passwordsSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing the JKS keystore password.",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container generate-tls-certs resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container generate-tls-certs resource requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "configAsCode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable configuration as code.",
+                    "default": false
+                },
+                "extraConfigFiles": {
+                    "type": "object",
+                    "description": "List of additional configuration-as-code files to be mounted",
+                    "default": {}
+                },
+                "securityRealm": {
+                    "type": "object",
+                    "description": "Content of the 'securityRealm' block",
+                    "default": {}
+                },
+                "authorizationStrategy": {
+                    "type": "object",
+                    "description": "Content of the 'authorizationStrategy' block",
+                    "default": {}
+                },
+                "security": {
+                    "type": "object",
+                    "description": "Content of the 'security' block",
+                    "default": {}
+                },
+                "extraJenkins": {
+                    "type": "object",
+                    "description": "Append additional settings under the 'jenkins' block",
+                    "default": {}
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Append additional settings at the root of the configuration-as-code file",
+                    "default": {}
+                },
+                "extraKubernetes": {
+                    "type": "object",
+                    "description": "Append additional settings under the Kubernetes cloud block",
+                    "default": {}
+                },
+                "extraClouds": {
+                    "type": "array",
+                    "description": "Additional clouds",
+                    "default": [],
+                    "items": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing configmap containing the config-as-code files.",
+                    "default": ""
+                },
+                "autoReload": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the creation of the autoReload sidecar container.",
+                            "default": true
+                        },
+                        "initialDelay": {
+                            "type": "number",
+                            "description": "In seconds, time",
+                            "default": 360
+                        },
+                        "reqRetries": {
+                            "type": "number",
+                            "description": "",
+                            "default": 12
+                        },
+                        "interval": {
+                            "type": "number",
+                            "description": "",
+                            "default": 10
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled %%MAIN_CONTAINER_NAME%% containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set %%MAIN_CONTAINER_NAME%% containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set %%MAIN_CONTAINER_NAME%% containers' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set %%MAIN_CONTAINER_NAME%% containers' Security Context runAsNonRoot",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "agent": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable the configuration of Jenkins kubernetes agents",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Jenkins image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Jenkins image repository",
+                            "default": "bitnami/jenkins-agent"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Jenkins image tag (immutable tags are recommended)",
+                            "default": "0.3142.0-debian-11-r23"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Jenkins image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Jenkins image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Jenkins image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "templateLabel": {
+                    "type": "string",
+                    "description": "Label for the Kubernetes agent template",
+                    "default": "kubernetes-agent"
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels for the Jenkins agent pods",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations for the Jenkins agent pods",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Additional sidecar containers for the Jenkins agent pods",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": ""
+                },
+                "args": {
+                    "type": "string",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": ""
+                },
+                "containerExtraEnvVars": {
+                    "type": "array",
+                    "description": "Additional env vars for the Jenkins agent pods",
+                    "default": [],
+                    "items": {}
+                },
+                "podExtraEnvVars": {
+                    "type": "array",
+                    "description": "Additional env vars for the Jenkins agent pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraAgentTemplate": {
+                    "type": "object",
+                    "description": "Extend the default agent template",
+                    "default": {}
+                },
+                "extraTemplates": {
+                    "type": "array",
+                    "description": "Provide your own custom agent templates",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Jenkins container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "512Mi"
+                                },
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "300m"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": false
+                        },
+                        "runAsUser": {
+                            "type": "string",
+                            "description": "User ID for the agent container",
+                            "default": ""
+                        },
+                        "runAsGroup": {
+                            "type": "string",
+                            "description": "User ID for the agent container",
+                            "default": ""
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Decide if the container runs privileged.",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Jenkins deployment strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Jenkins pod priority class name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Jenkins pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Jenkins pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Jenkins container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Jenkins pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Jenkins pods",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Add lifecycle hooks to the Jenkins deployment",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Jenkins pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Jenkins pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Jenkins container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Jenkins HTTP container port",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Jenkins HTTPS container port",
+                    "default": 8443
+                },
+                "agentListener": {
+                    "type": "number",
+                    "description": "Jenkins agent listener port, ignored if agent.enabled=false",
+                    "default": 50000
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Jenkins pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Jenkins pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Jenkins containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Jenkins container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Jenkins container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 180
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 180
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Jenkins service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Jenkins service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Jenkins service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Jenkins service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Jenkins service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Jenkins service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Jenkins service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Jenkins service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "agentListenerService": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "",
+                    "default": true
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Jenkins service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "agentListener": {
+                            "type": "number",
+                            "description": "Jenkins service agent listener port",
+                            "default": 50000
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "agentListener": {
+                            "type": "string",
+                            "description": "Node port for agent listener",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Jenkins service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Jenkins service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Jenkins service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Jenkins service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Jenkins service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Jenkins",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "jenkins.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Use a existing PVC which must be created manually before bound",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the PVC",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "8Gi"
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for Ingester's data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
         }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\""
-        }
-      }
     }
-  }
 }

--- a/bitnami/joomla/values.schema.json
+++ b/bitnami/joomla/values.schema.json
@@ -1,188 +1,1017 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "joomlaUsername": {
-      "type": "string",
-      "title": "Username",
-      "form": true
-    },
-    "joomlaPassword": {
-      "type": "string",
-      "title": "Password",
-      "form": true,
-      "description": "Defaults to a random 10-character alphanumeric string if not set"
-    },
-    "joomlaEmail": {
-      "type": "string",
-      "title": "Admin email",
-      "form": true
-    },
-    "persistence": {
-      "type": "object",
-      "properties": {
-        "joomla": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi"
-            }
-          }
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress Configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the Joomla! installation."
-        },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\""
-        }
-      }
-    },
-    "mariadb": {
-      "type": "object",
-      "title": "MariaDB Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MariaDB database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
-        },
-        "primary": {
-          "type": "object",
-          "properties": {
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "title": "Volume Size",
-                  "form": true,
-                  "hidden": {
-                    "value": false,
-                    "path": "mariadb/enabled"
-                  },
-                  "render": "slider",
-                  "sliderMin": 1,
-                  "sliderMax": 100,
-                  "sliderUnit": "Gi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MariaDB is disabled. Use this section to specify the external database details",
-      "form": true,
-      "hidden": "mariadb/enabled",
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host"
         },
-        "user": {
-          "type": "string",
-          "form": true,
-          "title": "Database Username"
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
         },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password"
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
         },
-        "database": {
-          "type": "string",
-          "form": true,
-          "title": "Database Name"
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
         },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port"
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Requested Resources",
-      "description": "Configure resource requests",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Harbor resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Harbor resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Joomla! image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Joomla! Image name",
+                    "default": "bitnami/joomla"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Joomla! Image tag",
+                    "default": "4.3.4-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Joomla! image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Joomla! image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
             }
-          }
+        },
+        "joomlaSkipInstall": {
+            "type": "string",
+            "description": "Skip Joomla! installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": "no"
+        },
+        "joomlaUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "joomlaPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "joomlaEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "allowEmptyPassword": {
+            "type": "string",
+            "description": "Allow DB blank passwords",
+            "default": "no"
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Joomla! volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Joomla! volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Joomla! volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "Host mount path for Joomla! volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Joomla! pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Joomla! pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Joomla! containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Joomla! containers' Security Context",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Joomla! container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Define the priority class name to use for the joomla pods here.",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Joomla! service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the Joomla Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Joomla! service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Joomla! service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "joomla.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress resource",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_joomla"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_joomla"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Persistent Volume access modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Host mount path for MariaDB volume",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Enable persistence using an existing PVC",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the database existing Secret Object",
+                    "default": ""
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_joomla"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_joomla"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image name",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag",
+                            "default": "1.0.1-debian-11-r32"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Exporter resource requests/limit",
+                    "default": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by Joomla's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Joomla only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Joomla. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Joomla. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
         }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Metrics",
-          "description": "Prometheus Exporter / Metrics",
-          "form": true
-        }
-      }
     }
-  }
 }

--- a/bitnami/jupyterhub/values.schema.json
+++ b/bitnami/jupyterhub/values.schema.json
@@ -1,0 +1,2175 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/daemonset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/daemonset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "hub": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Hub image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Hub image repository",
+                            "default": "bitnami/jupyterhub"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Hub image tag (immutable tags are recommended)",
+                            "default": "4.0.2-debian-11-r17"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Hub image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Hub image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Hub image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "baseUrl": {
+                    "type": "string",
+                    "description": "Hub base URL",
+                    "default": "/"
+                },
+                "adminUser": {
+                    "type": "string",
+                    "description": "Hub Dummy authenticator admin user",
+                    "default": "user"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Hub Dummy authenticator password",
+                    "default": ""
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Hub configuration file (to be used by jupyterhub_config.py)",
+                    "default": "Chart:\n  Name: {{ .Chart.Name }}\n  Version: {{ .Chart.Version }}\nRelease:\n  Name: {{ .Release.Name }}\n  Namespace: {{ .Release.Namespace }}\n  Service: {{ .Release.Service }}\nhub:\n  config:\n    JupyterHub:\n      admin_access: true\n      authenticator_class: dummy\n      DummyAuthenticator:\n      {{- if .Values.hub.password }}\n        password: {{ .Values.hub.password | quote }}\n      {{- else }}\n        password: {{ randAlphaNum 10 | quote }}\n      {{- end }}\n      Authenticator:\n        admin_users:\n          - {{ .Values.hub.adminUser }}\n  cookieSecret:\n  concurrentSpawnLimit: 64\n  consecutiveFailureLimit: 5\n  activeServerLimit:\n  db:\n    type: postgres\n    url: postgresql://{{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled }}@{{ ternary (include \"jupyterhub.postgresql.fullname\" .) .Values.externalDatabase.host .Values.postgresql.enabled }}:{{ ternary \"5432\" .Values.externalDatabase.port .Values.postgresql.enabled }}/{{ ternary .Values.postgresql.auth.database .Values.externalDatabase.database .Values.postgresql.enabled }}\n  services: {}\n  allowNamedServers: false\n  namedServerLimitPerUser:\n  {{- if .Values.hub.metrics.serviceMonitor.enabled }}\n  authenticatePrometheus: {{ .Values.hub.metrics.authenticatePrometheus }}\n  {{- end }}\n  redirectToServer:\n  shutdownOnLogout:\nsingleuser:\n  podNameTemplate: {{ include \"common.names.fullname\" . }}-jupyter-{username}\n  {{- if .Values.singleuser.tolerations }}\n  extraTolerations: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.tolerations \"context\" $) | nindent 4 }}\n  {{- end }}\n  {{- if .Values.singleuser.nodeSelector }}\n  nodeSelector: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.nodeSelector \"context\" $) | nindent 4 }}\n  {{- end }}\n  networkTools:\n    image:\n      name: {{ include \"jupyterhub.hubconfiguration.imageEntry\" ( dict \"imageRoot\" .Values.auxiliaryImage \"global\" $) }}\n      tag: {{ .Values.auxiliaryImage.tag }}\n      digest: {{ .Values.auxiliaryImage.digest }}\n      pullPolicy: {{ .Values.auxiliaryImage.pullPolicy }}\n      pullSecrets: {{- include \"jupyterhub.imagePullSecrets.list\" . | nindent 8 }}\n  cloudMetadata:\n    blockWithIptables: false\n  events: true\n  extraAnnotations:\n    {{- if .Values.commonAnnotations }}\n    {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.commonAnnotations \"context\" $ ) | nindent 4 }}\n    {{- end }}\n    {{- if .Values.singleuser.podAnnotations }}\n    {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.podAnnotations \"context\" $ ) | nindent 4 }}\n    {{- end }}\n  extraLabels:\n    hub.jupyter.org/network-access-hub: \"true\"\n    app.kubernetes.io/component: singleuser\n    {{- include \"common.labels.standard\" ( dict \"customLabels\" .Values.commonLabels \"context\" $ ) | nindent 4 }}\n    {{- if .Values.singleuser.podLabels }}\n    {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.podLabels \"context\" $ ) | nindent 4 }}\n    {{- end }}\n  {{- if .Values.singleuser.extraEnvVars }}\n  extraEnv: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.extraEnvVars \"context\" $ ) | nindent 4 }}\n  {{- end }}\n  {{- if .Values.singleuser.lifecycleHooks }}\n  lifecycleHooks: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.lifecycleHooks \"context\" $ ) | nindent 4 }}\n  {{- end }}\n  {{- if .Values.singleuser.initContainers }}\n  initContainers: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.initContainers \"context\" $ ) | nindent 4 }}\n  {{- end }}\n  {{- if .Values.singleuser.sidecars }}\n  extraContainers: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.sidecars \"context\" $ ) | nindent 4 }}\n  {{- end }}\n  {{- if .Values.singleuser.containerSecurityContext.enabled }}\n  uid: {{ .Values.singleuser.containerSecurityContext.runAsUser }}\n  {{- end }}\n  {{- if .Values.singleuser.podSecurityContext.enabled }}\n  fsGid: {{ .Values.singleuser.podSecurityContext.fsGroup }}\n  {{- end }}\n  serviceAccountName: {{ template \"jupyterhub.singleuserServiceAccountName\" . }}\n  storage:\n    {{- if .Values.singleuser.persistence.enabled }}\n    type: dynamic\n    {{- else }}\n    type: none\n    {{- end }}\n    extraLabels:\n      app.kubernetes.io/component: singleuser\n      {{- include \"common.labels.standard\" ( dict \"customLabels\" .Values.commonLabels \"context\" $ ) | nindent 6 }}\n    {{- if .Values.singleuser.extraVolumes }}\n    extraVolumes: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.extraVolumes \"context\" $ ) | nindent 4 }}\n    {{- end }}\n    {{- if .Values.singleuser.extraVolumeMounts }}\n    extraVolumeMounts: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.extraVolumeMounts \"context\" $ ) | nindent 4 }}\n    {{- end }}\n    capacity: {{ .Values.singleuser.persistence.size }}\n    homeMountPath: {{ .Values.singleuser.notebookDir }}\n    dynamic:\n      {{ include \"jupyterhub.storage.class\" (dict \"persistence\" .Values.singleuser.persistence \"global\" .Values.global) }}\n      pvcNameTemplate: {{ include \"common.names.fullname\" . }}-claim-{username}{servername}\n      volumeNameTemplate: {{ include \"common.names.fullname\" . }}-volume-{username}{servername}\n      storageAccessModes: {{- include \"common.tplvalues.render\" ( dict \"value\" .Values.singleuser.persistence.accessModes \"context\" $ ) | nindent 8 }}\n  image:\n    name: {{ include \"jupyterhub.hubconfiguration.imageEntry\" ( dict \"imageRoot\" .Values.singleuser.image \"global\" $) }}\n    tag: {{ .Values.singleuser.image.tag }}\n    digest: {{ .Values.singleuser.image.digest }}\n    pullPolicy: {{ .Values.singleuser.image.pullPolicy }}\n    pullSecrets: {{- include \"jupyterhub.imagePullSecrets.list\" . | nindent 8 }}\n  startTimeout: 300\n  {{- /* We need to replace the Kubernetes memory/cpu terminology (e.g. 10Gi, 10Mi) with one compatible with Python (10G, 10M) */}}\n  cpu:\n    limit: {{ regexReplaceAll \"([A-Za-z])i\" (default \"\" .Values.singleuser.resources.limits.cpu)  \"${1}\" }}\n    guarantee: {{ regexReplaceAll \"([A-Za-z])i\" (default \"\" .Values.singleuser.resources.requests.cpu) \"${1}\" }}\n  memory:\n    limit: {{ regexReplaceAll \"([A-Za-z])i\" (default \"\" .Values.singleuser.resources.limits.memory) \"${1}\" }}\n    guarantee: {{ regexReplaceAll \"([A-Za-z])i\" (default \"\" .Values.singleuser.resources.requests.memory) \"${1}\" }}\n  {{- if .Values.singleuser.command }}\n  cmd: {{- include \"common.tplvalues.render\" (dict \"value\" .Values.singleuser.command \"context\" $) | nindent 12 }}\n  {{- else }}\n  cmd: jupyterhub-singleuser\n  {{- end }}\n  defaultUrl:\ncull:\n  enabled: true\n  users: false\n  removeNamedServers: false\n  timeout: 3600\n  every: 600\n  concurrency: 10\n  maxAge: 0\n"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Secret with hub configuration (replaces the hub.configuration value) and proxy token",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Hub default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override Hub default args",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables to the Hub container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Hub container port",
+                            "default": 8081
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Hub containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Hub containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Hub containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Hub containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Hub containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Hub containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Hub container's Security Context runAsUser",
+                            "default": 1000
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Hub container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Hub pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Hub pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHooks for the Hub container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add extra labels to the Hub pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Add extra annotations to the Hub pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `hub.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `hub.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment.",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment.",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment.",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Hub pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Hub deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Hub pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Hub container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Hub pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Hub pod",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy Hub PodDisruptionBudget",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "string",
+                            "description": "Set minimum available hub instances",
+                            "default": ""
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Set maximum available hub instances",
+                            "default": ""
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Override Hub service account name",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Deploy Hub network policies",
+                            "default": true
+                        },
+                        "allowInterspaceAccess": {
+                            "type": "boolean",
+                            "description": "Allow communication between pods in different namespaces",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "string",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": ""
+                        },
+                        "extraEgress": {
+                            "type": "string",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": "## Hub --> Any IP:PORT\n##\n- to:\n"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Hub service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Hub service HTTP port",
+                                    "default": 8081
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "NodePort for the HTTP endpoint",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Hub service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Hub service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Hub service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Hub service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Hub service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra port to expose on Hub service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "authenticatePrometheus": {
+                            "type": "boolean",
+                            "description": "Use authentication for Prometheus",
+                            "default": false
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "If the operator is installed in your cluster, set to true to create a Service Monitor Entry",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "HTTP path to scrape for metrics",
+                                    "default": "/hub/metrics"
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Specify the timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                                    "default": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "Specify honorLabels parameter to add the scrape endpoint",
+                                    "default": false
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Proxy image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Proxy image repository",
+                            "default": "bitnami/configurable-http-proxy"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Proxy image tag (immutable tags are recommended)",
+                            "default": "4.5.6-debian-11-r16"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Proxy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Proxy image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Activate verbose output",
+                            "default": false
+                        }
+                    }
+                },
+                "secretToken": {
+                    "type": "string",
+                    "description": "Proxy secret token (used for communication with the Hub)",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Proxy default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override Proxy default args",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables to the Proxy container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "containerPort": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "number",
+                            "description": "Proxy api container port",
+                            "default": 8001
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "Proxy metrics container port",
+                            "default": 8002
+                        },
+                        "http": {
+                            "type": "number",
+                            "description": "Proxy http container port",
+                            "default": 8000
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Proxy containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Proxy containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Proxy containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Proxy containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Proxy containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Proxy containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Proxy container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Proxy container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Proxy pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Proxy pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Add lifecycle hooks to the Proxy deployment",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Add extra labels to the Proxy pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Add extra annotations to the Proxy pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `proxy.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `proxy.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment. Evaluated as a template.",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment. Evaluated as a template.",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment. Evaluated as a template.",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Proxy pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Proxy deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Proxy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Proxy container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Proxy pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Proxy pod",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy Proxy PodDisruptionBudget",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "string",
+                            "description": "Set minimum available proxy instances",
+                            "default": ""
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Set maximum available proxy instances",
+                            "default": ""
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Override Hub service account name",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Deploy Proxy network policies",
+                            "default": true
+                        },
+                        "allowInterspaceAccess": {
+                            "type": "boolean",
+                            "description": "Allow communication between pods in different namespaces",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "string",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": "## Any IP --> Proxy\n##\n- ports:\n    - port: {{ .Values.proxy.containerPort.http }}\n"
+                        },
+                        "extraEgress": {
+                            "type": "string",
+                            "description": "Add extra egress rules to the NetworkPolicy",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "API service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "API service HTTP port",
+                                            "default": 8001
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "NodePort for the HTTP endpoint",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Hub service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Hub service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Hub service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Hub service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Hub service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra port to expose on Hub service",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Metrics service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Metrics service port",
+                                            "default": 8002
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "NodePort for the HTTP endpoint",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Hub service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Hub service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Hub service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Hub service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Hub service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra port to expose on Hub service",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "public": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Public service type",
+                                    "default": "LoadBalancer"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Public service HTTP port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "NodePort for the HTTP endpoint",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Hub service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Hub service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Hub service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Hub service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Hub service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra port to expose on Hub service",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set to true to enable ingress record generation",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Set ingress rule hostname",
+                            "default": "jupyterhub.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to the Proxy pod",
+                            "default": "/"
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "If the operator is installed in your cluster, set to true to create a Service Monitor Entry",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "HTTP path to scrape for metrics",
+                                    "default": "/metrics"
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Specify the timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                                    "default": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "RelabelConfigs to apply to samples before scraping",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "Specify honorLabels parameter to add the scrape endpoint",
+                                    "default": false
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "imagePuller": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy ImagePuller daemonset",
+                    "default": true
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override ImagePuller default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override ImagePuller default args",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Add extra environment variables to the ImagePuller container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the ImagePuller containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the ImagePuller containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled ImagePuller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set ImagePuller container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set ImagePuller container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled ImagePuller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set ImagePuller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Add lifecycle hooks to the ImagePuller deployment",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Pod extra labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ImagePuller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `imagePuller.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `imagePuller.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment. Evaluated as a template.",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment. Evaluated as a template.",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment. Evaluated as a template.",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class Name",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds ImagePuller pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "ImagePuller deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for ImagePuller pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for ImagePuller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the ImagePuller pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the ImagePuller pod",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "singleuser": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Single User image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Single User image repository",
+                            "default": "bitnami/jupyter-base-notebook"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Single User image tag (immutabe tags are recommended)",
+                            "default": "4.0.2-debian-11-r16"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Single User image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Single User image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Single User image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "notebookDir": {
+                    "type": "string",
+                    "description": "Notebook directory (it will be the same as the PVC volume mount)",
+                    "default": "/opt/bitnami/jupyterhub-singleuser"
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Controls whether a process can gain more privileges than its parent process",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Single User default command",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables that should be set for the user pods",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Single User container port",
+                    "default": 8888
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Singleuser containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Singleuser containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Single User containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Single User container's Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Single User pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Single User pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Single User pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Single User pods",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment. Evaluated as a template.",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment. Evaluated as a template.",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Single User pod priority class name",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Add lifecycle hooks to the Single User deployment to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Single User pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Single User container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Single User pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Single User pod",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Override Single User service account name",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistent volume creation on Single User instances",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volumes storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volumes access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volumes size",
+                            "default": "10Gi"
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Deploy Single User network policies",
+                            "default": true
+                        },
+                        "allowInterspaceAccess": {
+                            "type": "boolean",
+                            "description": "Allow communication between pods in different namespaces",
+                            "default": true
+                        },
+                        "allowCloudMetadataAccess": {
+                            "type": "boolean",
+                            "description": "Allow Single User pods to access Cloud Metada endpoints",
+                            "default": false
+                        },
+                        "extraIngress": {
+                            "type": "string",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": ""
+                        },
+                        "extraEgress": {
+                            "type": "string",
+                            "description": "Add extra egress rules to the NetworkPolicy",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "auxiliaryImage": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Auxiliary image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Auxiliary image repository",
+                    "default": "bitnami/os-shell"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Auxiliary image tag (immutabe tags are recommended)",
+                    "default": "11-debian-11-r51"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Auxiliary image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Auxiliary image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_jupyterhub"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_jupyterhub"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for JupyterHub",
+                    "default": "postgres"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for JupyterHub",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "JupyterHub database name",
+                    "default": "jupyterhub"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kafka/values.schema.json
+++ b/bitnami/kafka/values.schema.json
@@ -1,0 +1,3333 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Kafka image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Kafka image repository",
+                    "default": "bitnami/kafka"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Kafka image tag (immutable tags are recommended)",
+                    "default": "3.5.1-debian-11-r44"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Kafka image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Kafka image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "extraInit": {
+            "type": "string",
+            "description": "Additional content for the kafka init script, rendered as a template.",
+            "default": ""
+        },
+        "config": {
+            "type": "string",
+            "description": "Configuration file for Kafka, rendered as a template. Auto-generated based on chart values when not specified.",
+            "default": ""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "ConfigMap with Kafka Configuration",
+            "default": ""
+        },
+        "extraConfig": {
+            "type": "string",
+            "description": "Additional configuration to be appended at the end of the generated Kafka configuration file.",
+            "default": ""
+        },
+        "secretConfig": {
+            "type": "string",
+            "description": "Additional configuration to be appended at the end of the generated Kafka configuration file.",
+            "default": ""
+        },
+        "existingSecretConfig": {
+            "type": "string",
+            "description": "Secret with additonal configuration that will be appended to the end of the generated Kafka configuration file",
+            "default": ""
+        },
+        "log4j": {
+            "type": "string",
+            "description": "An optional log4j.properties file to overwrite the default of the Kafka brokers",
+            "default": ""
+        },
+        "existingLog4jConfigMap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap containing a log4j.properties file",
+            "default": ""
+        },
+        "heapOpts": {
+            "type": "string",
+            "description": "Kafka Java Heap size",
+            "default": "-Xmx1024m -Xms1024m"
+        },
+        "interBrokerProtocolVersion": {
+            "type": "string",
+            "description": "Override the setting 'inter.broker.protocol.version' during the ZK migration.",
+            "default": ""
+        },
+        "listeners": {
+            "type": "object",
+            "properties": {
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name for the Kafka client listener",
+                            "default": "CLIENT"
+                        },
+                        "containerPort": {
+                            "type": "number",
+                            "description": "Port for the Kafka client listener",
+                            "default": 9092
+                        },
+                        "protocol": {
+                            "type": "string",
+                            "description": "Security protocol for the Kafka client listener. Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'",
+                            "default": "SASL_PLAINTEXT"
+                        },
+                        "sslClientAuth": {
+                            "type": "string",
+                            "description": "Optional. If SASL_SSL is enabled, configure mTLS TLS authentication type. If SSL protocol is enabled, overrides tls.authType for this listener. Allowed values are 'none', 'requested' and 'required'",
+                            "default": ""
+                        }
+                    }
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name for the Kafka controller listener",
+                            "default": "CONTROLLER"
+                        },
+                        "containerPort": {
+                            "type": "number",
+                            "description": "Port for the Kafka controller listener",
+                            "default": 9093
+                        },
+                        "protocol": {
+                            "type": "string",
+                            "description": "Security protocol for the Kafka controller listener. Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'",
+                            "default": "SASL_PLAINTEXT"
+                        },
+                        "sslClientAuth": {
+                            "type": "string",
+                            "description": "Optional. If SASL_SSL is enabled, configure mTLS TLS authentication type. If SSL protocol is enabled, overrides tls.authType for this listener. Allowed values are 'none', 'requested' and 'required'",
+                            "default": ""
+                        }
+                    }
+                },
+                "interbroker": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name for the Kafka inter-broker listener",
+                            "default": "INTERNAL"
+                        },
+                        "containerPort": {
+                            "type": "number",
+                            "description": "Port for the Kafka inter-broker listener",
+                            "default": 9094
+                        },
+                        "protocol": {
+                            "type": "string",
+                            "description": "Security protocol for the Kafka inter-broker listener. Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'",
+                            "default": "SASL_PLAINTEXT"
+                        },
+                        "sslClientAuth": {
+                            "type": "string",
+                            "description": "Optional. If SASL_SSL is enabled, configure mTLS TLS authentication type. If SSL protocol is enabled, overrides tls.authType for this listener. Allowed values are 'none', 'requested' and 'required'",
+                            "default": ""
+                        }
+                    }
+                },
+                "external": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "number",
+                            "description": "Port for the Kafka external listener",
+                            "default": 9095
+                        },
+                        "protocol": {
+                            "type": "string",
+                            "description": "Security protocol for the Kafka external listener. . Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'",
+                            "default": "SASL_PLAINTEXT"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name for the Kafka external listener",
+                            "default": "EXTERNAL"
+                        },
+                        "sslClientAuth": {
+                            "type": "string",
+                            "description": "Optional. If SASL_SSL is enabled, configure mTLS TLS authentication type. If SSL protocol is enabled, overrides tls.sslClientAuth for this listener. Allowed values are 'none', 'requested' and 'required'",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraListeners": {
+                    "type": "array",
+                    "description": "Array of listener objects to be appended to already existing listeners",
+                    "default": [],
+                    "items": {}
+                },
+                "overrideListeners": {
+                    "type": "string",
+                    "description": "Overrides the Kafka 'listeners' configuration setting.",
+                    "default": ""
+                },
+                "advertisedListeners": {
+                    "type": "string",
+                    "description": "Overrides the Kafka 'advertised.listener' configuration setting.",
+                    "default": ""
+                },
+                "securityProtocolMap": {
+                    "type": "string",
+                    "description": "Overrides the Kafka 'security.protocol.map' configuration setting.",
+                    "default": ""
+                }
+            }
+        },
+        "sasl": {
+            "type": "object",
+            "properties": {
+                "enabledMechanisms": {
+                    "type": "string",
+                    "description": "Comma-separated list of allowed SASL mechanisms when SASL listeners are configured. Allowed types: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`",
+                    "default": "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
+                },
+                "interBrokerMechanism": {
+                    "type": "string",
+                    "description": "SASL mechanism for inter broker communication.",
+                    "default": "PLAIN"
+                },
+                "controllerMechanism": {
+                    "type": "string",
+                    "description": "SASL mechanism for controller communications.",
+                    "default": "PLAIN"
+                },
+                "interbroker": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "Username for inter-broker communications when SASL is enabled",
+                            "default": "inter_broker_user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for inter-broker communications when SASL is enabled. If not set and SASL is enabled for the controller listener, a random password will be generated.",
+                            "default": ""
+                        }
+                    }
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "Username for controller communications when SASL is enabled",
+                            "default": "controller_user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for controller communications when SASL is enabled. If not set and SASL is enabled for the inter-broker listener, a random password will be generated.",
+                            "default": ""
+                        }
+                    }
+                },
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "users": {
+                            "type": "array",
+                            "description": "Comma-separated list of usernames for client communications when SASL is enabled",
+                            "default": [
+                                "user1"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "passwords": {
+                            "type": "string",
+                            "description": "Comma-separated list of passwords for client communications when SASL is enabled, must match the number of client.users",
+                            "default": ""
+                        }
+                    }
+                },
+                "zookeeper": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "Username for zookeeper communications when SASL is enabled.",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for zookeeper communications when SASL is enabled.",
+                            "default": ""
+                        }
+                    }
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing credentials for clientUsers, interBrokerUser, controllerUser and zookeeperUser",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Format to use for TLS certificates. Allowed types: `JKS` and `PEM`",
+                    "default": "JKS"
+                },
+                "pemChainIncluded": {
+                    "type": "boolean",
+                    "description": "Flag to denote that the Certificate Authority (CA) certificates are bundled with the endpoint cert.",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing the TLS certificates for the Kafka nodes.",
+                    "default": ""
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates for Kafka brokers. Currently only supported if `tls.type` is `PEM`",
+                    "default": false
+                },
+                "passwordsSecret": {
+                    "type": "string",
+                    "description": "Name of the secret containing the password to access the JKS files or PEM key when they are password-protected. (`key`: `password`)",
+                    "default": ""
+                },
+                "passwordsSecretKeystoreKey": {
+                    "type": "string",
+                    "description": "The secret key from the tls.passwordsSecret containing the password for the Keystore.",
+                    "default": "keystore-password"
+                },
+                "passwordsSecretTruststoreKey": {
+                    "type": "string",
+                    "description": "The secret key from the tls.passwordsSecret containing the password for the Truststore.",
+                    "default": "truststore-password"
+                },
+                "passwordsSecretPemPasswordKey": {
+                    "type": "string",
+                    "description": "The secret key from the tls.passwordsSecret containing the password for the PEM key inside 'tls.passwordsSecret'.",
+                    "default": ""
+                },
+                "keystorePassword": {
+                    "type": "string",
+                    "description": "Password to access the JKS keystore when it is password-protected. Ignored when 'tls.passwordsSecret' is provided.",
+                    "default": ""
+                },
+                "truststorePassword": {
+                    "type": "string",
+                    "description": "Password to access the JKS truststore when it is password-protected. Ignored when 'tls.passwordsSecret' is provided.",
+                    "default": ""
+                },
+                "keyPassword": {
+                    "type": "string",
+                    "description": "Password to access the PEM key when it is password-protected.",
+                    "default": ""
+                },
+                "jksTruststoreSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing your truststore if truststore not existing or different from the one in the `tls.existingSecret`",
+                    "default": ""
+                },
+                "jksTruststoreKey": {
+                    "type": "string",
+                    "description": "The secret key from the `tls.existingSecret` or `tls.jksTruststoreSecret` containing the truststore",
+                    "default": ""
+                },
+                "endpointIdentificationAlgorithm": {
+                    "type": "string",
+                    "description": "The endpoint identification algorithm to validate server hostname using server certificate",
+                    "default": "https"
+                },
+                "sslClientAuth": {
+                    "type": "string",
+                    "description": "Sets the default value for the ssl.client.auth Kafka setting.",
+                    "default": "required"
+                },
+                "zookeeper": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS for Zookeeper client connections.",
+                            "default": false
+                        },
+                        "verifyHostname": {
+                            "type": "boolean",
+                            "description": "Hostname validation.",
+                            "default": true
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for ZooKeeper client communications.",
+                            "default": ""
+                        },
+                        "existingSecretKeystoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the  tls.zookeeper.existingSecret containing the Keystore.",
+                            "default": "zookeeper.keystore.jks"
+                        },
+                        "existingSecretTruststoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.zookeeper.existingSecret containing the Truststore.",
+                            "default": "zookeeper.truststore.jks"
+                        },
+                        "passwordsSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing Keystore and Truststore passwords.",
+                            "default": ""
+                        },
+                        "passwordsSecretKeystoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.zookeeper.passwordsSecret containing the password for the Keystore.",
+                            "default": "keystore-password"
+                        },
+                        "passwordsSecretTruststoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.zookeeper.passwordsSecret containing the password for the Truststore.",
+                            "default": "truststore-password"
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access the JKS keystore when it is password-protected. Ignored when 'tls.passwordsSecret' is provided.",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access the JKS truststore when it is password-protected. Ignored when 'tls.passwordsSecret' is provided.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to add to Kafka pods",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the Kafka pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Kafka container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Kafka pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional Add init containers to the Kafka pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Kafka controller-eligible nodes",
+                    "default": 3
+                },
+                "controllerOnly": {
+                    "type": "boolean",
+                    "description": "If set to true, controller nodes will be deployed as dedicated controllers, instead of controller+broker processes.",
+                    "default": false
+                },
+                "minId": {
+                    "type": "number",
+                    "description": "Minimal node.id values for controller-eligible nodes. Do not change after first initialization.",
+                    "default": 0
+                },
+                "zookeeperMigrationMode": {
+                    "type": "boolean",
+                    "description": "Set to true to deploy cluster controller quorum",
+                    "default": false
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Configuration file for Kafka controller-eligible nodes, rendered as a template. Auto-generated based on chart values when not specified.",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "ConfigMap with Kafka Configuration for controller-eligible nodes.",
+                    "default": ""
+                },
+                "extraConfig": {
+                    "type": "string",
+                    "description": "Additional configuration to be appended at the end of the generated Kafka controller-eligible nodes configuration file.",
+                    "default": ""
+                },
+                "secretConfig": {
+                    "type": "string",
+                    "description": "Additional configuration to be appended at the end of the generated Kafka controller-eligible nodes configuration file.",
+                    "default": ""
+                },
+                "existingSecretConfig": {
+                    "type": "string",
+                    "description": "Secret with additonal configuration that will be appended to the end of the generated Kafka controller-eligible nodes configuration file",
+                    "default": ""
+                },
+                "heapOpts": {
+                    "type": "string",
+                    "description": "Kafka Java Heap size for controller-eligible nodes",
+                    "default": "-Xmx1024m -Xms1024m"
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Kafka container command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override Kafka container arguments",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to Kafka pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraContainerPorts": {
+                    "type": "array",
+                    "description": "Kafka controller-eligible extra containerPorts.",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Kafka containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Kafka containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Kafka containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the Kafka container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Kafka pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Kafka pods's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Kafka containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Kafka containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Force the child process to be run as non-privileged",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Allows the pod to mount the RootFS as ReadOnly only",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Kafka containers' server Security Context capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Kafka pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for Kafka pods",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for Kafka pods",
+                    "default": false
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Kafka pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Extra annotations for Kafka pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds the pod needs to gracefully terminate",
+                    "default": ""
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel",
+                    "default": "Parallel"
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Name of the existing priority class to be used by kafka pods",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "enableServiceLinks": {
+                    "type": "boolean",
+                    "description": "Whether information about services should be injected into pod's environment variable",
+                    "default": true
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kafka statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Kafka pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Kafka container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Kafka pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional Add init containers to the Kafka pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy a pdb object for the Kafka pod",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of unavailable Kafka replicas",
+                            "default": ""
+                        },
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Maximum number/percentage of unavailable Kafka replicas",
+                            "default": 1
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka data persistence using PVC, note that ZooKeeper persistence is unaffected",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "A manually managed Persistent Volume and Claim",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Kafka data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Kafka data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Kafka data PVC. If set, the PVC can't have a PV dynamically provisioned for it",
+                            "default": {}
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Mount path of the Kafka data volume",
+                            "default": "/bitnami/kafka"
+                        }
+                    }
+                },
+                "logPersistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka logs persistence using PVC, note that ZooKeeper persistence is unaffected",
+                            "default": false
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "A manually managed Persistent Volume and Claim",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Kafka logs volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Kafka logs volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Kafka log data PVC. If set, the PVC can't have a PV dynamically provisioned for it",
+                            "default": {}
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Mount path of the Kafka logs volume",
+                            "default": "/opt/bitnami/kafka/logs"
+                        }
+                    }
+                }
+            }
+        },
+        "broker": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Kafka broker-only nodes",
+                    "default": 0
+                },
+                "minId": {
+                    "type": "number",
+                    "description": "Minimal node.id values for broker-only nodes. Do not change after first initialization.",
+                    "default": 100
+                },
+                "zookeeperMigrationMode": {
+                    "type": "boolean",
+                    "description": "Set to true to deploy cluster controller quorum",
+                    "default": false
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Configuration file for Kafka broker-only nodes, rendered as a template. Auto-generated based on chart values when not specified.",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "ConfigMap with Kafka Configuration for broker-only nodes.",
+                    "default": ""
+                },
+                "extraConfig": {
+                    "type": "string",
+                    "description": "Additional configuration to be appended at the end of the generated Kafka broker-only nodes configuration file.",
+                    "default": ""
+                },
+                "secretConfig": {
+                    "type": "string",
+                    "description": "Additional configuration to be appended at the end of the generated Kafka broker-only nodes configuration file.",
+                    "default": ""
+                },
+                "existingSecretConfig": {
+                    "type": "string",
+                    "description": "Secret with additonal configuration that will be appended to the end of the generated Kafka broker-only nodes configuration file",
+                    "default": ""
+                },
+                "heapOpts": {
+                    "type": "string",
+                    "description": "Kafka Java Heap size for broker-only nodes",
+                    "default": "-Xmx1024m -Xms1024m"
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Kafka container command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override Kafka container arguments",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to Kafka pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraContainerPorts": {
+                    "type": "array",
+                    "description": "Kafka broker-only extra containerPorts.",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Kafka containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Kafka containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Kafka containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the Kafka container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Kafka pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Kafka pod's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Kafka containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Kafka containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Force the child process to be run as non-privileged",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Allows the pod to mount the RootFS as ReadOnly only",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Kafka containers' server Security Context capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Kafka pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for Kafka pods",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for Kafka pods",
+                    "default": false
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Kafka pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Extra annotations for Kafka pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds the pod needs to gracefully terminate",
+                    "default": ""
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel",
+                    "default": "Parallel"
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Name of the existing priority class to be used by kafka pods",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by pod(s)",
+                    "default": ""
+                },
+                "enableServiceLinks": {
+                    "type": "boolean",
+                    "description": "Whether information about services should be injected into pod's environment variable",
+                    "default": true
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kafka statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Kafka pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Kafka container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Kafka pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional Add init containers to the Kafka pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Deploy a pdb object for the Kafka pod",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of unavailable Kafka replicas",
+                            "default": ""
+                        },
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Maximum number/percentage of unavailable Kafka replicas",
+                            "default": 1
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka data persistence using PVC, note that ZooKeeper persistence is unaffected",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "A manually managed Persistent Volume and Claim",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Kafka data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Kafka data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Kafka data PVC. If set, the PVC can't have a PV dynamically provisioned for it",
+                            "default": {}
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Mount path of the Kafka data volume",
+                            "default": "/bitnami/kafka"
+                        }
+                    }
+                },
+                "logPersistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka logs persistence using PVC, note that ZooKeeper persistence is unaffected",
+                            "default": false
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "A manually managed Persistent Volume and Claim",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for Kafka logs volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for Kafka logs volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for Kafka log data PVC. If set, the PVC can't have a PV dynamically provisioned for it",
+                            "default": {}
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Mount path of the Kafka logs volume",
+                            "default": "/opt/bitnami/kafka/logs"
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "number",
+                            "description": "Kafka svc port for client connections",
+                            "default": 9092
+                        },
+                        "controller": {
+                            "type": "number",
+                            "description": "Kafka svc port for controller connections. It is used if \"kraft.enabled: true\"",
+                            "default": 9093
+                        },
+                        "interbroker": {
+                            "type": "number",
+                            "description": "Kafka svc port for inter-broker connections",
+                            "default": 9094
+                        },
+                        "external": {
+                            "type": "number",
+                            "description": "Kafka svc port for external connections",
+                            "default": 9095
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the Kafka service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "string",
+                            "description": "Node port for the Kafka client connections",
+                            "default": ""
+                        },
+                        "external": {
+                            "type": "string",
+                            "description": "Node port for the Kafka external connections",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Kafka service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Kafka service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Kafka service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Kafka service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Kafka service",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "controller": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the controller-eligible headless service.",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Labels for the controller-eligible headless service.",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "broker": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the broker-only headless service.",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Labels for the broker-only headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalAccess": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Kubernetes external cluster access to Kafka brokers",
+                    "default": false
+                },
+                "autoDiscovery": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable using an init container to auto-detect external IPs/ports by querying the K8s API",
+                            "default": false
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image repository",
+                                    "default": "bitnami/kubectl"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image tag (immutable tags are recommended)",
+                                    "default": "1.25.13-debian-11-r11"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Kubectl image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Init container auto-discovery image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the auto-discovery init container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the auto-discovery init container",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "forceExpose": {
+                            "type": "boolean",
+                            "description": "If set to true, force exposing controller-eligible nodes although they are configured as controller-only nodes",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP",
+                                    "default": "LoadBalancer"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "external": {
+                                            "type": "number",
+                                            "description": "Kafka port used for external access when service type is LoadBalancer",
+                                            "default": 9094
+                                        }
+                                    }
+                                },
+                                "loadBalancerIPs": {
+                                    "type": "array",
+                                    "description": "Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerNames": {
+                                    "type": "array",
+                                    "description": "Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerAnnotations": {
+                                    "type": "array",
+                                    "description": "Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Address(es) that are allowed when service is LoadBalancer",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "nodePorts": {
+                                    "type": "array",
+                                    "description": "Array of node ports used for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalIPs": {
+                                    "type": "array",
+                                    "description": "Use distinct service host IPs to configure Kafka external listener when service type is NodePort. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "useHostIPs": {
+                                    "type": "boolean",
+                                    "description": "Use service host IPs to configure Kafka external listener when service type is NodePort",
+                                    "default": false
+                                },
+                                "usePodIPs": {
+                                    "type": "boolean",
+                                    "description": "using the MY_POD_IP address for external access.",
+                                    "default": false
+                                },
+                                "domain": {
+                                    "type": "string",
+                                    "description": "Domain or external ip used to configure Kafka external listener when service type is NodePort or ClusterIP",
+                                    "default": ""
+                                },
+                                "publishNotReadyAddresses": {
+                                    "type": "boolean",
+                                    "description": "Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready",
+                                    "default": false
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Service labels for external access",
+                                    "default": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Service annotations for external access",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in the Kafka external service",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "broker": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP",
+                                    "default": "LoadBalancer"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "external": {
+                                            "type": "number",
+                                            "description": "Kafka port used for external access when service type is LoadBalancer",
+                                            "default": 9094
+                                        }
+                                    }
+                                },
+                                "loadBalancerIPs": {
+                                    "type": "array",
+                                    "description": "Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerNames": {
+                                    "type": "array",
+                                    "description": "Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerAnnotations": {
+                                    "type": "array",
+                                    "description": "Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Address(es) that are allowed when service is LoadBalancer",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "nodePorts": {
+                                    "type": "array",
+                                    "description": "Array of node ports used for each Kafka broker. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalIPs": {
+                                    "type": "array",
+                                    "description": "Use distinct service host IPs to configure Kafka external listener when service type is NodePort. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "useHostIPs": {
+                                    "type": "boolean",
+                                    "description": "Use service host IPs to configure Kafka external listener when service type is NodePort",
+                                    "default": false
+                                },
+                                "usePodIPs": {
+                                    "type": "boolean",
+                                    "description": "using the MY_POD_IP address for external access.",
+                                    "default": false
+                                },
+                                "domain": {
+                                    "type": "string",
+                                    "description": "Domain or external ip used to configure Kafka external listener when service type is NodePort or ClusterIP",
+                                    "default": ""
+                                },
+                                "publishNotReadyAddresses": {
+                                    "type": "boolean",
+                                    "description": "Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready",
+                                    "default": false
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Service labels for external access",
+                                    "default": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Service annotations for external access",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in the Kafka external service",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether a NetworkPolicy should be created",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "explicitNamespacesSelector": {
+                    "type": "object",
+                    "description": "A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed",
+                    "default": {}
+                },
+                "externalAccess": {
+                    "type": "object",
+                    "properties": {
+                        "from": {
+                            "type": "array",
+                            "description": "customize the from section for External Access on tcp-external port",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Kafka pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the service account to use. If not set and `create` is `true`, a name is generated",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create & use RBAC resources or not",
+                    "default": false
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "kafka": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to create a standalone Kafka exporter to expose Kafka metrics",
+                            "default": false
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Kafka exporter image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Kafka exporter image repository",
+                                    "default": "bitnami/kafka-exporter"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Kafka exporter image tag (immutable tags are recommended)",
+                                    "default": "1.7.0-debian-11-r102"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Kafka exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Kafka exporter image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Specify docker-registry secret names as an array",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "certificatesSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the optional certificate and key files",
+                            "default": ""
+                        },
+                        "tlsCert": {
+                            "type": "string",
+                            "description": "The secret key from the certificatesSecret if 'client-cert' key different from the default (cert-file)",
+                            "default": "cert-file"
+                        },
+                        "tlsKey": {
+                            "type": "string",
+                            "description": "The secret key from the certificatesSecret if 'client-key' key different from the default (key-file)",
+                            "default": "key-file"
+                        },
+                        "tlsCaSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the optional ca certificate for Kafka exporter client authentication",
+                            "default": ""
+                        },
+                        "tlsCaCert": {
+                            "type": "string",
+                            "description": "The secret key from the certificatesSecret or tlsCaSecret if 'ca-cert' key different from the default (ca-file)",
+                            "default": "ca-file"
+                        },
+                        "extraFlags": {
+                            "type": "object",
+                            "description": "Extra flags to be passed to Kafka exporter",
+                            "default": {}
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override Kafka exporter container command",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override Kafka exporter container arguments",
+                            "default": [],
+                            "items": {}
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Kafka exporter metrics container port",
+                                    "default": 9308
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable security context for the pods",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Set Kafka exporter pod's Security Context fsGroup",
+                                    "default": 1001
+                                },
+                                "seccompProfile": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Set Kafka exporter pod's Security Context seccomp profile",
+                                            "default": "RuntimeDefault"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable Kafka exporter containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Kafka exporter containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Kafka exporter containers' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Set Kafka exporter containers' Security Context allowPrivilegeEscalation",
+                                    "default": false
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set Kafka exporter containers' Security Context readOnlyRootFilesystem",
+                                    "default": true
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set Kafka exporter containers' Security Context capabilities to be dropped",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hostAliases": {
+                            "type": "array",
+                            "description": "Kafka exporter pods host aliases",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podLabels": {
+                            "type": "object",
+                            "description": "Extra labels for Kafka exporter pods",
+                            "default": {}
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Extra annotations for Kafka exporter pods",
+                            "default": {}
+                        },
+                        "podAffinityPreset": {
+                            "type": "string",
+                            "description": "Pod affinity preset. Ignored if `metrics.kafka.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "podAntiAffinityPreset": {
+                            "type": "string",
+                            "description": "Pod anti-affinity preset. Ignored if `metrics.kafka.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": "soft"
+                        },
+                        "nodeAffinityPreset": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Node affinity preset type. Ignored if `metrics.kafka.affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Node label key to match Ignored if `metrics.kafka.affinity` is set.",
+                                    "default": ""
+                                },
+                                "values": {
+                                    "type": "array",
+                                    "description": "Node label values to match. Ignored if `metrics.kafka.affinity` is set.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "affinity": {
+                            "type": "object",
+                            "description": "Affinity for pod assignment",
+                            "default": {}
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "description": "Node labels for pod assignment",
+                            "default": {}
+                        },
+                        "tolerations": {
+                            "type": "array",
+                            "description": "Tolerations for pod assignment",
+                            "default": [],
+                            "items": {}
+                        },
+                        "schedulerName": {
+                            "type": "string",
+                            "description": "Name of the k8s scheduler (other than default) for Kafka exporter",
+                            "default": ""
+                        },
+                        "enableServiceLinks": {
+                            "type": "boolean",
+                            "description": "Whether information about services should be injected into pod's environment variable",
+                            "default": true
+                        },
+                        "priorityClassName": {
+                            "type": "string",
+                            "description": "Kafka exporter pods' priorityClassName",
+                            "default": ""
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array",
+                            "description": "Topology Spread Constraints for pod assignment",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumes": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumes for the Kafka exporter pod(s)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the Kafka exporter container(s)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sidecars": {
+                            "type": "array",
+                            "description": "Add additional sidecar containers to the Kafka exporter pod(s)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "initContainers": {
+                            "type": "array",
+                            "description": "Add init containers to the Kafka exporter pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Kafka exporter metrics service port",
+                                            "default": 9308
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Static clusterIP or None for headless services",
+                                    "default": ""
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.metrics.kafka.service.ports.metrics }}"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/metrics"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "serviceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Enable creation of ServiceAccount for Kafka exporter pods",
+                                    "default": true
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "The name of the service account to use. If not set and `create` is `true`, a name is generated",
+                                    "default": ""
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                                    "default": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "jmx": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to expose JMX metrics to Prometheus",
+                            "default": false
+                        },
+                        "kafkaJmxPort": {
+                            "type": "number",
+                            "description": "JMX port where the exporter will collect metrics, exposed in the Kafka container.",
+                            "default": 5555
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "JMX exporter image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "JMX exporter image repository",
+                                    "default": "bitnami/jmx-exporter"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "JMX exporter image tag (immutable tags are recommended)",
+                                    "default": "0.19.0-debian-11-r66"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "JMX exporter image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Specify docker-registry secret names as an array",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable Prometheus JMX exporter containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Prometheus JMX exporter containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Prometheus JMX exporter containers' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Set Prometheus JMX exporter containers' Security Context allowPrivilegeEscalation",
+                                    "default": false
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set Prometheus JMX exporter containers' Security Context readOnlyRootFilesystem",
+                                    "default": true
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set Prometheus JMX exporter containers' Security Context capabilities to be dropped",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Prometheus JMX exporter metrics container port",
+                                    "default": 5556
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the JMX exporter container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the JMX exporter container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "Prometheus JMX exporter metrics service port",
+                                            "default": 5556
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Static clusterIP or None for headless services",
+                                    "default": ""
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.metrics.jmx.service.ports.metrics }}"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "whitelistObjectNames": {
+                            "type": "array",
+                            "description": "Allows setting which JMX objects you want to expose to via JMX stats to JMX exporter",
+                            "default": [
+                                "kafka.controller:*",
+                                "kafka.server:*",
+                                "java.lang:*",
+                                "kafka.network:*",
+                                "kafka.log:*"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "config": {
+                            "type": "string",
+                            "description": "Configuration file for JMX exporter",
+                            "default": "jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:{{ .Values.metrics.jmx.kafkaJmxPort }}/jmxrmi\nlowercaseOutputName: true\nlowercaseOutputLabelNames: true\nssl: false\n{{- if .Values.metrics.jmx.whitelistObjectNames }}\nwhitelistObjectNames: [\"{{ join \"\\\",\\\"\" .Values.metrics.jmx.whitelistObjectNames }}\"]\n{{- end }}"
+                        },
+                        "existingConfigmap": {
+                            "type": "string",
+                            "description": "Name of existing ConfigMap with JMX exporter configuration",
+                            "default": ""
+                        },
+                        "extraRules": {
+                            "type": "string",
+                            "description": "Add extra rules to JMX exporter configuration",
+                            "default": ""
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.kafka.enabled` or `metrics.jmx.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PrometheusRule (requires `metrics.kafka.enabled` or `metrics.jmx.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "groups": {
+                            "type": "array",
+                            "description": "Prometheus Rule Groups for Kafka",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "provisioning": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable kafka provisioning Job",
+                    "default": false
+                },
+                "numPartitions": {
+                    "type": "number",
+                    "description": "Default number of partitions for topics when unspecified",
+                    "default": 1
+                },
+                "replicationFactor": {
+                    "type": "number",
+                    "description": "Default replication factor for topics when unspecified",
+                    "default": 1
+                },
+                "topics": {
+                    "type": "array",
+                    "description": "Kafka topics to provision",
+                    "default": [],
+                    "items": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraProvisioningCommands": {
+                    "type": "array",
+                    "description": "Extra commands to run to provision cluster resources",
+                    "default": [],
+                    "items": {}
+                },
+                "parallel": {
+                    "type": "number",
+                    "description": "Number of provisioning commands to run at the same time",
+                    "default": 1
+                },
+                "preScript": {
+                    "type": "string",
+                    "description": "Extra bash script to run before topic provisioning. $CLIENT_CONF is path to properties file with most needed configurations",
+                    "default": ""
+                },
+                "postScript": {
+                    "type": "string",
+                    "description": "Extra bash script to run after topic provisioning. $CLIENT_CONF is path to properties file with most needed configurations",
+                    "default": ""
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Format to use for TLS certificates. Allowed types: `JKS` and `PEM`.",
+                                    "default": "jks"
+                                },
+                                "certificatesSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the TLS certificates for the Kafka provisioning Job.",
+                                    "default": ""
+                                },
+                                "cert": {
+                                    "type": "string",
+                                    "description": "The secret key from the certificatesSecret if 'cert' key different from the default (tls.crt)",
+                                    "default": "tls.crt"
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "The secret key from the certificatesSecret if 'key' key different from the default (tls.key)",
+                                    "default": "tls.key"
+                                },
+                                "caCert": {
+                                    "type": "string",
+                                    "description": "The secret key from the certificatesSecret if 'caCert' key different from the default (ca.crt)",
+                                    "default": "ca.crt"
+                                },
+                                "keystore": {
+                                    "type": "string",
+                                    "description": "The secret key from the certificatesSecret if 'keystore' key different from the default (keystore.jks)",
+                                    "default": "keystore.jks"
+                                },
+                                "truststore": {
+                                    "type": "string",
+                                    "description": "The secret key from the certificatesSecret if 'truststore' key different from the default (truststore.jks)",
+                                    "default": "truststore.jks"
+                                },
+                                "passwordsSecret": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing passwords to access the JKS files or PEM key when they are password-protected.",
+                                    "default": ""
+                                },
+                                "keyPasswordSecretKey": {
+                                    "type": "string",
+                                    "description": "The secret key from the passwordsSecret if 'keyPasswordSecretKey' key different from the default (key-password)",
+                                    "default": "key-password"
+                                },
+                                "keystorePasswordSecretKey": {
+                                    "type": "string",
+                                    "description": "The secret key from the passwordsSecret if 'keystorePasswordSecretKey' key different from the default (keystore-password)",
+                                    "default": "keystore-password"
+                                },
+                                "truststorePasswordSecretKey": {
+                                    "type": "string",
+                                    "description": "The secret key from the passwordsSecret if 'truststorePasswordSecretKey' key different from the default (truststore-password)",
+                                    "default": "truststore-password"
+                                },
+                                "keyPassword": {
+                                    "type": "string",
+                                    "description": "Password to access the password-protected PEM key if necessary. Ignored if 'passwordsSecret' is provided.",
+                                    "default": ""
+                                },
+                                "keystorePassword": {
+                                    "type": "string",
+                                    "description": "Password to access the JKS keystore. Ignored if 'passwordsSecret' is provided.",
+                                    "default": ""
+                                },
+                                "truststorePassword": {
+                                    "type": "string",
+                                    "description": "Password to access the JKS truststore. Ignored if 'passwordsSecret' is provided.",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override provisioning container command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override provisioning container arguments",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to the provisioning pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Extra annotations for Kafka provisioning pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Kafka provisioning pods",
+                    "default": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable creation of ServiceAccount for Kafka provisioning pods",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the service account to use. If not set and `create` is `true`, a name is generated",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Kafka provisioning container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Kafka provisioning container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Kafka provisioning pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Kafka provisioning pod's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kafka provisioning containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Kafka provisioning containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Kafka provisioning containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Kafka provisioning containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Kafka provisioning containers' Security Context readOnlyRootFilesystem",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Kafka provisioning containers' Security Context capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for kafka provisioning",
+                    "default": ""
+                },
+                "enableServiceLinks": {
+                    "type": "boolean",
+                    "description": "Whether information about services should be injected into pod's environment variable",
+                    "default": true
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Kafka provisioning pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Kafka provisioning container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Kafka provisioning pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional Add init containers to the Kafka provisioning pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "waitForKafka": {
+                    "type": "boolean",
+                    "description": "If true use an init container to wait until kafka is ready before starting provisioning",
+                    "default": true
+                }
+            }
+        },
+        "kraft": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the KRaft mode for Kafka",
+                    "default": true
+                },
+                "clusterId": {
+                    "type": "string",
+                    "description": "Kafka Kraft cluster ID. If not set, a random cluster ID will be generated the first time Kraft is initialized.",
+                    "default": ""
+                },
+                "controllerQuorumVoters": {
+                    "type": "string",
+                    "description": "Override the Kafka controller quorum voters of the Kafka Kraft cluster. If not set, it will be automatically configured to use all controller-elegible nodes.",
+                    "default": ""
+                }
+            }
+        },
+        "zookeeperChrootPath": {
+            "type": "string",
+            "description": "Path which puts data under some path in the global ZooKeeper namespace",
+            "default": ""
+        },
+        "zookeeper": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the ZooKeeper helm chart. Must be false if you use KRaft mode.",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of ZooKeeper nodes",
+                    "default": 1
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ZooKeeper auth",
+                                    "default": false
+                                },
+                                "clientUser": {
+                                    "type": "string",
+                                    "description": "User that will use ZooKeeper client (zkCli.sh) to authenticate. Must exist in the serverUsers comma-separated list.",
+                                    "default": ""
+                                },
+                                "clientPassword": {
+                                    "type": "string",
+                                    "description": "Password that will use ZooKeeper client (zkCli.sh) to authenticate. Must exist in the serverPasswords comma-separated list.",
+                                    "default": ""
+                                },
+                                "serverUsers": {
+                                    "type": "string",
+                                    "description": "Comma, semicolon or whitespace separated list of user to be created. Specify them as a string, for example: \"user1,user2,admin\"",
+                                    "default": ""
+                                },
+                                "serverPasswords": {
+                                    "type": "string",
+                                    "description": "Comma, semicolon or whitespace separated list of passwords to assign to users when created. Specify them as a string, for example: \"pass4user1, pass4user2, pass4admin\"",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on ZooKeeper using PVC(s)",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "8Gi"
+                        }
+                    }
+                }
+            }
+        },
+        "externalZookeeper": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "description": "List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be empty if you use KRaft mode.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/keycloak/values.schema.json
+++ b/bitnami/keycloak/values.schema.json
@@ -1,0 +1,1497 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "enableServiceLinks": {
+            "type": "boolean",
+            "description": "If set to false, disable Kubernetes service links in the pod spec",
+            "default": true
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "dnsPolicy": {
+            "type": "string",
+            "description": "DNS Policy for pod",
+            "default": ""
+        },
+        "dnsConfig": {
+            "type": "object",
+            "description": "DNS Configuration pod",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Keycloak image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Keycloak image repository",
+                    "default": "bitnami/keycloak"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Keycloak image tag (immutable tags are recommended)",
+                    "default": "22.0.1-debian-11-r30"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Keycloak image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Keycloak image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "adminUser": {
+                    "type": "string",
+                    "description": "Keycloak administrator user",
+                    "default": "user"
+                },
+                "adminPassword": {
+                    "type": "string",
+                    "description": "Keycloak administrator password for the new user",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret containing Keycloak admin password",
+                    "default": ""
+                },
+                "passwordSecretKey": {
+                    "type": "string",
+                    "description": "Key where the Keycloak admin password is being stored inside the existing secret.",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS encryption. Required for HTTPs traffic.",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates. Currently only supports PEM certificates",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret containing the TLS certificates per Keycloak replica",
+                    "default": ""
+                },
+                "usePem": {
+                    "type": "boolean",
+                    "description": "Use PEM certificates as input instead of PKS12/JKS stores",
+                    "default": false
+                },
+                "truststoreFilename": {
+                    "type": "string",
+                    "description": "Truststore filename inside the existing secret",
+                    "default": "keycloak.truststore.jks"
+                },
+                "keystoreFilename": {
+                    "type": "string",
+                    "description": "Keystore filename inside the existing secret",
+                    "default": "keycloak.keystore.jks"
+                },
+                "keystorePassword": {
+                    "type": "string",
+                    "description": "Password to access the keystore when it's password-protected",
+                    "default": ""
+                },
+                "truststorePassword": {
+                    "type": "string",
+                    "description": "Password to access the truststore when it's password-protected",
+                    "default": ""
+                },
+                "passwordsSecret": {
+                    "type": "string",
+                    "description": "Secret containing the Keystore and Truststore passwords.",
+                    "default": ""
+                }
+            }
+        },
+        "spi": {
+            "type": "object",
+            "properties": {
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret containing the Keycloak truststore for SPI connection over HTTPS/TLS",
+                    "default": ""
+                },
+                "truststorePassword": {
+                    "type": "string",
+                    "description": "Password to access the truststore when it's password-protected",
+                    "default": ""
+                },
+                "truststoreFilename": {
+                    "type": "string",
+                    "description": "Truststore filename inside the existing secret",
+                    "default": "keycloak-spi.truststore.jks"
+                },
+                "passwordsSecret": {
+                    "type": "string",
+                    "description": "Secret containing the SPI Truststore passwords.",
+                    "default": ""
+                },
+                "hostnameVerificationPolicy": {
+                    "type": "string",
+                    "description": "Verify the hostname of the server’s certificate. Allowed values: \"ANY\", \"WILDCARD\", \"STRICT\".",
+                    "default": ""
+                }
+            }
+        },
+        "production": {
+            "type": "boolean",
+            "description": "Run Keycloak in production mode. TLS configuration is required except when using proxy=edge.",
+            "default": false
+        },
+        "proxy": {
+            "type": "string",
+            "description": "reverse Proxy mode edge, reencrypt, passthrough or none",
+            "default": "passthrough"
+        },
+        "httpRelativePath": {
+            "type": "string",
+            "description": "Set the path relative to '/' for serving resources. Useful if you are migrating from older version which were using '/auth/'",
+            "default": "/"
+        },
+        "configuration": {
+            "type": "string",
+            "description": "Keycloak Configuration. Auto-generated based on other parameters when not specified",
+            "default": ""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "Name of existing ConfigMap with Keycloak configuration",
+            "default": ""
+        },
+        "extraStartupArgs": {
+            "type": "string",
+            "description": "Extra default startup args",
+            "default": ""
+        },
+        "initdbScripts": {
+            "type": "object",
+            "description": "Dictionary of initdb scripts",
+            "default": {}
+        },
+        "initdbScriptsConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on Keycloak container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Keycloak replicas to deploy",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Keycloak HTTP container port",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Keycloak HTTPS container port",
+                    "default": 8443
+                },
+                "infinispan": {
+                    "type": "number",
+                    "description": "Keycloak infinispan container port",
+                    "default": 7800
+                }
+            }
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional port-mappings for Keycloak container",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Keycloak pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Keycloak pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Keycloak containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Keycloak container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Keycloak container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Keycloak containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the Keycloak containers",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on Keycloak containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 300
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 1
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on Keycloak containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on Keycloak containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom Liveness probes for Keycloak",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom Rediness probes Keycloak",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom Startup probes for Keycloak",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHooks to set additional configuration at startup",
+            "default": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Keycloak pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Keycloak pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Pod management policy for the Keycloak statefulset",
+            "default": "Parallel"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Keycloak pods' Priority Class Name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Use an alternate scheduler, e.g. \"stork\".",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Keycloak pod needs to terminate gracefully",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Keycloak statefulset strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Keycloak statefulset rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Keycloak pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Keycloak container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Keycloak pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Keycloak pods",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type",
+                    "default": "ClusterIP"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable http port on service",
+                            "default": true
+                        }
+                    }
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Keycloak service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Keycloak service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Keycloak service clusterIP IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the SuiteCRM Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Address that are allowed when service is LoadBalancer",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Keycloak service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Keycloak service",
+                    "default": [],
+                    "items": {}
+                },
+                "extraHeadlessPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose on Keycloak headless service",
+                    "default": [],
+                    "items": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose on Keycloak headless service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Keycloak",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record (evaluated as template)",
+                    "default": "keycloak.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record (evaluated as template)",
+                    "default": "{{ .Values.httpRelativePath }}"
+                },
+                "servicePort": {
+                    "type": "string",
+                    "description": "Backend service port to use",
+                    "default": "http"
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Additional labels for the Ingress resource.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the default NetworkPolicy policy",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "additionalRules": {
+                    "type": "object",
+                    "description": "Additional NetworkPolicy rules",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Keycloak pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Auto-mount the service account token in the pod",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                },
+                "extraLabels": {
+                    "type": "object",
+                    "description": "Additional labels for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable autoscaling for Keycloak",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of Keycloak replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of Keycloak replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "string",
+                    "description": "Target CPU utilization percentage",
+                    "default": ""
+                },
+                "targetMemory": {
+                    "type": "string",
+                    "description": "Target Memory utilization percentage",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable exposing Keycloak statistics",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Metrics service HTTP port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.http }}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Metrics service HTTP port",
+                            "default": "http"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead",
+                            "default": ""
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create PrometheusRule Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "groups": {
+                            "type": "array",
+                            "description": "Groups, containing the alert rules.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "keycloakConfigCli": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable keycloak-config-cli job",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "keycloak-config-cli container image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "keycloak-config-cli container image repository",
+                            "default": "bitnami/keycloak-config-cli"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "keycloak-config-cli container image tag",
+                            "default": "5.8.0-debian-11-r30"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "keycloak-config-cli container image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "keycloak-config-cli container image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "keycloak-config-cli container image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "helm": {
+                            "type": "object",
+                            "properties": {
+                                "sh/hook": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "post-install,post-upgrade,post-rollback"
+                                },
+                                "sh/hook-delete-policy": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "hook-succeeded,before-hook-creation"
+                                },
+                                "sh/hook-weight": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "5"
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args for running the container (set to default if not set). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Job pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the keycloak-config-cli container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the keycloak-config-cli container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled keycloak-config-cli containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set keycloak-config-cli container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set keycloak-config-cli container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled keycloak-config-cli pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set keycloak-config-cli pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "backoffLimit": {
+                    "type": "number",
+                    "description": "Number of retries before considering a Job as failed",
+                    "default": 1
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Pod extra labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for job pod",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Additional environment variables to set",
+                    "default": [],
+                    "items": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "podTolerations": {
+                    "type": "array",
+                    "description": "Tolerations for job pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to the job",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Keycloak config cli pod",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Keycloak config cli pod",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "object",
+                    "description": "keycloak-config-cli realms configuration",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "ConfigMap with keycloak-config-cli configuration. This will override `keycloakConfigCli.config`",
+                    "default": ""
+                },
+                "cleanupAfterFinished": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enables Cleanup for Finished Jobs",
+                            "default": false
+                        },
+                        "seconds": {
+                            "type": "number",
+                            "description": "Sets the value of ttlSecondsAfterFinished",
+                            "default": 600
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "postgresPassword": {
+                            "type": "string",
+                            "description": "Password for the \"postgres\" admin user. Ignored if `auth.existingSecret` with key `postgres-password` is provided",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_keycloak"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_keycloak"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Keycloak",
+                    "default": "bn_keycloak"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Keycloak",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Keycloak database name",
+                    "default": "bitnami_keycloak"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretHostKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database host name",
+                    "default": ""
+                },
+                "existingSecretPortKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database port",
+                    "default": ""
+                },
+                "existingSecretUserKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database user",
+                    "default": ""
+                },
+                "existingSecretDatabaseKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database name",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": ""
+                }
+            }
+        },
+        "cache": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the keycloak distributed cache for kubernetes.",
+                    "default": true
+                },
+                "stackName": {
+                    "type": "string",
+                    "description": "Set infinispan cache stack to use",
+                    "default": "kubernetes"
+                },
+                "stackFile": {
+                    "type": "string",
+                    "description": "Set infinispan cache stack filename to use",
+                    "default": ""
+                }
+            }
+        },
+        "logging": {
+            "type": "object",
+            "properties": {
+                "output": {
+                    "type": "string",
+                    "description": "Alternates between the default log output format or json format",
+                    "default": "default"
+                },
+                "level": {
+                    "type": "string",
+                    "description": "Allowed values as documented: FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL, OFF",
+                    "default": "INFO"
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kiam/values.schema.json
+++ b/bitnami/kiam/values.schema.json
@@ -1,0 +1,1461 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "Release name override",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "Release full name override",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "kiam image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "kiam image name",
+                    "default": "bitnami/kiam"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "kiam image tag",
+                    "default": "4.2.0-debian-11-r377"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "kiam image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "kiam image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy the kiam server",
+                    "default": true
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "HTTPS port to expose at container level",
+                    "default": 8443
+                },
+                "resourceType": {
+                    "type": "string",
+                    "description": "Specify how to deploy the server (allowed values: `daemonset` and `deployment`)",
+                    "default": "daemonset"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "useHostNetwork": {
+                    "type": "boolean",
+                    "description": "Use host networking (ports will be directly exposed in the host)",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of replicas to deploy (when `server.resourceType` is `daemonset`)",
+                    "default": 1
+                },
+                "logJsonOutput": {
+                    "type": "boolean",
+                    "description": "Use JSON format for logs",
+                    "default": true
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Logging level",
+                    "default": "info"
+                },
+                "sslCertHostPath": {
+                    "type": "string",
+                    "description": "Path to the host system SSL certificates (necessary for contacting the AWS metadata server)",
+                    "default": "/etc/ssl/certs"
+                },
+                "podSecurityPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": true
+                        },
+                        "allowedHostPaths": {
+                            "type": "array",
+                            "description": "Extra host paths to allow in the PodSecurityPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "description": "Extra arguments to add to the default kiam command",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override kiam default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override kiam default args",
+                    "default": [],
+                    "items": {}
+                },
+                "tlsFiles": {
+                    "type": "object",
+                    "properties": {
+                        "ca": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "cert": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "gatewayTimeoutCreation": {
+                    "type": "string",
+                    "description": "Timeout when creating the kiam gateway",
+                    "default": "1s"
+                },
+                "tlsSecret": {
+                    "type": "string",
+                    "description": "Name of a secret with TLS certificates for the container",
+                    "default": ""
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Pod DNS policy",
+                    "default": "Default"
+                },
+                "roleBaseArn": {
+                    "type": "string",
+                    "description": "Base ARN for IAM roles. If not set kiam will detect it automatically",
+                    "default": ""
+                },
+                "cacheSyncInterval": {
+                    "type": "string",
+                    "description": "Cache synchronization interval",
+                    "default": "1m"
+                },
+                "assumeRoleArn": {
+                    "type": "string",
+                    "description": "IAM role for the server to assume",
+                    "default": ""
+                },
+                "sessionDuration": {
+                    "type": "string",
+                    "description": "Session duration for STS tokens",
+                    "default": "15m"
+                },
+                "tlsCerts": {
+                    "type": "object",
+                    "properties": {
+                        "certFileName": {
+                            "type": "string",
+                            "description": "",
+                            "default": "cert.pem"
+                        },
+                        "keyFileName": {
+                            "type": "string",
+                            "description": "",
+                            "default": "key.pem"
+                        },
+                        "caFileName": {
+                            "type": "string",
+                            "description": "",
+                            "default": "ca.pem"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the kiam container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the kiam container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled kiam server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set kiam server container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set kiam server container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "seLinuxOptions": {
+                            "type": "object",
+                            "description": "Set kiam server container's Security Context SE Linux options",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled kiam server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set kiam server pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for kiam pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for kiam pods",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "lifecycleHooks for the kiam server container to automate configuration before or after startup.",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure kiam server",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to configure kiam server",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to configure kiam server (in case of sensitive data)",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for kiam pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for kiam container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the kiam pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the kiam pods",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                },
+                                "metrics": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service grpc-lb port",
+                            "default": 8443
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "kiam service clusterIP IP",
+                            "default": "None"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for kiam service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable exposing kiam statistics",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.server.metrics.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Metrics port",
+                            "default": 9621
+                        },
+                        "syncInterval": {
+                            "type": "string",
+                            "description": "Metrics synchronization interval statistics",
+                            "default": "5s"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify Metric Relabellings to add to the scrape endpoint",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify Relabelings to add to the scrape endpoint",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Specify the timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "metrics service selector",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "agent": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy the kiam agent",
+                    "default": true
+                },
+                "logJsonOutput": {
+                    "type": "boolean",
+                    "description": "Use JSON format for logs",
+                    "default": true
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Logging level",
+                    "default": "info"
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Server priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "allowRouteRegExp": {
+                    "type": "string",
+                    "description": "Regexp with the allowed paths for agents to redirect",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "HTTPS port to expose at container level",
+                    "default": 8183
+                },
+                "iptables": {
+                    "type": "boolean",
+                    "description": "Have the agent modify the host iptables rules",
+                    "default": false
+                },
+                "iptablesRemoveOnShutdown": {
+                    "type": "boolean",
+                    "description": "Remove iptables rules when shutting down the agent node",
+                    "default": false
+                },
+                "hostInterface": {
+                    "type": "string",
+                    "description": "Interface for agents for redirecting requests",
+                    "default": "cali+"
+                },
+                "keepaliveParams": {
+                    "type": "object",
+                    "properties": {
+                        "permitWithoutStream": {
+                            "type": "boolean",
+                            "description": "Permit keepalive without stream",
+                            "default": false
+                        },
+                        "time": {
+                            "type": "string",
+                            "description": "Keepalive time",
+                            "default": ""
+                        },
+                        "timeout": {
+                            "type": "string",
+                            "description": "Keepalive timeout",
+                            "default": ""
+                        }
+                    }
+                },
+                "tlsFiles": {
+                    "type": "object",
+                    "properties": {
+                        "ca": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "cert": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "enableDeepProbe": {
+                    "type": "boolean",
+                    "description": "Use the probes using the `/health` endpoint",
+                    "default": false
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Pod DNS policy",
+                    "default": "ClusterFirstWithHostNet"
+                },
+                "sslCertHostPath": {
+                    "type": "string",
+                    "description": "Path to the host system SSL certificates (necessary for contacting the AWS metadata agent)",
+                    "default": "/etc/ssl/certs"
+                },
+                "tlsCerts": {
+                    "type": "object",
+                    "properties": {
+                        "certFileName": {
+                            "type": "string",
+                            "description": "",
+                            "default": "cert.pem"
+                        },
+                        "keyFileName": {
+                            "type": "string",
+                            "description": "",
+                            "default": "key.pem"
+                        },
+                        "caFileName": {
+                            "type": "string",
+                            "description": "",
+                            "default": "ca.pem"
+                        }
+                    }
+                },
+                "podSecurityPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": true
+                        },
+                        "allowedHostPaths": {
+                            "type": "array",
+                            "description": "Extra host paths to allow in the PodSecurityPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "tlsSecret": {
+                    "type": "string",
+                    "description": "Name of a secret with TLS certificates for the container",
+                    "default": ""
+                },
+                "useHostNetwork": {
+                    "type": "boolean",
+                    "description": "Use host networking (ports will be directly exposed in the host)",
+                    "default": true
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "description": "Extra arguments to add to the default kiam command",
+                    "default": {}
+                },
+                "gatewayTimeoutCreation": {
+                    "type": "string",
+                    "description": "Timeout when creating the kiam gateway",
+                    "default": "1s"
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override kiam default command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override kiam default args",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the kiam container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the kiam container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled agent containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set agent container's Security Context runAsUser",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set agent container's Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "add": {
+                                    "type": "array",
+                                    "description": "Add capabilities for the securityContext",
+                                    "default": [
+                                        "NET_ADMIN"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled agent pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set agent pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for kiam pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for kiam pods",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHooks to set additional configuration at startup.",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure kiam agent",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to configure kiam agent",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to configure kiam agent (in case of sensitive data)",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "kiam service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for kiam service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for kiam pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for kiam container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the kiam pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the kiam pods",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.agent.metrics.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable exposing kiam statistics",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service HTTP management port",
+                            "default": 9620
+                        },
+                        "syncInterval": {
+                            "type": "string",
+                            "description": "Metrics synchronization interval statistics",
+                            "default": "5s"
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped",
+                                    "default": "30s"
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify Metric Relabelings to add to the scrape endpoint",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify Relabelings to add to the scrape endpoint",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Specify the timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "metrics service selector",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": true
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kibana/values.schema.json
+++ b/bitnami/kibana/values.schema.json
@@ -1,0 +1,1048 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template with a string",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "A list of extra kubernetes resources to be deployed",
+            "default": [],
+            "items": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Kibana image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Kibana image repository",
+                    "default": "bitnami/kibana"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Kibana image tag (immutable tags are recommended)",
+                    "default": "8.9.2-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Kibana image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Kibana image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable %%MAIN_CONTAINER%% image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas of the Kibana Pod",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Set up update strategy for Kibana installation.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "%%MAIN_CONTAINER_NAME%% pods' priorityClassName",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "plugins": {
+            "type": "array",
+            "description": "Array containing the Kibana plugins to be installed in deployment",
+            "default": [],
+            "items": {}
+        },
+        "savedObjects": {
+            "type": "object",
+            "properties": {
+                "urls": {
+                    "type": "array",
+                    "description": "Array containing links to NDJSON files to be imported during Kibana initialization",
+                    "default": [],
+                    "items": {}
+                },
+                "configmap": {
+                    "type": "string",
+                    "description": "Configmap containing NDJSON files to be imported during Kibana initialization (evaluated as a template)",
+                    "default": ""
+                }
+            }
+        },
+        "extraConfiguration": {
+            "type": "object",
+            "description": "Extra settings to be added to the default kibana.yml configmap that the chart creates (unless replaced using `configurationCM`). Evaluated as a template",
+            "default": {}
+        },
+        "configurationCM": {
+            "type": "string",
+            "description": "ConfigMap containing a kibana.yml file that will replace the default one specified in configuration.yaml",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the %%MAIN_CONTAINER_NAME%% container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array containing extra env vars to configure Kibana",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars to configure Kibana",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars to configure Kibana (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array to add extra volumes. Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array to add extra mounts. Normally used with `extraVolumes`",
+            "default": [],
+            "items": {}
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Volume Permissions resources",
+                    "default": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Kibana data Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Provide an existing `PersistentVolumeClaim`",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size for the PV",
+                    "default": "10Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the startup probe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before startup probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the Liveness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before liveness probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the Readiness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before readiness probe is initiated",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readiness probe for the Web component",
+            "default": {}
+        },
+        "forceInitScripts": {
+            "type": "boolean",
+            "description": "Force execution of init scripts",
+            "default": false
+        },
+        "initScriptsCM": {
+            "type": "string",
+            "description": "Configmap with init scripts to execute",
+            "default": ""
+        },
+        "initScriptsSecret": {
+            "type": "string",
+            "description": "Secret with init scripts to execute (for sensitive data)",
+            "default": ""
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Kubernetes Service port",
+                            "default": 5601
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "%%MAIN_CONTAINER_NAME%% service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP if Kibana service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "%%MAIN_CONTAINER_NAME%% service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Kibana service (evaluated as a template)",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Extra labels for Kibana service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource. If specified as \"*\" no host rule is configured",
+                    "default": "kibana.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Kibana. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Additional arbitrary path/backend objects",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Port to expose at container level",
+                    "default": 5601
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled %%MAIN_CONTAINER_NAME%% pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set %%MAIN_CONTAINER_NAME%% pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled %%MAIN_CONTAINER_NAME%% containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set %%MAIN_CONTAINER_NAME%% containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set %%MAIN_CONTAINER_NAME%% container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels to add to Pod",
+            "default": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod",
+            "default": [],
+            "items": {}
+        },
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "basePath": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "rewriteBasePath": {
+                            "type": "boolean",
+                            "description": "",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "80"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "_prometheus/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable SSL/TLS encryption for Kibana server (HTTPS)",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Create self-signed TLS certificates. Currently only supports PEM certificates.",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing Kibana server certificates",
+                    "default": ""
+                },
+                "usePemCerts": {
+                    "type": "boolean",
+                    "description": "Use this variable if your secrets contain PEM certificates instead of PKCS12",
+                    "default": false
+                },
+                "keyPassword": {
+                    "type": "string",
+                    "description": "Password to access the PEM key when it is password-protected.",
+                    "default": ""
+                },
+                "keystorePassword": {
+                    "type": "string",
+                    "description": "Password to access the PKCS12 keystore when it is password-protected.",
+                    "default": ""
+                },
+                "passwordsSecret": {
+                    "type": "string",
+                    "description": "Name of a existing secret containing the Keystore or PEM key password",
+                    "default": ""
+                }
+            }
+        },
+        "elasticsearch": {
+            "type": "object",
+            "properties": {
+                "hosts": {
+                    "type": "array",
+                    "description": "List of elasticsearch hosts to connect to.",
+                    "default": [],
+                    "items": {}
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Elasticsearch port",
+                    "default": ""
+                },
+                "security": {
+                    "type": "object",
+                    "properties": {
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Set to 'true' if Elasticsearch has authentication enabled",
+                                    "default": false
+                                },
+                                "kibanaPassword": {
+                                    "type": "string",
+                                    "description": "Password of the 'kibana_system' user, used to authenticate Kibana connection with Elasticsearch.",
+                                    "default": ""
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of the existing secret containing the password for the 'kibana_system' user.",
+                                    "default": ""
+                                },
+                                "createSystemUser": {
+                                    "type": "boolean",
+                                    "description": "If enabled, Kibana will use Elasticsearch API to create the 'kibana_system' user at startup.",
+                                    "default": false
+                                },
+                                "elasticsearchPasswordSecret": {
+                                    "type": "string",
+                                    "description": "Name of the existing secret containing the password for the 'elastic' user.",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Set to 'true' if Elasticsearch API uses TLS/SSL (HTTPS)",
+                                    "default": false
+                                },
+                                "verificationMode": {
+                                    "type": "string",
+                                    "description": "Verification mode for SSL communications.",
+                                    "default": "full"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of the existing secret containing Elasticsearch Truststore or CA certificate. Required unless verificationMode=none",
+                                    "default": ""
+                                },
+                                "usePemCerts": {
+                                    "type": "boolean",
+                                    "description": "Set to 'true' to use PEM certificates instead of PKCS12.",
+                                    "default": false
+                                },
+                                "truststorePassword": {
+                                    "type": "string",
+                                    "description": "Password to access the PKCS12 trustore in case it is password-protected.",
+                                    "default": ""
+                                },
+                                "passwordsSecret": {
+                                    "type": "string",
+                                    "description": "Name of a existing secret containing the Truststore password",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kong/values.schema.json
+++ b/bitnami/kong/values.schema.json
@@ -1,0 +1,1482 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template with a string",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Kong resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Kong resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the daemonset/deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the daemonset/deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "kong image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "kong image repository",
+                    "default": "bitnami/kong"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "kong image tag (immutable tags are recommended)",
+                    "default": "3.4.0-debian-11-r22"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "kong image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "kong image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "database": {
+            "type": "string",
+            "description": "Select which database backend Kong will use. Can be 'postgresql', 'cassandra' or 'off'",
+            "default": "postgresql"
+        },
+        "useDaemonset": {
+            "type": "boolean",
+            "description": "Use a daemonset instead of a deployment. `replicaCount` will not take effect.",
+            "default": false
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Kong replicas",
+            "default": 2
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Kong containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Kong container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Kong container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Kong pods' Security Context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Kong pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kong update strategy",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Kong deployment rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority Class Name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Use an alternate scheduler, e.g. \"stork\".",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Kong pod needs to terminate gracefully",
+            "default": ""
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Additional pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional pod labels",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the Kong deployment deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Kong pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Kong pods",
+            "default": [],
+            "items": {}
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a HorizontalPodAutoscaler object for the Kong deployment",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of replicas to scale back",
+                    "default": 2
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of replicas to scale out",
+                    "default": 5
+                },
+                "metrics": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "resource": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "targetAverageUtilization": {
+                                        "type": "number",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Deploy a PodDisruptionBudget object for Kong deployment",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum available Kong replicas (expressed in percentage)",
+                    "default": ""
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum unavailable Kong replicas (expressed in percentage)",
+                    "default": "50%"
+                }
+            }
+        },
+        "kong": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "initScriptsCM": {
+                    "type": "string",
+                    "description": "Configmap with init scripts to execute",
+                    "default": ""
+                },
+                "initScriptsSecret": {
+                    "type": "string",
+                    "description": "Configmap with init scripts to execute",
+                    "default": ""
+                },
+                "declarativeConfig": {
+                    "type": "string",
+                    "description": "Declarative configuration to be loaded by Kong (evaluated as a template)",
+                    "default": ""
+                },
+                "declarativeConfigCM": {
+                    "type": "string",
+                    "description": "Configmap with declarative configuration to be loaded by Kong (evaluated as a template)",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure Kong",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to configure Kong",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to configure Kong (in case of sensitive data)",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "proxyHttp": {
+                            "type": "number",
+                            "description": "Kong proxy HTTP container port",
+                            "default": 8000
+                        },
+                        "proxyHttps": {
+                            "type": "number",
+                            "description": "Kong proxy HTTPS container port",
+                            "default": 8443
+                        },
+                        "adminHttp": {
+                            "type": "number",
+                            "description": "Kong admin HTTP container port",
+                            "default": 8001
+                        },
+                        "adminHttps": {
+                            "type": "number",
+                            "description": "Kong admin HTTPS container port",
+                            "default": 8444
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Kong container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Kong container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Kong containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Kong containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Kong containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 20
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe (kong container)",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe (kong container)",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe (kong container)",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Lifecycle hooks (kong container)",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "exposeAdmin": {
+                    "type": "boolean",
+                    "description": "Add the Kong Admin ports to the service",
+                    "default": false
+                },
+                "disableHttpPort": {
+                    "type": "boolean",
+                    "description": "Disable Kong proxy HTTP and Kong admin HTTP ports",
+                    "default": false
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "proxyHttp": {
+                            "type": "number",
+                            "description": "Kong proxy service HTTP port",
+                            "default": 80
+                        },
+                        "proxyHttps": {
+                            "type": "number",
+                            "description": "Kong proxy service HTTPS port",
+                            "default": 443
+                        },
+                        "adminHttp": {
+                            "type": "number",
+                            "description": "Kong admin service HTTP port (only if service.exposeAdmin=true)",
+                            "default": 8001
+                        },
+                        "adminHttps": {
+                            "type": "number",
+                            "description": "Kong admin service HTTPS port (only if service.exposeAdmin=true)",
+                            "default": 8444
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "proxyHttp": {
+                            "type": "string",
+                            "description": "NodePort for the Kong proxy HTTP endpoint",
+                            "default": ""
+                        },
+                        "proxyHttps": {
+                            "type": "string",
+                            "description": "NodePort for the Kong proxy HTTPS endpoint",
+                            "default": ""
+                        },
+                        "adminHttp": {
+                            "type": "string",
+                            "description": "NodePort for the Kong admin HTTP endpoint",
+                            "default": ""
+                        },
+                        "adminHttps": {
+                            "type": "string",
+                            "description": "NodePort for the Kong admin HTTPS endpoint",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Cluster internal IP of the service",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "external traffic policy managing client source IP preservation",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP if kong service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Kong service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Kong service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "kong.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Ingress path",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Additional arbitrary path/backend objects",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingressController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the Kong Ingress Controller",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Kong Ingress Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Kong Ingress Controller image name",
+                            "default": "bitnami/kong-ingress-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Kong Ingress Controller image tag",
+                            "default": "2.11.1-debian-11-r5"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Kong Ingress Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Kong Ingress Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "proxyReadyTimeout": {
+                    "type": "number",
+                    "description": "Maximum time (in seconds) to wait for the Kong container to be ready",
+                    "default": 300
+                },
+                "ingressClass": {
+                    "type": "string",
+                    "description": "Name of the class to register Kong Ingress Controller (useful when having other Ingress Controllers in the cluster)",
+                    "default": "kong"
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure Kong",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to configure Kong Ingress Controller",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to configure Kong Ingress Controller (in case of sensitive data)",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array of extra volume mounts to be added to the Kong Ingress Controller container (evaluated as template). Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "health": {
+                            "type": "number",
+                            "description": "Kong Ingress Controller health container port",
+                            "default": 10254
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Kong Ingress Controller container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Kong Ingress Controller container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Kong Ingress Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Kong Ingress Controller containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Kong Ingress Controller containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 20
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe (Kong Ingress Controller container)",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe (Kong Ingress Controller container)",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe (Kong Ingress Controller container)",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Lifecycle hooks (Kong Ingress Controller container)",
+                    "default": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable the creation of a ServiceAccount for Keycloak pods",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the created ServiceAccount (name generated using common.names.fullname template otherwise)",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Auto-mount the service account token in the pod",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create the necessary RBAC resources for the Ingress Controller to work",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "migration": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure the Kong migration job",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to configure the Kong migration job",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to configure the Kong migration job (in case of sensitive data)",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "helm": {
+                            "type": "object",
+                            "properties": {
+                                "sh/hook": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "post-install, pre-upgrade"
+                                },
+                                "sh/hook-delete-policy": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "before-hook-creation,hook-succeeded"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "postgresPassword": {
+                            "type": "string",
+                            "description": "Password for the \"postgres\" admin user",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "kong"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "kong"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        },
+                        "usePasswordFiles": {
+                            "type": "boolean",
+                            "description": "Mount credentials as a files instead of using an environment variable",
+                            "default": false
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL image repository",
+                            "default": "bitnami/postgresql"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL image tag (immutable tags are recommended)",
+                            "default": "14.9.0-debian-11-r24"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "external": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string",
+                            "description": "Database host",
+                            "default": ""
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Database port number",
+                            "default": 5432
+                        },
+                        "user": {
+                            "type": "string",
+                            "description": "Non-root username for Kong",
+                            "default": "kong"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the non-root username for Kong",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Kong database name",
+                            "default": "kong"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret resource containing the database credentials",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Name of an existing secret key containing the database credentials",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "cassandra": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the Cassandra helm chart",
+                    "default": false
+                },
+                "dbUser": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "Cassandra admin user",
+                            "default": "kong"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for `cassandra.dbUser.user`. Randomly generated if empty",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for Cassandra credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "usePasswordFile": {
+                    "type": "boolean",
+                    "description": "Mount credentials as a files instead of using an environment variable",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Cassandra replicas",
+                    "default": 1
+                },
+                "external": {
+                    "type": "object",
+                    "properties": {
+                        "hosts": {
+                            "type": "array",
+                            "description": "List of Cassandra hosts",
+                            "default": [],
+                            "items": {}
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Cassandra port number",
+                            "default": 9042
+                        },
+                        "user": {
+                            "type": "string",
+                            "description": "Username of the external cassandra installation",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password of the external cassandra installation",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret resource containing the Cassandra credentials",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Name of an existing secret key containing the Cassandra credentials",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Prometheus metrics HTTP container port",
+                            "default": 9119
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.port }}"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Cluster internal IP of the service",
+                            "default": ""
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Prometheus metrics service HTTP port",
+                                    "default": 9119
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "serviceAccount": {
+                            "type": "string",
+                            "description": "Service account used by Prometheus Operator",
+                            "default": ""
+                        },
+                        "rbac": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Create the necessary RBAC resources so Prometheus Operator can reach Kong's namespace",
+                                    "default": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kube-prometheus/values.schema.json
+++ b/bitnami/kube-prometheus/values.schema.json
@@ -1,0 +1,4095 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override `kube-prometheus.name` template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override `kube-prometheus.fullname` template with a string",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "operator": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Prometheus Operator to the cluster",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Prometheus Operator image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Prometheus Operator image repository",
+                            "default": "bitnami/prometheus-operator"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Prometheus Operator image tag (immutable tags are recommended)",
+                            "default": "0.68.0-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Prometheus Operator image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Prometheus Operator image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "description": "Additional arguments passed to Prometheus Operator",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Prometheus Operator container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Prometheus Operator nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Prometheus Operator nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Prometheus Operator nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Prometheus Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Prometheus Operator container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Prometheus Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Prometheus Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specify whether to create a ServiceAccount for Prometheus Operator",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to create",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the Kubernetess scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Prometheus Operator pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable pod security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Linux Kernel capabilities which should be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Mount / (root) as a readonly filesystem",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Prometheus Operator service port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Specific cluster IP when service type is cluster IP. Use `None` for headless service",
+                            "default": ""
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Kubernetes Service nodePort",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when svc is `LoadBalancer`",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "healthCheckNodePort": {
+                            "type": "string",
+                            "description": "Specifies the health check node port (numeric port number) for the service if `externalTrafficPolicy` is set to Local.",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for Prometheus Operator service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for Prometheus Operator service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a ServiceMonitor to monitor Prometheus Operator",
+                            "default": true
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "extraParameters": {
+                            "type": "object",
+                            "description": "Any extra parameter to be added to the endpoint configured in the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Configure resource requests and limits",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Operator Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Operator Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Prometheus Operator Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Prometheus Operator Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Prometheus Operator Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Prometheus Operator Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Prometheus Operator Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Prometheus Operator pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Prometheus Operator pods",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class assigned to the Pods",
+                    "default": ""
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off liveness probe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off readiness probe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off startup probe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for Prometheus Operator",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Log format for Prometheus Operator",
+                    "default": "logfmt"
+                },
+                "configReloaderResources": {
+                    "type": "object",
+                    "description": "Set the prometheus config reloader side-car CPU and memory requests and limits.",
+                    "default": {}
+                },
+                "kubeletService": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If true, the operator will create and maintain a service for scraping kubelets",
+                            "default": true
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace to deploy the kubelet service",
+                            "default": "kube-system"
+                        }
+                    }
+                },
+                "prometheusConfigReloader": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "description": "Prometheus Config Reloader image. If not set, the same as `operator.image.registry`",
+                            "default": {}
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable container security context",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "mount / (root) as a readonly filesystem",
+                                    "default": false
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Switch privilegeEscalation possibility on or off",
+                                    "default": false
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Force the container to run as a non root user",
+                                    "default": true
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Linux Kernel capabilities which should be dropped",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Turn on and off liveness probe",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Delay before liveness probe is initiated",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "How often to perform the probe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "When the probe times out",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive failures for the probe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive successes for the probe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Turn on and off readiness probe",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Delay before readiness probe is initiated",
+                                    "default": 15
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "How often to perform the probe",
+                                    "default": 20
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "When the probe times out",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive failures for the probe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive successes for the probe",
+                                    "default": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "namespaces": {
+                    "type": "string",
+                    "description": "Optional comma-separated list of namespaces to watch (default=all).",
+                    "default": ""
+                }
+            }
+        },
+        "prometheus": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Prometheus to the cluster",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Prometheus image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Prometheus image repository",
+                            "default": "bitnami/prometheus"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Prometheus image tag (immutable tags are recommended)",
+                            "default": "2.47.0-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Prometheus image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specify whether to create a ServiceAccount for Prometheus",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to create",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for created Prometheus ServiceAccount",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Mount / (root) as a readonly filesystem",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to run as a non root user",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Linux Kernel capabilities which should be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a pod disruption budget for Prometheus",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number / percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number / percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Prometheus service port",
+                                    "default": 9090
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Specific cluster IP when service type is cluster IP. Use `None` for headless service",
+                            "default": ""
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is `LoadBalancer`",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "healthCheckNodePort": {
+                            "type": "string",
+                            "description": "Specifies the health check node port",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for Prometheus service  (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for Prometheus service  (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a ServiceMonitor to monitor Prometheus itself",
+                            "default": true
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress Path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Override API Version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "prometheus.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The Path to Prometheus. You may need to set this to '/*' in order to use this with ALB ingress controllers",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at prometheus.ingress.hostname parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Additional arbitrary path/backend objects",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "externalUrl": {
+                    "type": "string",
+                    "description": "External URL used to access Prometheus",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "CPU/Memory resource requests/limits for node",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Prometheus Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Prometheus Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Prometheus Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Prometheus Node labels for pod assignment",
+                    "default": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Prometheus Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Prometheus Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "scrapeInterval": {
+                    "type": "string",
+                    "description": "Interval between consecutive scrapes",
+                    "default": ""
+                },
+                "evaluationInterval": {
+                    "type": "string",
+                    "description": "Interval between consecutive evaluations",
+                    "default": ""
+                },
+                "scrapeTimeout": {
+                    "type": "string",
+                    "description": "Timeout after which the global scrape is ended",
+                    "default": ""
+                },
+                "sampleLimit": {
+                    "type": "string",
+                    "description": "Per-scrape max number of scraped samples. Requires Prometheus v2.45.0 and newer",
+                    "default": ""
+                },
+                "enforcedSampleLimit": {
+                    "type": "string",
+                    "description": "Override sampleLimits set by ServiceMonitor, PodMonitor or Probe objects",
+                    "default": ""
+                },
+                "listenLocal": {
+                    "type": "boolean",
+                    "description": "ListenLocal makes the Prometheus server listen on loopback",
+                    "default": false
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off liveness probe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path of the HTTP service for checking the healthy state",
+                            "default": "/-/healthy"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off readiness probe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path of the HTTP service for checking the ready state",
+                            "default": "/-/ready"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off readiness probe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path of the HTTP service for checking the ready state",
+                            "default": "/-/ready"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 60
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "enableAdminAPI": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus adminitrative API",
+                    "default": false
+                },
+                "enableFeatures": {
+                    "type": "array",
+                    "description": "Enable access to Prometheus disabled features.",
+                    "default": [],
+                    "items": {}
+                },
+                "alertingEndpoints": {
+                    "type": "array",
+                    "description": "Alertmanagers to which alerts will be sent",
+                    "default": [],
+                    "items": {}
+                },
+                "externalLabels": {
+                    "type": "object",
+                    "description": "External labels to add to any time series or alerts when communicating with external systems",
+                    "default": {}
+                },
+                "replicaExternalLabelName": {
+                    "type": "string",
+                    "description": "Name of the external label used to denote replica name",
+                    "default": ""
+                },
+                "replicaExternalLabelNameClear": {
+                    "type": "boolean",
+                    "description": "Clear external label used to denote replica name",
+                    "default": false
+                },
+                "routePrefix": {
+                    "type": "string",
+                    "description": "Prefix used to register routes, overriding externalUrl route",
+                    "default": "/"
+                },
+                "prometheusExternalLabelName": {
+                    "type": "string",
+                    "description": "Name of the external label used to denote Prometheus instance name",
+                    "default": ""
+                },
+                "prometheusExternalLabelNameClear": {
+                    "type": "boolean",
+                    "description": "Clear external label used to denote Prometheus instance name",
+                    "default": false
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Secrets that should be mounted into the Prometheus Pods",
+                    "default": [],
+                    "items": {}
+                },
+                "configMaps": {
+                    "type": "array",
+                    "description": "ConfigMaps that should be mounted into the Prometheus Pods",
+                    "default": [],
+                    "items": {}
+                },
+                "querySpec": {
+                    "type": "object",
+                    "description": "The query command line flags when starting Prometheus",
+                    "default": {}
+                },
+                "ruleNamespaceSelector": {
+                    "type": "object",
+                    "description": "Namespaces to be selected for PrometheusRules discovery",
+                    "default": {}
+                },
+                "ruleSelector": {
+                    "type": "object",
+                    "description": "PrometheusRules to be selected for target discovery",
+                    "default": {}
+                },
+                "serviceMonitorSelector": {
+                    "type": "object",
+                    "description": "ServiceMonitors to be selected for target discovery",
+                    "default": {}
+                },
+                "serviceMonitorNamespaceSelector": {
+                    "type": "object",
+                    "description": "Namespaces to be selected for ServiceMonitor discovery",
+                    "default": {}
+                },
+                "podMonitorSelector": {
+                    "type": "object",
+                    "description": "PodMonitors to be selected for target discovery.",
+                    "default": {}
+                },
+                "podMonitorNamespaceSelector": {
+                    "type": "object",
+                    "description": "Namespaces to be selected for PodMonitor discovery",
+                    "default": {}
+                },
+                "probeSelector": {
+                    "type": "object",
+                    "description": "Probes to be selected for target discovery.",
+                    "default": {}
+                },
+                "probeNamespaceSelector": {
+                    "type": "object",
+                    "description": "Namespaces to be selected for Probe discovery",
+                    "default": {}
+                },
+                "scrapeConfigSelector": {
+                    "type": "object",
+                    "description": "ScrapeConfig to be selected for target discovery.",
+                    "default": {}
+                },
+                "scrapeConfigNamespaceSelector": {
+                    "type": "object",
+                    "description": "Namespaces to be selected for ScrapeConfig discovery",
+                    "default": {}
+                },
+                "retention": {
+                    "type": "string",
+                    "description": "Metrics retention days",
+                    "default": "10d"
+                },
+                "retentionSize": {
+                    "type": "string",
+                    "description": "Maximum size of metrics",
+                    "default": ""
+                },
+                "disableCompaction": {
+                    "type": "boolean",
+                    "description": "Disable the compaction of the Prometheus TSDB",
+                    "default": false
+                },
+                "walCompression": {
+                    "type": "boolean",
+                    "description": "Enable compression of the write-ahead log using Snappy",
+                    "default": false
+                },
+                "paused": {
+                    "type": "boolean",
+                    "description": "If true, the Operator won't process any Prometheus configuration changes",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Prometheus replicas desired",
+                    "default": 1
+                },
+                "shards": {
+                    "type": "number",
+                    "description": "Number of Prometheus shards desired",
+                    "default": 1
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for Prometheus",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Log format for Prometheus",
+                    "default": "logfmt"
+                },
+                "podMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "labels": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        }
+                    }
+                },
+                "remoteRead": {
+                    "type": "array",
+                    "description": "The remote_read spec configuration for Prometheus",
+                    "default": [],
+                    "items": {}
+                },
+                "remoteWrite": {
+                    "type": "array",
+                    "description": "The remote_write spec configuration for Prometheus",
+                    "default": [],
+                    "items": {}
+                },
+                "enableRemoteWriteReceiver": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus to be used as a receiver for the Prometheus remote write protocol.",
+                    "default": false
+                },
+                "storageSpec": {
+                    "type": "object",
+                    "description": "Prometheus StorageSpec for persistent data",
+                    "default": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use PVCs to persist data. If the storageSpec is provided this will not take effect.",
+                            "default": false
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume Storage Class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume Size",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class assigned to the Pods",
+                    "default": ""
+                },
+                "containers": {
+                    "type": "array",
+                    "description": "Containers allows injecting additional containers",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the prometheus pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "volumes": {
+                    "type": "array",
+                    "description": "Volumes allows configuration of additional volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "volumeMounts": {
+                    "type": "array",
+                    "description": "VolumeMounts allows configuration of additional VolumeMounts. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "additionalPrometheusRules": {
+                    "type": "array",
+                    "description": "PrometheusRule defines recording and alerting rules for a Prometheus instance.",
+                    "default": [],
+                    "items": {}
+                },
+                "additionalArgs": {
+                    "type": "array",
+                    "description": "Allows setting additional arguments for the Prometheus container",
+                    "default": [],
+                    "items": {}
+                },
+                "additionalScrapeConfigs": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable additional scrape configs",
+                            "default": false
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Indicates if the cart should use external additional scrape configs or internal configs",
+                            "default": "external"
+                        },
+                        "external": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret that Prometheus should use for the additional external scrape configuration",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Name of the key inside the secret to be used for the additional external scrape configuration",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "internal": {
+                            "type": "object",
+                            "properties": {
+                                "jobList": {
+                                    "type": "array",
+                                    "description": "A list of Prometheus scrape jobs",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "additionalScrapeConfigsExternal": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Deprecated: Enable additional scrape configs that are managed externally to this chart",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Deprecated: Name of the secret that Prometheus should use for the additional scrape configuration",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Deprecated: Name of the key inside the secret to be used for the additional scrape configuration",
+                            "default": ""
+                        }
+                    }
+                },
+                "additionalAlertRelabelConfigsExternal": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable additional Prometheus alert relabel configs that are managed externally to this chart",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the secret that Prometheus should use for the additional Prometheus alert relabel configuration",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Name of the key inside the secret to be used for the additional Prometheus alert relabel configuration",
+                            "default": ""
+                        }
+                    }
+                },
+                "additionalAlertManagerExternal": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable additional Prometheus AlertManager configs that are managed externally to this chart",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the secret that Prometheus should use for the additional Prometheus AlertManager configuration",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Name of the key inside the secret to be used for the additional Prometheus AlertManager configuration",
+                            "default": ""
+                        }
+                    }
+                },
+                "thanos": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a Thanos sidecar container",
+                            "default": false
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Thanos image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Thanos image name",
+                                    "default": "bitnami/thanos"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Thanos image tag",
+                                    "default": "0.32.2-debian-11-r5"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Thanos image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Thanos image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Specify docker-registry secret names as an array",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable container security context",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "mount / (root) as a readonly filesystem",
+                                    "default": false
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Switch privilegeEscalation possibility on or off",
+                                    "default": false
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Force the container to run as a non root user",
+                                    "default": true
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Linux Kernel capabilities which should be dropped",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "prometheusUrl": {
+                            "type": "string",
+                            "description": "Override default prometheus url `http://localhost:9090`",
+                            "default": ""
+                        },
+                        "extraArgs": {
+                            "type": "array",
+                            "description": "Additional arguments passed to the thanos sidecar container",
+                            "default": [],
+                            "items": {}
+                        },
+                        "objectStorageConfig": {
+                            "type": "object",
+                            "properties": {
+                                "secretName": {
+                                    "type": "string",
+                                    "description": "Support mounting a Secret for the objectStorageConfig of the sideCar container.",
+                                    "default": ""
+                                },
+                                "secretKey": {
+                                    "type": "string",
+                                    "description": "Secret key with the configuration file.",
+                                    "default": "thanos.yaml"
+                                }
+                            }
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Additional volumeMounts from `prometheus.volumes` for thanos sidecar container",
+                            "default": [],
+                            "items": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the Thanos sidecar container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The resources requests for the Thanos sidecar container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Turn on and off liveness probe",
+                                    "default": true
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Path of the HTTP service for checking the healthy state",
+                                    "default": "/-/healthy"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Delay before liveness probe is initiated",
+                                    "default": 0
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "How often to perform the probe",
+                                    "default": 5
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "When the probe times out",
+                                    "default": 3
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive failures for the probe",
+                                    "default": 120
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive successes for the probe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Turn on and off readiness probe",
+                                    "default": true
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Path of the HTTP service for checking the ready state",
+                                    "default": "/-/ready"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Delay before readiness probe is initiated",
+                                    "default": 0
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "How often to perform the probe",
+                                    "default": 5
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "When the probe times out",
+                                    "default": 3
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive failures for the probe",
+                                    "default": 120
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Minimum consecutive successes for the probe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Kubernetes service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "grpc": {
+                                            "type": "number",
+                                            "description": "Thanos service port",
+                                            "default": 10901
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Specific cluster IP when service type is cluster IP. Use `None` to create headless service by default.",
+                                    "default": "None"
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "grpc": {
+                                            "type": "string",
+                                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Address that are allowed when svc is `LoadBalancer`",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Additional labels for Thanos service",
+                                    "default": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional annotations for Thanos service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Additional ports to expose from the Thanos sidecar container",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Prometheus service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "ingress": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress controller resource",
+                                    "default": false
+                                },
+                                "pathType": {
+                                    "type": "string",
+                                    "description": "Ingress path type",
+                                    "default": "ImplementationSpecific"
+                                },
+                                "apiVersion": {
+                                    "type": "string",
+                                    "description": "Force Ingress API version (automatically detected if not set)",
+                                    "default": ""
+                                },
+                                "hostname": {
+                                    "type": "string",
+                                    "description": "Default host for the ingress record",
+                                    "default": "thanos.prometheus.local"
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Default path for the ingress record",
+                                    "default": "/"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                                    "default": {}
+                                },
+                                "ingressClassName": {
+                                    "type": "string",
+                                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                                    "default": ""
+                                },
+                                "tls": {
+                                    "type": "boolean",
+                                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                                    "default": false
+                                },
+                                "selfSigned": {
+                                    "type": "boolean",
+                                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                                    "default": false
+                                },
+                                "extraHosts": {
+                                    "type": "array",
+                                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraPaths": {
+                                    "type": "array",
+                                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraTls": {
+                                    "type": "array",
+                                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "secrets": {
+                                    "type": "array",
+                                    "description": "Custom TLS certificates as secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraRules": {
+                                    "type": "array",
+                                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "configReloader": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable config-reloader sidecar service",
+                                    "default": false
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "description": "Kubernetes service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "config-reloader sidecar container service port",
+                                            "default": 8080
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Specific cluster IP when service type is cluster IP. Use `None` to create headless service by default.",
+                                    "default": "None"
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Address that are allowed when svc is `LoadBalancer`",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Additional labels for Prometheus service",
+                                    "default": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional annotations for Prometheus service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Additional ports to expose from the config-reloader sidecar container",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Prometheus service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Creates a ServiceMonitor to monitor Prometheus config-reloader sidecar",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "HTTP path to scrape for metrics",
+                                    "default": "/metrics"
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Metric relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Relabel configs",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "portName": {
+                    "type": "string",
+                    "description": "Port name used for the pods and governing service. This defaults to web",
+                    "default": "web"
+                }
+            }
+        },
+        "alertmanager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Alertmanager to the cluster",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Prometheus image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Prometheus image repository",
+                            "default": "bitnami/alertmanager"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Prometheus image tag (immutable tags are recommended)",
+                            "default": "0.26.0-debian-11-r14"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Prometheus image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specify whether to create a ServiceAccount for Alertmanager",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to create",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off",
+                            "default": false
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the container to run as a non root user",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Linux Kernel capabilities which should be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a pod disruption budget for Alertmanager",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number / percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number / percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Alertmanager service port",
+                                    "default": 9093
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Specific cluster IP when service type is cluster IP. Use `None` for headless service",
+                            "default": ""
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when svc is `LoadBalancer`",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "healthCheckNodePort": {
+                            "type": "string",
+                            "description": "Specifies the health check node port",
+                            "default": ""
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for Alertmanager service (this value is evaluated as a template)",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a ServiceMonitor to monitor Alertmanager",
+                            "default": true
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval. If not set, the Prometheus default scrape interval is used.",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "extraParameters": {
+                            "type": "object",
+                            "description": "Any extra parameter to be added to the endpoint configured in the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress Path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Override API Version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "alertmanager.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The Path to Alert Manager. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at alertmanager.ingress.hostname parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Additional arbitrary path/backend objects",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "externalUrl": {
+                    "type": "string",
+                    "description": "External URL used to access Alertmanager",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "CPU/Memory resource requests/limits for node",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Alertmanager Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Alertmanager Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Alertmanager Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Alertmanager Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Alertmanager Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Alertmanager Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Alertmanager Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Alertmanager Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "global": {
+                            "type": "object",
+                            "properties": {
+                                "resolve_timeout": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "5m"
+                                }
+                            }
+                        },
+                        "route": {
+                            "type": "object",
+                            "properties": {
+                                "group_wait": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "30s"
+                                },
+                                "group_interval": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "5m"
+                                },
+                                "repeat_interval": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "12h"
+                                },
+                                "receiver": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": null
+                                },
+                                "routes": {
+                                    "type": "array",
+                                    "description": "",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "match": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "alertname": {
+                                                        "type": "string",
+                                                        "description": ""
+                                                    }
+                                                }
+                                            },
+                                            "receiver": {
+                                                "type": "string",
+                                                "description": ""
+                                            }
+                                        }
+                                    }
+                                },
+                                "group_by": {
+                                    "type": "array",
+                                    "description": "",
+                                    "default": [
+                                        "job"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "receivers": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "templateFiles": {
+                    "type": "object",
+                    "description": "Extra files to be added inside the `alertmanager-{{ template \"kube-prometheus.alertmanager.fullname\" . }}` secret.",
+                    "default": {}
+                },
+                "externalConfig": {
+                    "type": "boolean",
+                    "description": "Alertmanager configuration is created externally. If true, `alertmanager.config` is ignored, and a secret will not be created.",
+                    "default": false
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Alertmanager replicas desired",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off liveness probe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path of the HTTP service for checking the healthy state",
+                            "default": "/-/healthy"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 120
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Turn on and off readiness probe",
+                            "default": true
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path of the HTTP service for checking the ready state",
+                            "default": "/-/ready"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe",
+                            "default": 120
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe",
+                            "default": 1
+                        }
+                    }
+                },
+                "podMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "labels": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        }
+                    }
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Log level for Alertmanager",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Log format for Alertmanager",
+                    "default": "logfmt"
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Secrets that should be mounted into the Alertmanager Pods",
+                    "default": [],
+                    "items": {}
+                },
+                "configMaps": {
+                    "type": "array",
+                    "description": "ConfigMaps that should be mounted into the Alertmanager Pods",
+                    "default": [],
+                    "items": {}
+                },
+                "retention": {
+                    "type": "string",
+                    "description": "Metrics retention days",
+                    "default": "120h"
+                },
+                "storageSpec": {
+                    "type": "object",
+                    "description": "Alertmanager StorageSpec for persistent data",
+                    "default": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use PVCs to persist data. If the storageSpec is provided this will not take effect.",
+                            "default": false
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume Storage Class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume Size",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        }
+                    }
+                },
+                "paused": {
+                    "type": "boolean",
+                    "description": "If true, the Operator won't process any Alertmanager configuration changes",
+                    "default": false
+                },
+                "listenLocal": {
+                    "type": "boolean",
+                    "description": "ListenLocal makes the Alertmanager server listen on loopback",
+                    "default": false
+                },
+                "containers": {
+                    "type": "array",
+                    "description": "Containers allows injecting additional containers",
+                    "default": [],
+                    "items": {}
+                },
+                "volumes": {
+                    "type": "array",
+                    "description": "Volumes allows configuration of additional volumes. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "volumeMounts": {
+                    "type": "array",
+                    "description": "VolumeMounts allows configuration of additional VolumeMounts. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class assigned to the Pods",
+                    "default": ""
+                },
+                "additionalPeers": {
+                    "type": "array",
+                    "description": "AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster",
+                    "default": [],
+                    "items": {}
+                },
+                "routePrefix": {
+                    "type": "string",
+                    "description": "Prefix used to register routes, overriding externalUrl route",
+                    "default": "/"
+                },
+                "portName": {
+                    "type": "string",
+                    "description": "Port name used for the pods and governing service. This defaults to web",
+                    "default": "web"
+                },
+                "configNamespaceSelector": {
+                    "type": "object",
+                    "description": "Namespaces to be selected for AlertmanagerConfig discovery. If nil, only check own namespace. This defaults to {}",
+                    "default": {}
+                },
+                "configSelector": {
+                    "type": "object",
+                    "description": "AlertmanagerConfigs to be selected for to merge and configure Alertmanager with. This defaults to {}",
+                    "default": {}
+                },
+                "configuration": {
+                    "type": "object",
+                    "description": "EXPERIMENTAL: alertmanagerConfiguration specifies the global Alertmanager configuration. If defined, it takes precedence over the `configSecret` field. This field may change in future releases. The specified global alertmanager config will not force add a namespace label in routes and inhibitRules",
+                    "default": {}
+                }
+            }
+        },
+        "node-exporter": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "labels": {
+                            "type": "object",
+                            "properties": {
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "node-exporter"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "",
+                            "default": true
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "",
+                            "default": "jobLabel"
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "properties": {
+                        "collector": {
+                            "type": "object",
+                            "properties": {
+                                "filesystem": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ignored-mount-points": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
+                                        },
+                                        "ignored-fs-types": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "kube-state-metrics": {
+            "type": "object",
+            "properties": {
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "",
+                            "default": true
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "exporters": {
+            "type": "object",
+            "properties": {
+                "node-exporter": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable node-exporter",
+                            "default": true
+                        }
+                    }
+                },
+                "kube-state-metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable kube-state-metrics",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "kubelet": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create a ServiceMonitor to scrape kubelet service",
+                    "default": true
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace where kubelet service is deployed. Related configuration `operator.kubeletService.namespace`",
+                    "default": "kube-system"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "boolean",
+                            "description": "Enable scraping of the kubelet over HTTPS",
+                            "default": true
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": "k8s-app"
+                        },
+                        "resource": {
+                            "type": "boolean",
+                            "description": "Enable scraping /metrics/resource from kubelet's service",
+                            "default": false
+                        },
+                        "resourcePath": {
+                            "type": "string",
+                            "description": "From kubernetes 1.18, /metrics/resource/v1alpha1 was renamed to /metrics/resource",
+                            "default": "/metrics/resource/v1alpha1"
+                        },
+                        "resourceRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "resourceMetricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "cAdvisor": {
+                            "type": "boolean",
+                            "description": "Enable scraping /metrics/cadvisor from kubelet's service",
+                            "default": true
+                        },
+                        "cAdvisorMetricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling for scraping cAdvisor",
+                            "default": [],
+                            "items": {}
+                        },
+                        "cAdvisorRelabelings": {
+                            "type": "array",
+                            "description": "Relabel configs for scraping cAdvisor",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "blackboxExporter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Blackbox Exporter deployment",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Blackbox Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Blackbox Exporter image repository",
+                            "default": "bitnami/blackbox-exporter"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Blackbox Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Blackbox Exporter image tag (immutable tags are recommended)",
+                            "default": "0.24.0-debian-11-r109"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Blackbox Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to blackboxExporter nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for blackboxExporter nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for blackboxExporter nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Blackbox Exporter replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Blackbox Exporter nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Blackbox Exporter nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Blackbox Exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "existingConfigMap": {
+                    "type": "string",
+                    "description": "ConfigMap pointing to the Blackbox Exporter configuration",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Blackbox Exporter HTTP container port",
+                            "default": 19115
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable creation of ServiceAccount for WordPress pod",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the blackboxExporter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the blackboxExporter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Blackbox Exporter pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Blackbox Exporter pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Blackbox Exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Blackbox Exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Blackbox Exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the blackboxExporter container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "blackboxExporter pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for blackboxExporter pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for blackboxExporter pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `blackboxExporter.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `blackboxExporter.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `blackboxExporter.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `blackboxExporter.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `blackboxExporter.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Blackbox Exporter pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Blackbox Exporter pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Blackbox Exporter pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Blackbox Exporter pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Blackbox Exporter pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Blackbox Exporter statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Blackbox Exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Blackbox Exporter container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Blackbox Exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Blackbox Exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Blackbox Exporter service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Blackbox Exporter HTTP service port",
+                                    "default": 19115
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Blackbox Exporter service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Blackbox Exporter service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Blackbox Exporter service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Blackbox Exporter service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Blackbox Exporter service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Blackbox Exporter service",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "kubeApiServer": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create a ServiceMonitor to scrape kube-apiserver service",
+                    "default": true
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval. If not set, the Prometheus default scrape interval is used.",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": "component"
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "kubeControllerManager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create a ServiceMonitor to scrape kube-controller-manager service",
+                    "default": true
+                },
+                "endpoints": {
+                    "type": "array",
+                    "description": "If your kube controller manager is not deployed as a pod, specify IPs it can be found on",
+                    "default": [],
+                    "items": {}
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace where kube-controller-manager service is deployed.",
+                    "default": "kube-system"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to create a Service object for kube-controller-manager",
+                            "default": true
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Listening port of the kube-controller-manager Service object",
+                                    "default": 10252
+                                }
+                            }
+                        },
+                        "targetPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Port to target on the kube-controller-manager Pods. This should be the port that kube-controller-manager is exposing metrics on",
+                                    "default": 10252
+                                }
+                            }
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Optional PODs Label selector for the service",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for kube-controller-manaer service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": "component"
+                        },
+                        "https": {
+                            "type": "boolean",
+                            "description": "Enable scraping kube-controller-manager over https",
+                            "default": false
+                        },
+                        "insecureSkipVerify": {
+                            "type": "string",
+                            "description": "Skip TLS certificate validation when scraping",
+                            "default": ""
+                        },
+                        "serverName": {
+                            "type": "string",
+                            "description": "Name of the server to use when validating TLS certificate",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "kubeScheduler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create a ServiceMonitor to scrape kube-scheduler service",
+                    "default": true
+                },
+                "endpoints": {
+                    "type": "array",
+                    "description": "If your kube scheduler is not deployed as a pod, specify IPs it can be found on",
+                    "default": [],
+                    "items": {}
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace where kube-scheduler service is deployed.",
+                    "default": "kube-system"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to create a Service object for kube-scheduler",
+                            "default": true
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Listening port of the kube scheduler Service object",
+                                    "default": 10251
+                                }
+                            }
+                        },
+                        "targetPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Port to target on the kube scheduler Pods. This should be the port that kube scheduler is exposing metrics on",
+                                    "default": 10251
+                                }
+                            }
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Optional PODs Label selector for the service",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for kube-scheduler service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "boolean",
+                            "description": "Enable scraping kube-scheduler over https",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": "component"
+                        },
+                        "insecureSkipVerify": {
+                            "type": "string",
+                            "description": "Skip TLS certificate validation when scraping",
+                            "default": ""
+                        },
+                        "serverName": {
+                            "type": "string",
+                            "description": "Name of the server to use when validating TLS certificate",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "coreDns": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create a ServiceMonitor to scrape coredns service",
+                    "default": true
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace where core dns service is deployed.",
+                    "default": "kube-system"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to create a Service object for coredns",
+                            "default": true
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Listening port of the coredns Service object",
+                                    "default": 9153
+                                }
+                            }
+                        },
+                        "targetPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Port to target on the coredns Pods. This should be the port that coredns is exposing metrics on",
+                                    "default": 9153
+                                }
+                            }
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Optional PODs Label selector for the service",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for coredns service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval. If not set, the Prometheus default scrape interval is used.",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": "k8s-app"
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabel configs to apply to samples before ingestion.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs to apply to samples before ingestion.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "kubeProxy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create a ServiceMonitor to scrape the kube-proxy Service",
+                    "default": true
+                },
+                "endpoints": {
+                    "type": "array",
+                    "description": "If your kube-proxy is not deployed as a pod, specify IPs it can be found on",
+                    "default": [],
+                    "items": {}
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace where kube-proxy service is deployed.",
+                    "default": "kube-system"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to create a Service object for kube-proxy",
+                            "default": true
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Listening port of the kube-proxy Service object",
+                                    "default": 10249
+                                }
+                            }
+                        },
+                        "targetPorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Port to target on the kube-proxy Pods. This should be the port that kube-proxy is exposing metrics on",
+                                    "default": 10249
+                                }
+                            }
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Optional PODs Label selector for the service",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for kube-proxy service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "boolean",
+                            "description": "Enable scraping kube-proxy over https.",
+                            "default": false
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": "k8s-app"
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metric relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Relabel configs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": true
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy and bound it with RBAC. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": true
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kube-state-metrics/values.schema.json
+++ b/bitnami/kube-state-metrics/values.schema.json
@@ -1,0 +1,814 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override `kube-state-metrics.name` template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override `kube-state-metrics.fullname` template with a string",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create & use RBAC resources or not",
+                    "default": true
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy and bound it with RBAC. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "kube-state-metrics image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "kube-state-metrics image repository",
+                    "default": "bitnami/kube-state-metrics"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "kube-state-metrics image tag (immutable tags are recommended)",
+                    "default": "2.10.0-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "kube-state-metrics image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "kube-state-metrics image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "extraArgs": {
+            "type": "object",
+            "description": "Additional command line arguments to pass to kube-state-metrics",
+            "default": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the kube-state-metrics container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to kube-state-metrics nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for kube-state-metrics pod(s)",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for kube-state-metrics pod(s)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the kube-state-metrics pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the kube-state-metrics container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the kube-state-metrics pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the kube-state-metrics pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "namespaces": {
+            "type": "string",
+            "description": "Comma-separated list of namespaces to be enabled. Defaults to all namespaces. Evaluated as a template.",
+            "default": ""
+        },
+        "kubeResources": {
+            "type": "object",
+            "properties": {
+                "certificatesigningrequests": {
+                    "type": "boolean",
+                    "description": "Enable the `certificatesigningrequests` resource",
+                    "default": true
+                },
+                "configmaps": {
+                    "type": "boolean",
+                    "description": "Enable the `configmaps` resource",
+                    "default": true
+                },
+                "cronjobs": {
+                    "type": "boolean",
+                    "description": "Enable the `cronjobs` resource",
+                    "default": true
+                },
+                "daemonsets": {
+                    "type": "boolean",
+                    "description": "Enable the `daemonsets` resource",
+                    "default": true
+                },
+                "deployments": {
+                    "type": "boolean",
+                    "description": "Enable the `deployments` resource",
+                    "default": true
+                },
+                "endpoints": {
+                    "type": "boolean",
+                    "description": "Enable the `endpoints` resource",
+                    "default": true
+                },
+                "horizontalpodautoscalers": {
+                    "type": "boolean",
+                    "description": "Enable the `horizontalpodautoscalers` resource",
+                    "default": true
+                },
+                "ingresses": {
+                    "type": "boolean",
+                    "description": "Enable the `ingresses` resource",
+                    "default": true
+                },
+                "jobs": {
+                    "type": "boolean",
+                    "description": "Enable the `jobs` resource",
+                    "default": true
+                },
+                "limitranges": {
+                    "type": "boolean",
+                    "description": "Enable the `limitranges` resource",
+                    "default": true
+                },
+                "mutatingwebhookconfigurations": {
+                    "type": "boolean",
+                    "description": "Enable the `mutatingwebhookconfigurations` resource",
+                    "default": true
+                },
+                "namespaces": {
+                    "type": "boolean",
+                    "description": "Enable the `namespaces` resource",
+                    "default": true
+                },
+                "networkpolicies": {
+                    "type": "boolean",
+                    "description": "Enable the `networkpolicies` resource",
+                    "default": true
+                },
+                "nodes": {
+                    "type": "boolean",
+                    "description": "Enable the `nodes` resource",
+                    "default": true
+                },
+                "persistentvolumeclaims": {
+                    "type": "boolean",
+                    "description": "Enable the `persistentvolumeclaims` resource",
+                    "default": true
+                },
+                "persistentvolumes": {
+                    "type": "boolean",
+                    "description": "Enable the `persistentvolumes` resource",
+                    "default": true
+                },
+                "poddisruptionbudgets": {
+                    "type": "boolean",
+                    "description": "Enable the `poddisruptionbudgets` resource",
+                    "default": true
+                },
+                "pods": {
+                    "type": "boolean",
+                    "description": "Enable the `pods` resource",
+                    "default": true
+                },
+                "replicasets": {
+                    "type": "boolean",
+                    "description": "Enable the `replicasets` resource",
+                    "default": true
+                },
+                "replicationcontrollers": {
+                    "type": "boolean",
+                    "description": "Enable the `replicationcontrollers` resource",
+                    "default": true
+                },
+                "resourcequotas": {
+                    "type": "boolean",
+                    "description": "Enable the `resourcequotas` resource",
+                    "default": true
+                },
+                "secrets": {
+                    "type": "boolean",
+                    "description": "Enable the `secrets` resource",
+                    "default": true
+                },
+                "services": {
+                    "type": "boolean",
+                    "description": "Enable the `services` resource",
+                    "default": true
+                },
+                "statefulsets": {
+                    "type": "boolean",
+                    "description": "Enable the `statefulsets` resource",
+                    "default": true
+                },
+                "storageclasses": {
+                    "type": "boolean",
+                    "description": "Enable the `storageclasses` resource",
+                    "default": true
+                },
+                "verticalpodautoscalers": {
+                    "type": "boolean",
+                    "description": "Enable the `verticalpodautoscalers` resource",
+                    "default": false
+                },
+                "validatingwebhookconfigurations": {
+                    "type": "boolean",
+                    "description": "Enable the `validatingwebhookconfigurations` resource",
+                    "default": false
+                },
+                "volumeattachments": {
+                    "type": "boolean",
+                    "description": "Enable the `volumeattachments` resource",
+                    "default": true
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled kube-state-metrics pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set kube-state-metrics pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled kube-state-metrics containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set kube-state-metrics containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set kube-state-metrics container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "kube-state-metrics service port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Specific cluster IP when service type is cluster IP. Use `None` for headless service",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Address that are allowed when svc is `LoadBalancer`",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "kube-state-metrics service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for kube-state-metrics service",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Additional labels for kube-state-metrics service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Enable hostNetwork mode",
+            "default": false
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority class assigned to the Pods",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the kube-state-metrics pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Desired number of controller pods",
+            "default": 1
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod labels",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "description": "Allows setting of `RollingUpdate` strategy",
+            "default": {}
+        },
+        "minReadySeconds": {
+            "type": "number",
+            "description": "How many seconds a pod needs to be ready before killing the next, during update",
+            "default": 0
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turn on and off liveness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before liveness probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turn on and off readiness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before readiness probe is initiated",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turn on and off startup probe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before startup probe is initiated",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readiness probe for the Web component",
+            "default": {}
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Creates a ServiceMonitor to monitor kube-state-metrics",
+                    "default": false
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace in which Prometheus is running",
+                    "default": ""
+                },
+                "jobLabel": {
+                    "type": "string",
+                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                    "default": ""
+                },
+                "interval": {
+                    "type": "string",
+                    "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                    "default": ""
+                },
+                "scrapeTimeout": {
+                    "type": "string",
+                    "description": "Timeout after which the scrape is ended",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "ServiceMonitor selector labels",
+                    "default": {}
+                },
+                "honorLabels": {
+                    "type": "boolean",
+                    "description": "Honor metrics labels",
+                    "default": false
+                },
+                "relabelings": {
+                    "type": "array",
+                    "description": "ServiceMonitor relabelings",
+                    "default": [],
+                    "items": {}
+                },
+                "metricRelabelings": {
+                    "type": "array",
+                    "description": "ServiceMonitor metricRelabelings",
+                    "default": [],
+                    "items": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Extra labels for the ServiceMonitor",
+                    "default": {}
+                },
+                "extraParameters": {
+                    "type": "object",
+                    "description": "Any extra parameter to be added to the endpoint configured in the ServiceMonitor",
+                    "default": {}
+                }
+            }
+        },
+        "selfMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Creates a selfMonitor to monitor kube-state-metrics itself",
+                    "default": false
+                },
+                "telemetryPort": {
+                    "type": "number",
+                    "description": "Kube-state-metrics telemetry Port",
+                    "default": 8081
+                },
+                "telemetryNodePort": {
+                    "type": "string",
+                    "description": "Kube-state-metrics Node Port",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/kubeapps/values.schema.json
+++ b/bitnami/kubeapps/values.schema.json
@@ -1,125 +1,2891 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "frontend": {
-      "type": "object",
-      "title": "Frontend configuration",
-      "form": true,
-      "properties": {
-        "replicaCount": {
-          "type": "integer",
-          "title": "Number of replicas",
-          "form": true
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "enableIPv6": {
+            "type": "boolean",
+            "description": "Enable IPv6 configuration",
+            "default": false
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Kubeapps",
+                    "default": false
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "kubeapps.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "nginx": {
+                            "type": "object",
+                            "properties": {
+                                "ingress": {
+                                    "type": "object",
+                                    "properties": {
+                                        "kubernetes": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/proxy-read-timeout": {
+                                                    "type": "object",
+                                                    "description": "",
+                                                    "default": {
+                                                        "nginx.ingress.kubernetes.io/proxy-read-timeout": "600"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "packaging": {
+            "type": "object",
+            "properties": {
+                "helm": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the standard Helm packaging.",
+                            "default": true
+                        }
+                    }
+                },
+                "carvel": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable support for the Carvel (kapp-controller) packaging.",
+                            "default": false
+                        }
+                    }
+                },
+                "flux": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable support for Flux (v2) packaging.",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "frontend": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "NGINX image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "NGINX image repository",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "NGINX image tag (immutable tags are recommended)",
+                            "default": "1.25.2-debian-11-r8"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "NGINX image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "NGINX image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "proxypassAccessTokenAsBearer": {
+                    "type": "boolean",
+                    "description": "Use access_token as the Bearer when talking to the k8s api server",
+                    "default": false
+                },
+                "proxypassExtraSetHeader": {
+                    "type": "string",
+                    "description": "Set an additional proxy header for all requests proxied via NGINX",
+                    "default": ""
+                },
+                "largeClientHeaderBuffers": {
+                    "type": "string",
+                    "description": "Set large_client_header_buffers in NGINX config",
+                    "default": "4 32k"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of frontend replicas to deploy",
+                    "default": 2
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Frontend deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The CPU limits for the NGINX container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The memory limits for the NGINX container",
+                                    "default": "128Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the NGINX container",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the NGINX container",
+                                    "default": "32Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to the NGINX container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for the NGINX container",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for the NGINX container",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "NGINX HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled frontend pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set frontend pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled NGINX containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set NGINX container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set NGINX container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Custom lifecycle hooks for frontend containers",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for frontend pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for frontend pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class name for frontend pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for frontend pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for frontend pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for frontend container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the frontend pod",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the frontend pods",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Frontend service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Frontend service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Frontend service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Frontend service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Frontend service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Frontend service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for frontend service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "dashboard": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether Kubeapps Dashboard should be deployed or not",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Dashboard image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Dashboard image repository",
+                            "default": "bitnami/kubeapps-dashboard"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Dashboard image tag (immutable tags are recommended)",
+                            "default": "2.8.0-debian-11-r50"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Dashboard image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Dashboard image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Dashboard image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "customStyle": {
+                    "type": "string",
+                    "description": "Custom CSS injected to the Dashboard to customize Kubeapps look and feel",
+                    "default": ""
+                },
+                "customAppViews": {
+                    "type": "array",
+                    "description": "Package names to signal a custom app view",
+                    "default": [],
+                    "items": {}
+                },
+                "customComponents": {
+                    "type": "string",
+                    "description": "Custom Form components injected into the BasicDeploymentForm",
+                    "default": ""
+                },
+                "remoteComponentsUrl": {
+                    "type": "string",
+                    "description": "Remote URL that can be used to load custom components vs loading from the local filesystem",
+                    "default": ""
+                },
+                "skipAvailablePackageDetails": {
+                    "type": "boolean",
+                    "description": "Skip the package details view and go straight to the installation view of the latest version",
+                    "default": false
+                },
+                "customLocale": {
+                    "type": "string",
+                    "description": "Custom translations injected to the Dashboard to customize the strings used in Kubeapps",
+                    "default": ""
+                },
+                "defaultTheme": {
+                    "type": "string",
+                    "description": "Default theme used in the Dashboard if the user has not selected any theme yet.",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Dashboard replicas to deploy",
+                    "default": 2
+                },
+                "createNamespaceLabels": {
+                    "type": "object",
+                    "description": "Labels added to newly created namespaces",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Dashboard deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to the Dashboard container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for the Dashboard container",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for the Dashboard container",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Dashboard HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The CPU limits for the Dashboard container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The memory limits for the Dashboard container",
+                                    "default": "128Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the Dashboard container",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the Dashboard container",
+                                    "default": "32Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dashboard pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Dashboard pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dashboard containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Dashboard container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Dashboard container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Custom lifecycle hooks for Dashboard containers",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Dashboard pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Dashboard pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class name for Dashboard pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for Dashboard pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for Dashboard pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for Dashboard container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Dashboard pod",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Dashboard pods",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Dashboard service HTTP port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Dashboard service",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "apprepository": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Kubeapps AppRepository Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Kubeapps AppRepository Controller image repository",
+                            "default": "bitnami/kubeapps-apprepository-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Kubeapps AppRepository Controller image tag (immutable tags are recommended)",
+                            "default": "2.8.0-debian-11-r20"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Kubeapps AppRepository Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Kubeapps AppRepository Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Kubeapps AppRepository Controller image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "syncImage": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Kubeapps Asset Syncer image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Kubeapps Asset Syncer image repository",
+                            "default": "bitnami/kubeapps-asset-syncer"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Kubeapps Asset Syncer image tag (immutable tags are recommended)",
+                            "default": "2.8.0-debian-11-r20"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Kubeapps Asset Syncer image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Kubeapps Asset Syncer image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Kubeapps Asset Syncer image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "globalReposNamespaceSuffix": {
+                    "type": "string",
+                    "description": "Suffix for the namespace of global repos in the Helm plugin. Defaults to empty for backwards compatibility. Ignored if kubeappsapis.pluginConfig.helm.packages.v1alpha1.globalPackagingNamespace is set.",
+                    "default": ""
+                },
+                "initialRepos": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "url": {
+                                "type": "string",
+                                "description": ""
+                            }
+                        }
+                    }
+                },
+                "customAnnotations": {
+                    "type": "object",
+                    "description": "Custom annotations be added to each AppRepository-generated CronJob, Job and Pod",
+                    "default": {}
+                },
+                "customLabels": {
+                    "type": "object",
+                    "description": "Custom labels be added to each AppRepository-generated CronJob, Job and Pod",
+                    "default": {}
+                },
+                "initialReposProxy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enables the proxy",
+                            "default": false
+                        },
+                        "httpProxy": {
+                            "type": "string",
+                            "description": "URL for the http proxy",
+                            "default": ""
+                        },
+                        "httpsProxy": {
+                            "type": "string",
+                            "description": "URL for the https proxy",
+                            "default": ""
+                        },
+                        "noProxy": {
+                            "type": "string",
+                            "description": "URL to exclude from using the proxy",
+                            "default": ""
+                        }
+                    }
+                },
+                "crontab": {
+                    "type": "string",
+                    "description": "Default schedule for syncing App repositories (defaults to every 10 minutes)",
+                    "default": ""
+                },
+                "watchAllNamespaces": {
+                    "type": "boolean",
+                    "description": "Watch all namespaces to support separate AppRepositories per namespace",
+                    "default": true
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Additional command line flags for AppRepository Controller",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of AppRepository Controller replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "AppRepository Controller deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The CPU limits for the AppRepository Controller container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The memory limits for the AppRepository Controller container",
+                                    "default": "128Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the AppRepository Controller container",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the AppRepository Controller container",
+                                    "default": "32Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled AppRepository Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set AppRepository Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled AppRepository Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set AppRepository Controller container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set AppRepository Controller container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Custom lifecycle hooks for AppRepository Controller containers",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to AppRepository Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for AppRepository Controller pod(s)",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for AppRepository Controller pod(s)",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the AppRepository Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the AppRepository Controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for AppRepository Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for AppRepository Controller pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class name for AppRepository Controller pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for AppRepository Controller pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the AppRepository Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the AppRepository Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "authProxy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether Kubeapps should configure OAuth login/logout",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OAuth2 Proxy image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OAuth2 Proxy image repository",
+                            "default": "bitnami/oauth2-proxy"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OAuth2 Proxy image tag (immutable tags are recommended)",
+                            "default": "7.4.0-debian-11-r281"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OAuth2 Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OAuth2 Proxy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OAuth2 Proxy image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "external": {
+                    "type": "boolean",
+                    "description": "Use an external Auth Proxy instead of deploying its own one",
+                    "default": false
+                },
+                "oauthLoginURI": {
+                    "type": "string",
+                    "description": "OAuth Login URI to which the Kubeapps frontend redirects for authn",
+                    "default": "/oauth2/start"
+                },
+                "oauthLogoutURI": {
+                    "type": "string",
+                    "description": "OAuth Logout URI to which the Kubeapps frontend redirects for authn",
+                    "default": "/oauth2/sign_out"
+                },
+                "skipKubeappsLoginPage": {
+                    "type": "boolean",
+                    "description": "Skip the Kubeapps login page when using OIDC and directly redirect to the IdP",
+                    "default": false
+                },
+                "provider": {
+                    "type": "string",
+                    "description": "OAuth provider",
+                    "default": ""
+                },
+                "clientID": {
+                    "type": "string",
+                    "description": "OAuth Client ID",
+                    "default": ""
+                },
+                "clientSecret": {
+                    "type": "string",
+                    "description": "OAuth Client secret",
+                    "default": ""
+                },
+                "cookieSecret": {
+                    "type": "string",
+                    "description": "Secret used by oauth2-proxy to encrypt any credentials",
+                    "default": ""
+                },
+                "existingOauth2Secret": {
+                    "type": "string",
+                    "description": "Name of an existing secret containing the OAuth client secrets, it should contain the keys clientID, clientSecret, and cookieSecret",
+                    "default": ""
+                },
+                "cookieRefresh": {
+                    "type": "string",
+                    "description": "Duration after which to refresh the cookie",
+                    "default": "2m"
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "OAuth scope specification",
+                    "default": "openid email groups"
+                },
+                "emailDomain": {
+                    "type": "string",
+                    "description": "Allowed email domains",
+                    "default": "*"
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Additional command line flags for oauth2-proxy",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Auth Proxy container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to the Auth Proxy container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Auth Proxy containers(s)",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Auth Proxy containers(s)",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Auth Proxy container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "proxy": {
+                            "type": "number",
+                            "description": "Auth Proxy HTTP container port",
+                            "default": 3000
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Auth Proxy containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Auth Proxy container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Auth Proxy container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The CPU limits for the OAuth2 Proxy container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The memory limits for the OAuth2 Proxy container",
+                                    "default": "128Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the OAuth2 Proxy container",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the OAuth2 Proxy container",
+                                    "default": "32Mi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "pinnipedProxy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether Kubeapps should configure Pinniped Proxy",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Pinniped Proxy image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Pinniped Proxy image repository",
+                            "default": "bitnami/kubeapps-pinniped-proxy"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Pinniped Proxy image tag (immutable tags are recommended)",
+                            "default": "2.8.0-debian-11-r49"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Pinniped Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Pinniped Proxy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Pinniped Proxy image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "defaultPinnipedNamespace": {
+                    "type": "string",
+                    "description": "Namespace in which pinniped concierge is installed",
+                    "default": "pinniped-concierge"
+                },
+                "defaultAuthenticatorType": {
+                    "type": "string",
+                    "description": "Authenticator type",
+                    "default": "JWTAuthenticator"
+                },
+                "defaultAuthenticatorName": {
+                    "type": "string",
+                    "description": "Authenticator name",
+                    "default": "jwt-authenticator"
+                },
+                "defaultPinnipedAPISuffix": {
+                    "type": "string",
+                    "description": "API suffix",
+                    "default": "pinniped.dev"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "TLS secret with which to proxy requests",
+                            "default": ""
+                        },
+                        "caCertificate": {
+                            "type": "string",
+                            "description": "TLS CA cert config map which clients of pinniped proxy should use with TLS requests",
+                            "default": ""
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "For the Pinniped Proxy container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Pinniped Proxy container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Pinniped Proxy container(s)",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Pinniped Proxy container(s)",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Pinniped Proxy container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "pinnipedProxy": {
+                            "type": "number",
+                            "description": "Pinniped Proxy container port",
+                            "default": 3333
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Pinniped Proxy containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Pinniped Proxy container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Pinniped Proxy container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The CPU limits for the Pinniped Proxy container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The memory limits for the Pinniped Proxy container",
+                                    "default": "128Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the Pinniped Proxy container",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the Pinniped Proxy container",
+                                    "default": "32Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "pinnipedProxy": {
+                                    "type": "number",
+                                    "description": "Pinniped Proxy service port",
+                                    "default": 3333
+                                }
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Pinniped Proxy service",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "clusters": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "featureFlags": {
+            "type": "object",
+            "properties": {
+                "apiOnly": {
+                    "type": "object",
+                    "properties": {
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nginx": {
+                                            "type": "object",
+                                            "properties": {
+                                                "ingress": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kubernetes": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "io/backend-protocol": {
+                                                                    "type": "string",
+                                                                    "description": "",
+                                                                    "default": "GRPC"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress for API operations only. Access to \"/\" will not be possible, so Dashboard will be unusable.",
+                            "default": false
+                        }
+                    }
+                },
+                "operators": {
+                    "type": "boolean",
+                    "description": "Enable support for Operators in Kubeapps",
+                    "default": false
+                },
+                "schemaEditor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable a visual editor for customizing the package schemas",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a PostgreSQL server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Username for PostgreSQL server",
+                            "default": "postgres"
+                        },
+                        "postgresPassword": {
+                            "type": "string",
+                            "description": "Password for 'postgres' user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "assets"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable PostgreSQL Primary data persistence using PVC",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled PostgreSQL replicas pods' Security Context",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the PostgreSQL container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the PostgreSQL container",
+                                    "default": "256Mi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "kubeappsapis": {
+            "type": "object",
+            "properties": {
+                "enabledPlugins": {
+                    "type": "array",
+                    "description": "Manually override which plugins are enabled for the Kubeapps-APIs service",
+                    "default": [],
+                    "items": {}
+                },
+                "pluginConfig": {
+                    "type": "object",
+                    "properties": {
+                        "core": {
+                            "type": "object",
+                            "properties": {
+                                "packages": {
+                                    "type": "object",
+                                    "properties": {
+                                        "v1alpha1": {
+                                            "type": "object",
+                                            "properties": {
+                                                "versionsInSummary": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "major": {
+                                                            "type": "number",
+                                                            "description": "Number of major versions to display in the summary",
+                                                            "default": 3
+                                                        },
+                                                        "minor": {
+                                                            "type": "number",
+                                                            "description": "Number of minor versions to display in the summary",
+                                                            "default": 3
+                                                        },
+                                                        "patch": {
+                                                            "type": "number",
+                                                            "description": "Number of patch versions to display in the summary",
+                                                            "default": 3
+                                                        }
+                                                    }
+                                                },
+                                                "timeoutSeconds": {
+                                                    "type": "number",
+                                                    "description": "Value to wait for Kubernetes commands to complete",
+                                                    "default": 300
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "helm": {
+                            "type": "object",
+                            "properties": {
+                                "packages": {
+                                    "type": "object",
+                                    "properties": {
+                                        "v1alpha1": {
+                                            "type": "object",
+                                            "properties": {
+                                                "globalPackagingNamespace": {
+                                                    "type": "string",
+                                                    "description": "Custom global packaging namespace. Using this value will override the current \"kubeapps release namespace + suffix\" pattern and will create a new namespace if not exists.",
+                                                    "default": ""
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "kappController": {
+                            "type": "object",
+                            "properties": {
+                                "packages": {
+                                    "type": "object",
+                                    "properties": {
+                                        "v1alpha1": {
+                                            "type": "object",
+                                            "properties": {
+                                                "defaultUpgradePolicy": {
+                                                    "type": "string",
+                                                    "description": "Default upgrade policy generating version constraints",
+                                                    "default": "none"
+                                                },
+                                                "defaultPrereleasesVersionSelection": {
+                                                    "type": "array",
+                                                    "description": "Default policy for allowing prereleases containing one of the identifiers",
+                                                    "default": null,
+                                                    "nullable": true,
+                                                    "items": {}
+                                                },
+                                                "defaultAllowDowngrades": {
+                                                    "type": "boolean",
+                                                    "description": "Default policy for allowing applications to be downgraded to previous versions",
+                                                    "default": false
+                                                },
+                                                "globalPackagingNamespace": {
+                                                    "type": "string",
+                                                    "description": "Default global packaging namespace",
+                                                    "default": "kapp-controller-packaging-global"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "flux": {
+                            "type": "object",
+                            "properties": {
+                                "packages": {
+                                    "type": "object",
+                                    "properties": {
+                                        "v1alpha1": {
+                                            "type": "object",
+                                            "properties": {
+                                                "defaultUpgradePolicy": {
+                                                    "type": "string",
+                                                    "description": "Default upgrade policy generating version constraints",
+                                                    "default": "none"
+                                                },
+                                                "noCrossNamespaceRefs": {
+                                                    "type": "boolean",
+                                                    "description": "Enable this flag to disallow cross-namespace references, useful when running Flux on multi-tenant clusters",
+                                                    "default": false
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "packages": {
+                                    "type": "object",
+                                    "properties": {
+                                        "v1alpha1": {
+                                            "type": "object",
+                                            "properties": {
+                                                "trustedNamespaces": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "headerName": {
+                                                            "type": "string",
+                                                            "description": "Optional header name for trusted namespaces",
+                                                            "default": ""
+                                                        },
+                                                        "headerPattern": {
+                                                            "type": "string",
+                                                            "description": "Optional header pattern for trusted namespaces",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Kubeapps-APIs image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Kubeapps-APIs image repository",
+                            "default": "bitnami/kubeapps-apis"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Kubeapps-APIs image tag (immutable tags are recommended)",
+                            "default": "2.8.0-debian-11-r49"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Kubeapps-APIs image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Kubeapps-APIs image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Kubeapps-APIs image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of frontend replicas to deploy",
+                    "default": 2
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "KubeappsAPIs deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Additional command line flags for KubeappsAPIs",
+                    "default": [],
+                    "items": {}
+                },
+                "qps": {
+                    "type": "string",
+                    "description": "KubeappsAPIs Kubernetes API client QPS limit",
+                    "default": "50.0"
+                },
+                "burst": {
+                    "type": "string",
+                    "description": "KubeappsAPIs Kubernetes API client Burst limit",
+                    "default": "100"
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "The grace time period for sig term",
+                    "default": 300
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to the KubeappsAPIs container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for the KubeappsAPIs container",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for the KubeappsAPIs container",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "KubeappsAPIs HTTP container port",
+                            "default": 50051
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The CPU limits for the KubeappsAPIs container",
+                                    "default": "250m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The memory limits for the KubeappsAPIs container",
+                                    "default": "256Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested CPU for the KubeappsAPIs container",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the KubeappsAPIs container",
+                                    "default": "32Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled KubeappsAPIs pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set KubeappsAPIs pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled KubeappsAPIs containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set KubeappsAPIs container's Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set KubeappsAPIs container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "Custom lifecycle hooks for KubeappsAPIs containers",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the KubeappsAPIs pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the KubeappsAPIs container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for KubeappsAPIs pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for KubeappsAPIs pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class name for KubeappsAPIs pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Custom host aliases for KubeappsAPIs pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the KubeappsAPIs pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the KubeappsAPIs pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "KubeappsAPIs service HTTP port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for KubeappsAPIs service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable password authentication",
+                            "default": true
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Redis&reg; password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "The name of an existing secret with Redis&reg; credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Redis(R) architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "master": {
+                    "type": "object",
+                    "properties": {
+                        "extraFlags": {
+                            "type": "array",
+                            "description": "Array with additional command line flags for Redis&reg; master",
+                            "default": [
+                                "--maxmemory 200mb",
+                                "--maxmemory-policy allkeys-lru"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "disableCommands": {
+                            "type": "array",
+                            "description": "Array with commands to deactivate on Redis&reg;",
+                            "default": [],
+                            "items": {}
+                        },
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable Redis&reg; master data persistence using PVC",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "replica": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Redis&reg; replicas to deploy",
+                            "default": 1
+                        },
+                        "extraFlags": {
+                            "type": "array",
+                            "description": "Array with additional command line flags for Redis&reg; replicas",
+                            "default": [
+                                "--maxmemory 200mb",
+                                "--maxmemory-policy allkeys-lru"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "disableCommands": {
+                            "type": "array",
+                            "description": "Array with commands to deactivate on Redis&reg;",
+                            "default": [],
+                            "items": {}
+                        },
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable Redis&reg; replica data persistence using PVC",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
-    },
-    "dashboard": {
-      "type": "object",
-      "title": "Dashboard configuration",
-      "form": true,
-      "properties": {
-        "replicaCount": {
-          "type": "integer",
-          "title": "Number of replicas",
-          "form": true
-        }
-      }
-    },
-    "kubeappsapis": {
-      "type": "object",
-      "title": "kubeappsapis configuration",
-      "form": true,
-      "properties": {
-        "replicaCount": {
-          "type": "integer",
-          "title": "Number of replicas",
-          "form": true
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the Kubeapps dashboard."
-        },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        },
-        "tls": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable TLS configuration",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        }
-      }
-    },
-    "authProxy": {
-      "type": "object",
-      "title": "OIDC Proxy configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable OIDC proxy",
-          "description": "Use an OIDC provider in order to manage accounts, groups and roles with a single application"
-        },
-        "provider": {
-          "type": "string",
-          "form": true,
-          "title": "Identity Provider name",
-          "description": "See https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#generating-a-cookie-secret to find available providers",
-          "hidden": {
-            "value": false,
-            "path": "authProxy/enabled"
-          }
-        },
-        "clientID": {
-          "type": "string",
-          "form": true,
-          "title": "Client ID:",
-          "description": "Client ID of the Identity Provider",
-          "hidden": {
-            "value": false,
-            "path": "authProxy/enabled"
-          }
-        },
-        "clientSecret": {
-          "type": "string",
-          "form": true,
-          "title": "Client Secret",
-          "description": "Secret used to validate the Client ID",
-          "hidden": {
-            "value": false,
-            "path": "authProxy/enabled"
-          }
-        },
-        "cookieSecret": {
-          "type": "string",
-          "form": true,
-          "title": "Cookie Secret",
-          "description": "Used by OAuth2 Proxy to encrypt any credentials",
-          "hidden": {
-            "value": false,
-            "path": "authProxy/enabled"
-          }
-        }
-      }
     }
-  }
 }

--- a/bitnami/kubernetes-event-exporter/values.schema.json
+++ b/bitnami/kubernetes-event-exporter/values.schema.json
@@ -1,0 +1,693 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override kubernetes-event-exporter.fullname include (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override kubernetes-event-exporter.fullname template",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Desired number of pod replicas",
+            "default": 1
+        },
+        "revisionHistoryLimit": {
+            "type": "number",
+            "description": "Desired number of old ReplicaSets to retain ",
+            "default": 10
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "HTTP container port",
+                    "default": 2112
+                }
+            }
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional port-mappings for the container",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Container image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Container image name",
+                    "default": "bitnami/kubernetes-event-exporter"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Container image tag",
+                    "default": "1.4.0-debian-11-r14"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Container image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Container image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "logLevel": {
+                    "type": "string",
+                    "description": "Verbosity of the logs (options: `fatal`, `error`, `warn`, `info` or `debug`)",
+                    "default": "debug"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "How the logs are formatted. Allowed values: `pretty` or `json`",
+                    "default": "pretty"
+                },
+                "receivers": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "file": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "layout": {
+                                        "type": "object",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "route": {
+                    "type": "object",
+                    "properties": {
+                        "routes": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "match": {
+                                        "type": "array",
+                                        "description": "",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "receiver": {
+                                                    "type": "string",
+                                                    "description": ""
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create the RBAC roles for API accessibility",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod labels",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable security context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the container",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable container security context",
+                    "default": true
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "add": {
+                            "type": "array",
+                            "description": "Add capabilities for the securityContext",
+                            "default": [],
+                            "items": {}
+                        },
+                        "drop": {
+                            "type": "array",
+                            "description": "Drop capabilities for the securityContext",
+                            "default": [
+                                "ALL"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "description": "Allows the pod to mount the RootFS as ReadOnly only",
+                    "default": true
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "If the pod should run as a non root container.",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Define the uid with which the pod will run",
+                    "default": 1001
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Lifecycle for the container to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "Specify resource limits which the container is not allowed to succeed.",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "Specify resource requests which the container needs to spawn.",
+                    "default": {}
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Configure startup probe for Kubernetes event exporter pod",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Configure liveness probe for Kubernetes event exporter pod",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Configure readiness probe for Kubernetes event exporter pod",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Set Priority Class Name to allow priority control over other pods",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Deployment strategy type.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array containing extra env vars to be added to all containers",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars to be added to all containers",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars to be added to all containers",
+            "default": ""
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array to add extra mounts (normally used with extraVolumes)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array to add extra volumes",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Attach additional init containers to pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to pods",
+            "default": [],
+            "items": {}
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable exposing  statistics",
+                    "default": false
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.http }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Metrics service HTTP port",
+                                    "default": 2112
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "endpoints": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Metrics service HTTP port",
+                            "default": "http"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead",
+                            "default": ""
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create PrometheusRule Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "groups": {
+                            "type": "array",
+                            "description": "Groups, containing the alert rules.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "vpa": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable VPA",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for VPA resource",
+                            "default": {}
+                        },
+                        "recommenders": {
+                            "type": "array",
+                            "description": "Recommender responsible for generating recommendation for the object.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "controlledResources": {
+                            "type": "array",
+                            "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                            "default": [],
+                            "items": {}
+                        },
+                        "maxAllowed": {
+                            "type": "object",
+                            "description": "VPA Max allowed resources for the pod",
+                            "default": {}
+                        },
+                        "minAllowed": {
+                            "type": "object",
+                            "description": "VPA Min allowed resources for the pod",
+                            "default": {}
+                        },
+                        "updatePolicy": {
+                            "type": "object",
+                            "properties": {
+                                "minReplicas": {
+                                    "type": "number",
+                                    "description": "Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction",
+                                    "default": 1
+                                },
+                                "updateMode": {
+                                    "type": "string",
+                                    "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                    "default": "Auto"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/logstash/values.schema.json
+++ b/bitnami/logstash/values.schema.json
@@ -1,0 +1,853 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override logstash.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override logstash.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Logstash image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Logstash image repository",
+                    "default": "bitnami/logstash"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Logstash image tag (immutable tags are recommended)",
+                    "default": "8.9.2-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Logstash image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Logstash image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "configFileName": {
+            "type": "string",
+            "description": "Logstash configuration file name. It must match the name of the configuration file mounted as a configmap.",
+            "default": "logstash.conf"
+        },
+        "enableMonitoringAPI": {
+            "type": "boolean",
+            "description": "Whether to enable the Logstash Monitoring API or not  Kubernetes cluster domain",
+            "default": true
+        },
+        "monitoringAPIPort": {
+            "type": "number",
+            "description": "Logstash Monitoring API Port",
+            "default": 9600
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array containing extra env vars to configure Logstash",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "To add secrets to environment",
+            "default": ""
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "To add configmaps to environment",
+            "default": ""
+        },
+        "input": {
+            "type": "string",
+            "description": "Input Plugins configuration",
+            "default": "# udp {\n#   port => 1514\n#   type => syslog\n# }\n# tcp {\n#   port => 1514\n#   type => syslog\n# }\nhttp { port => 8080 }"
+        },
+        "filter": {
+            "type": "string",
+            "description": "Filter Plugins configuration",
+            "default": ""
+        },
+        "output": {
+            "type": "string",
+            "description": "Output Plugins configuration",
+            "default": "# elasticsearch {\n#   hosts => [\"${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}\"]\n#   manage_template => false\n#   index => \"%{[@metadata][beat]}-%{+YYYY.MM.dd}\"\n# }\n# gelf {\n#   host => \"${GRAYLOG_HOST}\"\n#   port => ${GRAYLOG_PORT}\n# }\nstdout {}"
+        },
+        "existingConfiguration": {
+            "type": "string",
+            "description": "Name of existing ConfigMap object with the Logstash configuration (`input`, `filter`, and `output` will be ignored).",
+            "default": ""
+        },
+        "enableMultiplePipelines": {
+            "type": "boolean",
+            "description": "Allows user to use multiple pipelines",
+            "default": false
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array to add extra volumes (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array to add extra mounts (normally used with extraVolumes, evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Logstash pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the service account to use. If not set and `create` is `true`, a name is generated",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows automount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "containerPort": {
+                        "type": "number",
+                        "description": ""
+                    },
+                    "protocol": {
+                        "type": "string",
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Logstash pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Logstash pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Logstash replicas to deploy",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy type (`RollingUpdate`, or `OnDelete`)",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Pod management policy",
+            "default": "OrderedReady"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Logstash pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Pod priority",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the Logstash pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Logstash pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Logstash pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Logstash containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Logstash containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Logstash container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Logstash container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Logstash container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the Logstash container",
+                    "default": {}
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startup probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readiness probe for the Web component",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type (`ClusterIP`, `NodePort`, or `LoadBalancer`)",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": ""
+                            },
+                            "targetPort": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "protocol": {
+                                "type": "string",
+                                "description": ""
+                            }
+                        }
+                    }
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Addresses that are allowed when service is LoadBalancer",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "External traffic policy, configure to Local to preserve client source IP when using an external loadBalancer",
+                    "default": ""
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Static clusterIP or None for headless services",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Logstash service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Logstash data persistence using PVC",
+                    "default": false
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume and Claim",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Logstash data volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Logstash data volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Logstash data volume",
+                    "default": "2Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Mount path of the Logstash data volume",
+                    "default": "/bitnami/logstash/data"
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the volumePermissions init container",
+                            "default": 0
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "logstash.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Logstash. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "If true, create a pod disruption budget for pods.",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number / percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number / percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/magento/values.schema.json
+++ b/bitnami/magento/values.schema.json
@@ -1,0 +1,1449 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override magento.fullname template",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override magento.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Magento image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Magento image repository",
+                    "default": "bitnami/magento"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Magento image tag (immutable tags are recommended)",
+                    "default": "2.4.6-debian-11-r69"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Magento image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Magento image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Magento Pods to run",
+            "default": 1
+        },
+        "magentoSkipInstall": {
+            "type": "boolean",
+            "description": "Skip Magento installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "magentoHost": {
+            "type": "string",
+            "description": "Magento host to create application URLs",
+            "default": ""
+        },
+        "magentoUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "magentoPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "magentoEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "magentoFirstName": {
+            "type": "string",
+            "description": "Magento Admin First Name",
+            "default": ""
+        },
+        "magentoLastName": {
+            "type": "string",
+            "description": "Magento Admin Last Name",
+            "default": ""
+        },
+        "magentoAdminUri": {
+            "type": "string",
+            "description": "Magento prefix to access Magento Admin",
+            "default": ""
+        },
+        "magentoMode": {
+            "type": "string",
+            "description": "Magento mode",
+            "default": ""
+        },
+        "magentoExtraInstallArgs": {
+            "type": "string",
+            "description": "Magento extra install args",
+            "default": ""
+        },
+        "magentoDeployStaticContent": {
+            "type": "boolean",
+            "description": "Deploy static content during the first deployment, to optimize page load time",
+            "default": false
+        },
+        "magentoUseHttps": {
+            "type": "boolean",
+            "description": "Use SSL to access the Magento Store. Valid values: `true`, `false`",
+            "default": false
+        },
+        "magentoUseSecureAdmin": {
+            "type": "boolean",
+            "description": "Use SSL to access the Magento Admin. Valid values: `true`, `false`",
+            "default": false
+        },
+        "magentoSkipReindex": {
+            "type": "boolean",
+            "description": "Skip Magento Indexer reindex step during the initialization. Valid values: `true`, `false`",
+            "default": false
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`",
+            "default": [],
+            "items": {}
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Array of additional container ports for the Magento container",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "%%MAIN_CONTAINER_NAME%% pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Magento container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resourcesc for the Magento container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Magento pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Magento pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Magento containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Magento containers' Security Context",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set %%MAIN_CONTAINER_NAME%% container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 300
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "magento Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "magento Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "magento Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "magento Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb, elasticsearch) only accessible by magento's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "magento Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes magento only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "magento Namespace selector label that is allowed to access magento. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "magento Pods selector label that is allowed to access magento. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "magento Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "magento Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements.",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MariaDB image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MariaDB image repository",
+                            "default": "bitnami/mariadb"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MariaDB image tag (immutable tags are recommended)",
+                            "default": "10.6.15-debian-11-r2"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_magento"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_magento"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Database Persistent Volume Access Modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_magento"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_magento"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password",
+                    "default": ""
+                }
+            }
+        },
+        "elasticsearch": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a elasticsearch server to use as magento's search engine",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Elasticsearch image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Elasticsearch image repository",
+                            "default": "bitnami/elasticsearch"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Elasticsearch image tag (immutable tags are recommended)",
+                            "default": "7.17.12-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Elasticsearch image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "sysctlImage": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable kernel settings modifier image for Elasticsearch",
+                            "default": true
+                        }
+                    }
+                },
+                "master": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch master-eligible nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "coordinating": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch coordinating-only nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch data nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "ingest": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch ingest nodes",
+                            "default": 1
+                        }
+                    }
+                }
+            }
+        },
+        "externalElasticsearch": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external elasticsearch server",
+                    "default": ""
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port of the external elasticsearch server",
+                    "default": ""
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Magento volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Modes for Magento volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Magento volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name for Magento volume",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "Host mount path for Magento volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resourcesc for the init container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 8443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes http node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes https node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Static clusterIP or None for headless services",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Control hosts connecting to \"LoadBalancer\" only",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the Magento Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for %%MAIN_CONTAINER_NAME%% service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Default path type for the ingress resource",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "magento.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress resource",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS for `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the metrics container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the metrics container",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus metrics service type",
+                            "default": "ClusterIP"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service Metrics port",
+                            "default": 9117
+                        }
+                    }
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables (eg proxy)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable autoscaling for replicas",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "string",
+                    "description": "Target CPU utilization percentage",
+                    "default": ""
+                },
+                "targetMemory": {
+                    "type": "string",
+                    "description": "Target Memory utilization percentage",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/mariadb-galera/values.schema.json
+++ b/bitnami/mariadb-galera/values.schema.json
@@ -1,224 +1,1148 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "galera": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "Galera cluster name",
-          "form": true
-        },
-        "mariabackup": {
-          "type": "object",
-          "properties": {
-            "password": {
-              "type": "string",
-              "title": "Mariabackup password for SST",
-              "form": true,
-              "description": "Defaults to a random 10-character alphanumeric string if not set",
-              "hidden": {
-                "value": true,
-                "path": "existingSecret"
-              }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
             }
-          }
-        }
-      }
-    },
-    "rootUser": {
-      "type": "object",
-      "properties": {
-        "password": {
-          "type": "string",
-          "title": "MariaDB admin password",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "hidden": {
-            "value": true,
-            "path": "existingSecret"
-          }
         },
-        "user": {
-          "type": "string",
-          "title": "MariaDB admin user",
-          "description": "Name of the admin user to be created during the 1st initialization of MariaDB.",
-          "form": true
-        }
-      }
-    },
-    "db": {
-      "type": "object",
-      "title": "Custom database & users",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "MariaDB custom database",
-          "description": "Name of the custom database to be created during the 1st initialization of MariaDB",
-          "form": true
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
         },
-        "user": {
-          "type": "string",
-          "title": "MariaDB custom user",
-          "description": "Name of the custom user to be created during the 1st initialization of MariaDB. This user only has permissions on the MariaDB custom database",
-          "form": true
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template with a string (will prepend the release name)",
+            "default": ""
         },
-        "password": {
-          "type": "string",
-          "title": "Password for MariaDB custom user",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "hidden": {
-            "value": true,
-            "path": "existingSecret"
-          }
-        }
-      }
-    },
-    "ldap": {
-      "type": "object",
-      "title": "LDAP configuration",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable LDAP support",
-          "description": "Enable authentication using LDAP"
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template with a string",
+            "default": ""
         },
-        "uri": {
-          "type": "string",
-          "title": "LDAP URL",
-          "form": true,
-          "hidden": {
-            "value": false,
-            "path": "ldap/enabled"
-          }
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
         },
-        "base": {
-          "type": "string",
-          "title": "LDAP base DN",
-          "form": true,
-          "hidden": {
-            "value": false,
-            "path": "ldap/enabled"
-          }
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
         },
-        "binddn": {
-          "type": "string",
-          "title": "LDAP bind DN",
-          "form": true,
-          "hidden": {
-            "value": false,
-            "path": "ldap/enabled"
-          }
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
         },
-        "bindpw": {
-          "type": "string",
-          "title": "LDAP bind password",
-          "form": true,
-          "hidden": {
-            "value": false,
-            "path": "ldap/enabled"
-          }
-        }
-      }
-    },
-    "replicaCount": {
-      "type": "integer",
-      "form": true,
-      "title": "Desired number of cluster nodes"
-    },
-    "persistence": {
-      "type": "object",
-      "title": "Persistence",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable persistence",
-          "description": "Enable persistence using Persistent Volume Claims"
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the Kubernetes scheduler (other than default)",
+            "default": ""
         },
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi",
-          "hidden": {
-            "value": false,
-            "path": "persistence/enabled"
-          }
-        }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "title": "ServiceAccount configuration",
-      "form": true,
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create a ServiceAcccount",
-          "description": "Specify whether a ServiceAcccount for MariaDB Galera pods should be created"
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes DNS Domain name to use",
+            "default": "cluster.local"
         },
-        "name": {
-          "type": "string",
-          "form": true,
-          "title": "ServiceAcccount name",
-          "description": "ServiceAcccount name to use. Auto-generated if not specified",
-          "hidden": {
-            "value": false,
-            "path": "serviceAccount/create"
-          }
-        }
-      }
-    },
-    "rbac": {
-      "type": "object",
-      "title": "RBAC rules configuration",
-      "form": true,
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create RBAC rules",
-          "description": "Specify whether RBAC resources should be created and used"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
         },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
-          }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MariaDB Galera image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MariaDB Galera image repository",
+                    "default": "bitnami/mariadb-galera"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MariaDB Galera image tag (immutable tags are recommended)",
+                    "default": "11.0.3-debian-11-r7"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MariaDB Galera image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "MariaDB Galera image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel",
+            "default": "OrderedReady"
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type",
+                    "default": "ClusterIP"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Specific cluster IP when service type is cluster IP. Use `None` for headless service",
+                    "default": ""
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "mysql": {
+                            "type": "number",
+                            "description": "MariaDB service port",
+                            "default": 3306
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "mysql": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "External IP list to use with ClusterIP service type",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Addresses that are allowed when svc is `LoadBalancer`",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "%%MAIN_CONTAINER_NAME%% service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for MariaDB Galera service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        },
+                        "publishNotReadyAddresses": {
+                            "type": "boolean",
+                            "description": "Publish not Ready MariaDB Galera pods' IPs in the headless service.",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specify whether a ServiceAccount should be created",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array containing extra env vars to configure MariaDB Galera replicas",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars to configure MariaDB Galera replicas",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars to configure MariaDB Galera replicas",
+            "default": ""
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specify whether RBAC resources should be created and used",
+                    "default": false
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable security context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the container filesystem",
+                    "default": 1001
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the container",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled galera's container Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set galera's container Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set galera's container Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "rootUser": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string",
+                    "description": "Username for the admin user.",
+                    "default": "root"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the admin user. Ignored if existing secret is provided.",
+                    "default": ""
+                },
+                "forcePassword": {
+                    "type": "boolean",
+                    "description": "Option to force users to specify a password. That is required for 'helm upgrade' to work properly.",
+                    "default": false
+                }
+            }
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Use existing secret for password details (`rootUser.password`, `db.password`, `galera.mariabackup.password` will be ignored and picked up from this secret)",
+            "default": ""
+        },
+        "usePasswordFiles": {
+            "type": "boolean",
+            "description": "Mount credentials as a files instead of using an environment variable.",
+            "default": false
+        },
+        "customPasswordFiles": {
+            "type": "object",
+            "description": "Use custom password files when `usePasswordFiles` is set to `true`. Define path for keys `root`, `user`, and `mariabackup`.",
+            "default": {}
+        },
+        "db": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string",
+                    "description": "Username of new user to create",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the new user. Ignored if existing secret is provided.",
+                    "default": ""
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name for new database to create",
+                    "default": "my_database"
+                },
+                "forcePassword": {
+                    "type": "boolean",
+                    "description": "Option to force users to specify a password. That is required for 'helm upgrade' to work properly.",
+                    "default": false
+                }
+            }
+        },
+        "galera": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Galera cluster name",
+                    "default": "galera"
+                },
+                "bootstrap": {
+                    "type": "object",
+                    "properties": {
+                        "forceBootstrap": {
+                            "type": "boolean",
+                            "description": "Option to force the boostraping from the indicated node in `galera.bootstarp.bootstrapFromNode`",
+                            "default": false
+                        },
+                        "bootstrapFromNode": {
+                            "type": "number",
+                            "description": "Node to bootstrap from, you will need to change this parameter in case you want to bootstrap from other node",
+                            "default": 0
+                        },
+                        "forceSafeToBootstrap": {
+                            "type": "boolean",
+                            "description": "Force `safe_to_bootstrap: 1` in `grastate.date` file",
+                            "default": false
+                        }
+                    }
+                },
+                "mariabackup": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "MariaBackup username",
+                            "default": "mariabackup"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MariaBackup password. Password is ignored if existingSecret is specified.",
+                            "default": ""
+                        },
+                        "forcePassword": {
+                            "type": "boolean",
+                            "description": "Option to force users to specify a password. That is required for 'helm upgrade' to work properly.",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP support",
+                    "default": false
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "LDAP URL beginning in the form `ldap`",
+                    "default": ""
+                },
+                "base": {
+                    "type": "string",
+                    "description": "LDAP base DN",
+                    "default": ""
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "LDAP bind DN",
+                    "default": ""
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "LDAP bind password",
+                    "default": ""
+                },
+                "bslookup": {
+                    "type": "string",
+                    "description": "LDAP base lookup",
+                    "default": ""
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "LDAP custom filter",
+                    "default": ""
+                },
+                "map": {
+                    "type": "string",
+                    "description": "LDAP custom map",
+                    "default": ""
+                },
+                "nss_initgroups_ignoreusers": {
+                    "type": "string",
+                    "description": "LDAP ignored users",
+                    "default": "root,nslcd"
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "LDAP search scope",
+                    "default": ""
+                },
+                "tls_reqcert": {
+                    "type": "string",
+                    "description": "LDAP TLS check on server certificates",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS support for replication traffic",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates",
+                    "default": false
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "Name of the secret that contains the certificates",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "Certificate filename",
+                    "default": ""
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "description": "Certificate key filename",
+                    "default": ""
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "description": "CA Certificate filename",
+                    "default": ""
+                }
+            }
+        },
+        "mariadbConfiguration": {
+            "type": "string",
+            "description": "Configuration for the MariaDB server",
+            "default": "[client]\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\nplugin_dir=/opt/bitnami/mariadb/plugin\n\n[mysqld]\ndefault_storage_engine=InnoDB\nbasedir=/opt/bitnami/mariadb\ndatadir=/bitnami/mariadb/data\nplugin_dir=/opt/bitnami/mariadb/plugin\ntmpdir=/opt/bitnami/mariadb/tmp\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\npid_file=/opt/bitnami/mariadb/tmp/mysqld.pid\nbind_address=0.0.0.0\n\n## Character set\n##\ncollation_server=utf8_unicode_ci\ninit_connect='SET NAMES utf8'\ncharacter_set_server=utf8\n\n## MyISAM\n##\nkey_buffer_size=32M\nmyisam_recover_options=FORCE,BACKUP\n\n## Safety\n##\nskip_host_cache\nskip_name_resolve\nmax_allowed_packet=16M\nmax_connect_errors=1000000\nsql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY\nsysdate_is_now=1\n\n## Binary Logging\n##\nlog_bin=mysql-bin\nexpire_logs_days=14\n# Disabling for performance per http://severalnines.com/blog/9-tips-going-production-galera-cluster-mysql\nsync_binlog=0\n# Required for Galera\nbinlog_format=row\n\n## Caches and Limits\n##\ntmp_table_size=32M\nmax_heap_table_size=32M\n# Re-enabling as now works with Maria 10.1.2\nquery_cache_type=1\nquery_cache_limit=4M\nquery_cache_size=256M\nmax_connections=500\nthread_cache_size=50\nopen_files_limit=65535\ntable_definition_cache=4096\ntable_open_cache=4096\n\n## InnoDB\n##\ninnodb=FORCE\ninnodb_strict_mode=1\n# Mandatory per https://github.com/codership/documentation/issues/25\ninnodb_autoinc_lock_mode=2\n# Per https://www.percona.com/blog/2006/08/04/innodb-double-write/\ninnodb_doublewrite=1\ninnodb_flush_method=O_DIRECT\ninnodb_log_files_in_group=2\ninnodb_log_file_size=128M\ninnodb_flush_log_at_trx_commit=1\ninnodb_file_per_table=1\n# 80% Memory is default reco.\n# Need to re-evaluate when DB size grows\ninnodb_buffer_pool_size=2G\ninnodb_file_format=Barracuda\n\n## Logging\n##\nlog_error=/opt/bitnami/mariadb/logs/mysqld.log\nslow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log\nlog_queries_not_using_indexes=1\nslow_query_log=1\n\n## SSL\n## Use extraVolumes and extraVolumeMounts to mount /certs filesystem\n# ssl_ca=/certs/ca.pem\n# ssl_cert=/certs/server-cert.pem\n# ssl_key=/certs/server-key.pem\n\n[galera]\nwsrep_on=ON\nwsrep_provider=/opt/bitnami/mariadb/lib/libgalera_smm.so\nwsrep_sst_method=mariabackup\nwsrep_slave_threads=4\nwsrep_cluster_address=gcomm://\nwsrep_cluster_name=galera\nwsrep_sst_auth=\"root:\"\n# Enabled for performance per https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit\ninnodb_flush_log_at_trx_commit=2\n# MYISAM REPLICATION SUPPORT #\nwsrep_mode=REPLICATE_MYISAM\n\n[mariadb]\nplugin_load_add=auth_pam\n\n## Data-at-Rest Encryption\n## Use extraVolumes and extraVolumeMounts to mount /encryption filesystem\n# plugin_load_add=file_key_management\n# file_key_management_filename=/encryption/keyfile.enc\n# file_key_management_filekey=FILE:/encryption/keyfile.key\n# file_key_management_encryption_algorithm=AES_CTR\n# encrypt_binlog=ON\n# encrypt_tmp_files=ON\n\n## InnoDB/XtraDB Encryption\n# innodb_encrypt_tables=ON\n# innodb_encrypt_temporary_tables=ON\n# innodb_encrypt_log=ON\n# innodb_encryption_threads=4\n# innodb_encryption_rotate_key_age=1\n\n## Aria Encryption\n# aria_encrypt_tables=ON\n# encrypt_tmp_disk_tables=ON"
+        },
+        "configurationConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with the MariaDB configuration files (Note: Overrides `mariadbConfiguration`). The value is evaluated as a template.",
+            "default": ""
+        },
+        "initdbScripts": {
+            "type": "object",
+            "description": "Specify dictionary of scripts to be run at first boot",
+            "default": {}
+        },
+        "initdbScriptsConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)",
+            "default": ""
+        },
+        "extraFlags": {
+            "type": "string",
+            "description": "MariaDB additional command line flags",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Desired number of cluster nodes",
+            "default": 3
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "updateStrategy for MariaDB Master StatefulSet",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for MariaDB Galera pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for MariaDB Galera  pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pods assignment",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the galera container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "mysql": {
+                    "type": "number",
+                    "description": "mariadb database container port",
+                    "default": 3306
+                },
+                "galera": {
+                    "type": "number",
+                    "description": "galera cluster container port",
+                    "default": 4567
+                },
+                "ist": {
+                    "type": "number",
+                    "description": "galera IST container port",
+                    "default": 4568
+                },
+                "sst": {
+                    "type": "number",
+                    "description": "galera SST container port",
+                    "default": 4444
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Provide an existing `PersistentVolumeClaim`",
+                    "default": ""
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "Subdirectory of the volume to mount",
+                    "default": ""
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Path to mount the volume at",
+                    "default": "/bitnami/mariadb"
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                    "default": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim Labels",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume Size",
+                    "default": "8Gi"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority Class Name for Statefulset",
+            "default": ""
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Additional init containers (this value is evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers (this value is evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Extra volumes",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Mount extra volume(s)",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turn on and off liveness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before liveness probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turn on and off readiness probe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before readiness probe is initiated",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turn on and off startup probe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Delay before startup probe is initiated",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "How often to perform the probe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "When the probe times out",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive failures for the probe",
+                    "default": 48
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Minimum consecutive successes for the probe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom rediness probe for the Web component",
+            "default": {}
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a Pod disruption budget should be created",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number / percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number / percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MariaDB Prometheus exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MariaDB Prometheus exporter image repository",
+                            "default": "bitnami/mysqld-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MariaDB Prometheus exporter image tag (immutable tags are recommended)",
+                            "default": "0.15.0-debian-11-r24"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MariaDB Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "MariaDB Prometheus exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "MariaDB Prometheus exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "MariaDB Prometheus exporter additional command line flags",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled exporter's container Security Context",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus exporter service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Prometheus exporter service port",
+                            "default": 9104
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "9104"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Prometheus metrics service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Prometheus metrics service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Prometheus metrics service external traffic policy",
+                            "default": "Cluster"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Optional namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "How frequently to scrape metrics (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "ServiceMonitor extra labels",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRules": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true`, and makes little sense without ServiceMonitor)",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "properties": {
+                                "app": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "prometheus-operator"
+                                },
+                                "release": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "prometheus"
+                                }
+                            }
+                        },
+                        "rules": {
+                            "type": "object",
+                            "description": "PrometheusRule rules to configure",
+                            "default": {}
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/mariadb/values.schema.json
+++ b/bitnami/mariadb/values.schema.json
@@ -1,176 +1,1736 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "architecture": {
-      "type": "string",
-      "title": "MariaDB architecture",
-      "form": true,
-      "description": "Allowed values: `standalone` or `replication`"
-    },
-    "auth": {
-      "type": "object",
-      "title": "Authentication configuration",
-      "form": true,
-      "properties": {
-        "rootPassword": {
-          "type": "string",
-          "title": "MariaDB root password",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set"
-        },
-        "database": {
-          "type": "string",
-          "title": "MariaDB custom database",
-          "description": "Name of the custom database to be created during the 1st initialization of MariaDB",
-          "form": true
-        },
-        "username": {
-          "type": "string",
-          "title": "MariaDB custom user",
-          "description": "Name of the custom user to be created during the 1st initialization of MariaDB. This user only has permissions on the MariaDB custom database",
-          "form": true
-        },
-        "password": {
-          "type": "string",
-          "title": "Password for MariaDB custom user",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true,
-          "hidden": {
-            "value": false,
-            "path": "usePassword"
-          }
-        },
-        "replicationUser": {
-          "type": "string",
-          "title": "MariaDB replication user",
-          "description": "Name of user used to manage replication.",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        },
-        "replicationPassword": {
-          "type": "string",
-          "title": "Password for MariaDB replication user",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        }
-      }
-    },
-    "primary": {
-      "type": "object",
-      "title": "Primary replicas settings",
-      "form": true,
-      "properties": {
-        "persistence": {
-          "type": "object",
-          "title": "Persistence for primary replicas",
-          "form": true,
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "form": true,
-              "title": "Enable persistence",
-              "description": "Enable persistence using Persistent Volume Claims"
-            },
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi",
-              "hidden": {
-                "value": false,
-                "path": "persistence/enabled"
-              }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker Image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global storage class for dynamic provisioning",
+                    "default": ""
+                }
             }
-          }
-        }
-      }
-    },
-    "secondary": {
-      "type": "object",
-      "title": "Secondary replicas settings",
-      "form": true,
-      "hidden": {
-        "value": false,
-        "path": "replication/enabled"
-      },
-      "properties": {
-        "persistence": {
-          "type": "object",
-          "title": "Persistence for secondary replicas",
-          "form": true,
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "form": true,
-              "title": "Enable persistence",
-              "description": "Enable persistence using Persistent Volume Claims"
-            },
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi",
-              "hidden": {
-                "value": false,
-                "path": "persistence/enabled"
-              }
-            }
-          }
-        }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
         },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override mariadb.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override mariadb.fullname",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all MariaDB resources (sub-charts are not considered)",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all MariaDB resources (sub-charts are not considered)",
+            "default": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the scheduler (other than default) to dispatch pods",
+            "default": ""
+        },
+        "runtimeClassName": {
+            "type": "string",
+            "description": "Name of the Runtime Class for all MariaDB pods",
+            "default": ""
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
-          }
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MariaDB image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MariaDB image repository",
+                    "default": "bitnami/mariadb"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MariaDB image tag (immutable tags are recommended)",
+                    "default": "11.0.3-debian-11-r5"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "MariaDB image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "MariaDB architecture (`standalone` or `replication`)",
+            "default": "standalone"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "rootPassword": {
+                    "type": "string",
+                    "description": "Password for the `root` user. Ignored if existing secret is provided.",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name for a custom database to create",
+                    "default": "my_database"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Name for a custom user to create",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the new user. Ignored if existing secret is provided",
+                    "default": ""
+                },
+                "replicationUser": {
+                    "type": "string",
+                    "description": "MariaDB replication user",
+                    "default": "replicator"
+                },
+                "replicationPassword": {
+                    "type": "string",
+                    "description": "MariaDB replication user password. Ignored if existing secret is provided",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use existing secret for password details (`auth.rootPassword`, `auth.password`, `auth.replicationPassword` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`",
+                    "default": ""
+                },
+                "forcePassword": {
+                    "type": "boolean",
+                    "description": "Force users to specify required passwords",
+                    "default": false
+                },
+                "usePasswordFiles": {
+                    "type": "boolean",
+                    "description": "Mount credentials as files instead of using environment variables",
+                    "default": false
+                },
+                "customPasswordFiles": {
+                    "type": "object",
+                    "description": "Use custom password files when `auth.usePasswordFiles` is set to `true`. Define path for keys `root` and `user`, also define `replicator` if `architecture` is set to `replication`",
+                    "default": {}
+                }
+            }
+        },
+        "initdbScripts": {
+            "type": "object",
+            "description": "Dictionary of initdb scripts",
+            "default": {}
+        },
+        "initdbScriptsConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)",
+            "default": ""
+        },
+        "primary": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the primary database (eg primary, master, leader, ...)",
+                    "default": "primary"
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command on MariaDB Primary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args on MariaDB Primary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the MariaDB Primary container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "MariaDB Primary configuration to be injected as ConfigMap",
+                    "default": "[mysqld]\nskip-name-resolve\nexplicit_defaults_for_timestamp\nbasedir=/opt/bitnami/mariadb\ndatadir=/bitnami/mariadb/data\nplugin_dir=/opt/bitnami/mariadb/plugin\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\ntmpdir=/opt/bitnami/mariadb/tmp\nmax_allowed_packet=16M\nbind-address=*\npid-file=/opt/bitnami/mariadb/tmp/mysqld.pid\nlog-error=/opt/bitnami/mariadb/logs/mysqld.log\ncharacter-set-server=UTF8\ncollation-server=utf8_general_ci\nslow_query_log=0\nlong_query_time=10.0\n\n[client]\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\ndefault-character-set=UTF8\nplugin_dir=/opt/bitnami/mariadb/plugin\n\n[manager]\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\npid-file=/opt/bitnami/mariadb/tmp/mysqld.pid"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with MariaDB Primary configuration.",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MariaDB primary statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "rollingUpdatePartition": {
+                    "type": "string",
+                    "description": "Partition update strategy for Mariadb Primary statefulset",
+                    "default": ""
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations for MariaDB primary pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for MariaDB primary pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "MariaDB primary pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "MariaDB primary pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MariaDB primary node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "MariaDB primary node label key to match Ignored if `primary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "MariaDB primary node label values to match. Ignored if `primary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for MariaDB primary pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for MariaDB primary pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for MariaDB primary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of MariaDB primary pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for MariaDB primary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class for MariaDB primary pods assignment",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Runtime Class for MariaDB primary pods",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for MariaDB primary pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the mounted volumes' filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "MariaDB primary container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the MariaDB primary container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set primary container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set primary container's Security Context privileged",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set primary container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for MariaDB primary containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for MariaDB primary containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for MariaDB primary containers",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for MariaDB primary containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for MariaDB primary containers",
+                    "default": {}
+                },
+                "startupWaitOptions": {
+                    "type": "object",
+                    "description": "Override default builtin startup wait check options for MariaDB primary containers",
+                    "default": {}
+                },
+                "extraFlags": {
+                    "type": "string",
+                    "description": "MariaDB primary additional command line flags",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on MariaDB primary containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for MariaDB primary containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for MariaDB primary containers",
+                    "default": ""
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on MariaDB primary replicas using a `PersistentVolumeClaim`. If false, use emptyDir",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "Subdirectory of the volume to mount at",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "MariaDB primary persistent volume storage Class",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "MariaDB primary persistent volume claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "MariaDB primary persistent volume access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "MariaDB primary persistent volume size",
+                            "default": "8Gi"
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes to the MariaDB Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the MariaDB Primary container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers for the MariaDB Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers for the MariaDB Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MariaDB Primary Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "number",
+                                    "description": "MariaDB Primary Kubernetes service port for MariaDB",
+                                    "default": 3306
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "MariaDB Primary Kubernetes service port for metrics",
+                                    "default": 9104
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "string",
+                                    "description": "MariaDB Primary Kubernetes service node port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "MariaDB Primary Kubernetes service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "MariaDB Primary loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when MariaDB Primary service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for MariaDB primary pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of MariaDB primary pods that must still be available after the eviction",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of MariaDB primary pods that can be unavailable after the eviction",
+                            "default": ""
+                        }
+                    }
+                },
+                "revisionHistoryLimit": {
+                    "type": "number",
+                    "description": "Maximum number of revisions that will be maintained in the StatefulSet",
+                    "default": 10
+                }
+            }
+        },
+        "secondary": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the secondary database (eg secondary, slave, ...)",
+                    "default": "secondary"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of MariaDB secondary replicas",
+                    "default": 1
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command on MariaDB Secondary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args on MariaDB Secondary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the MariaDB Secondary container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "MariaDB Secondary configuration to be injected as ConfigMap",
+                    "default": "[mysqld]\nskip-name-resolve\nexplicit_defaults_for_timestamp\nbasedir=/opt/bitnami/mariadb\ndatadir=/bitnami/mariadb/data\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\ntmpdir=/opt/bitnami/mariadb/tmp\nmax_allowed_packet=16M\nbind-address=0.0.0.0\npid-file=/opt/bitnami/mariadb/tmp/mysqld.pid\nlog-error=/opt/bitnami/mariadb/logs/mysqld.log\ncharacter-set-server=UTF8\ncollation-server=utf8_general_ci\nslow_query_log=0\nlong_query_time=10.0\n\n[client]\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\ndefault-character-set=UTF8\n\n[manager]\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\npid-file=/opt/bitnami/mariadb/tmp/mysqld.pid"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with MariaDB Secondary configuration.",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MariaDB secondary statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "rollingUpdatePartition": {
+                    "type": "string",
+                    "description": "Partition update strategy for Mariadb Secondary statefulset",
+                    "default": ""
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations for MariaDB secondary pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for MariaDB secondary pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "MariaDB secondary pod affinity preset. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "MariaDB secondary pod anti-affinity preset. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MariaDB secondary node affinity preset type. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "MariaDB secondary node label key to match Ignored if `secondary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "MariaDB secondary node label values to match. Ignored if `secondary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for MariaDB secondary pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for MariaDB secondary pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for MariaDB secondary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for MariaDB secondary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class for MariaDB secondary pods assignment",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Runtime Class for MariaDB secondary pods",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of MariaDB secondary pods",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for MariaDB secondary pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the mounted volumes' filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "MariaDB secondary container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the MariaDB secondary container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set secondary container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set secondary container's Security Context privileged",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set secondary container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for MariaDB secondary containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for MariaDB secondary containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 15
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for MariaDB secondary containers",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for MariaDB secondary containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for MariaDB secondary containers",
+                    "default": {}
+                },
+                "startupWaitOptions": {
+                    "type": "object",
+                    "description": "Override default builtin startup wait check options for MariaDB secondary containers",
+                    "default": {}
+                },
+                "extraFlags": {
+                    "type": "string",
+                    "description": "MariaDB secondary additional command line flags",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on MariaDB secondary containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for MariaDB secondary containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for MariaDB secondary containers",
+                    "default": ""
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on MariaDB secondary replicas using a `PersistentVolumeClaim`",
+                            "default": true
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "Subdirectory of the volume to mount at",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "MariaDB secondary persistent volume storage Class",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "MariaDB secondary persistent volume claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "MariaDB secondary persistent volume access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "MariaDB secondary persistent volume size",
+                            "default": "8Gi"
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes to the MariaDB secondary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the MariaDB secondary container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers for the MariaDB secondary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers for the MariaDB secondary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MariaDB secondary Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "number",
+                                    "description": "MariaDB secondary Kubernetes service port for MariaDB",
+                                    "default": 3306
+                                },
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "MariaDB secondary Kubernetes service port for metrics",
+                                    "default": 9104
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "string",
+                                    "description": "MariaDB secondary Kubernetes service node port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "MariaDB secondary Kubernetes service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "MariaDB secondary loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when MariaDB secondary service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for MariaDB secondary pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of MariaDB secondary pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of MariaDB secondary pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "revisionHistoryLimit": {
+                    "type": "number",
+                    "description": "Maximum number of revisions that will be maintained in the StatefulSet",
+                    "default": 10
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for MariaDB pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for MariaDB Service Account",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": false
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": false
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Exporter image repository",
+                            "default": "bitnami/mysqld-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Exporter image tag (immutable tags are recommended)",
+                            "default": "0.15.0-debian-11-r24"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9104"
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "properties": {
+                        "primary": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secondary": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "object",
+                    "properties": {
+                        "primary": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secondary": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for MariaDB metrics container",
+                            "default": false
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set metrics container's Security Context privileged",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set metrics container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for MariaDB prometheus exporter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for MariaDB prometheus exporter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "primaryAccessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes primary mariadb nodes only accessible from a particular origin.",
+                                    "default": false
+                                },
+                                "customRules": {
+                                    "type": "array",
+                                    "description": "Custom network policy for the primary node.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "secondaryAccessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes primary mariadb nodes only accessible from a particular origin.",
+                                    "default": false
+                                },
+                                "customRules": {
+                                    "type": "array",
+                                    "description": "Custom network policy for the secondary nodes.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/mastodon/values.schema.json
+++ b/bitnami/mastodon/values.schema.json
@@ -1,0 +1,2571 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Mastodon image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Mastodon image repository",
+                    "default": "bitnami/mastodon"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Mastodon image tag (immutable tags are recommended)",
+                    "default": "4.1.7-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Mastodon image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Mastodon image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Mastodon image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Mastodon image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "environment": {
+            "type": "string",
+            "description": "Mastodon Rails and Node environment. Should be one of 'production',",
+            "default": "production"
+        },
+        "adminUser": {
+            "type": "string",
+            "description": "Mastodon admin username",
+            "default": "user"
+        },
+        "adminEmail": {
+            "type": "string",
+            "description": "Mastodon admin email",
+            "default": "user@changeme.com"
+        },
+        "adminPassword": {
+            "type": "string",
+            "description": "Mastodon admin password",
+            "default": ""
+        },
+        "defaultConfig": {
+            "type": "string",
+            "description": "Default configuration for Mastodon in the form of environment variables",
+            "default": "MASTODON_ADMIN_USERNAME: {{ .Values.adminUser | quote }}\nMASTODON_ADMIN_EMAIL: {{ .Values.adminEmail | quote }}\nDB_HOST: {{ include \"mastodon.database.host\" . | quote }}\nDB_PORT: {{ include \"mastodon.database.port\" . | quote }}\nDB_NAME: {{ include \"mastodon.database.name\" . | quote }}\nDB_USER: {{ include \"mastodon.database.user\" . | quote }}\nES_ENABLED: {{ .Values.enableSearches | quote }}\nES_HOST: {{ include \"mastodon.elasticsearch.host\" . | quote }}\nES_PORT: {{ include \"mastodon.elasticsearch.port\" . | quote }}\nWEB_DOMAIN: {{ include \"mastodon.web.domain\" . | quote }}\nLOCAL_DOMAIN: {{ .Values.localDomain | quote }}\nLOCAL_HTTPS: {{ .Values.local_https | quote }}\nDEFAULT_LOCALE: {{ .Values.defaultLocale | quote }}\nSTREAMING_API_BASE_URL: {{ include \"mastodon.streaming.url\" . | quote }}\nREDIS_HOST: {{ include \"mastodon.redis.host\" . | quote }}\nREDIS_PORT: {{ include \"mastodon.redis.port\" . | quote }}\nSMTP_SERVER: {{ .Values.smtp.server | quote }}\nSMTP_PORT: {{ .Values.smtp.port | quote }}\nSMTP_FROM_ADDRESS: {{ .Values.smtp.from_address | quote }}\nSMTP_DOMAIN: {{ .Values.smtp.domain | quote }}\nSMTP_REPLY_TO: {{ .Values.smtp.reply_to | quote }}\nSMTP_DELIVERY_METHOD: {{ .Values.smtp.delivery_method | quote }}\nSMTP_CA_FILE: {{ .Values.smtp.ca_file | quote }}\nSMTP_OPENSSL_VERIFY_MODE: {{ .Values.smtp.openssl_verify_mode | quote }}\nSMTP_ENABLE_STARTTLS_AUTO: {{ .Values.smtp.enable_starttls_auto | quote }}\nSMTP_TLS: {{ .Values.smtp.tls | quote }}\nSMTP_AUTH_METHOD: {{ .Values.smtp.auth_method | quote }}\nRAILS_ENV: {{ .Values.environment | quote }}\nNODE_ENV: {{ .Values.environment | quote }}\n{{- if .Values.enableS3 }}\nS3_ENABLED: \"true\"\nS3_BUCKET: {{ include \"mastodon.s3.bucket\" . | quote }}\nS3_ENDPOINT: {{ include \"mastodon.s3.endpoint\" . | quote }}\nS3_HOSTNAME: {{ include \"mastodon.s3.host\" . | quote }}\nS3_REGION: {{ include \"mastodon.s3.region\" . | quote }}\nS3_ALIAS_HOST: {{ include \"mastodon.s3.aliasHost\" . | quote }}\nS3_PROTOCOL: {{ include \"mastodon.s3.protocol.setting\" . | quote }}\n{{- end }}\n"
+        },
+        "defaultSecretConfig": {
+            "type": "string",
+            "description": "Default secret configuration for Mastodon in the form of environment variables",
+            "default": "MASTODON_ADMIN_PASSWORD: {{ include \"common.secrets.passwords.manage\" (dict \"secret\" (printf \"%s-default\" (include \"common.names.fullname\" .)) \"key\" \"MASTODON_ADMIN_PASSWORD\" \"providedValues\" (list \"adminPassword\") \"context\" $) }}\nSECRET_KEY_BASE: {{ include \"common.secrets.passwords.manage\" (dict \"secret\" (printf \"%s-default\" (include \"common.names.fullname\" .)) \"key\" \"SECRET_KEY_BASE\" \"providedValues\" (list \"secretKeyBase\") \"context\" $) }}\nOTP_SECRET: {{ include \"common.secrets.passwords.manage\" (dict \"secret\" (printf \"%s-default\" (include \"common.names.fullname\" .)) \"key\" \"OTP_SECRET\" \"providedValues\" (list \"otpSecret\") \"context\" $) }}\n"
+        },
+        "extraConfig": {
+            "type": "object",
+            "description": "Extra configuration for Mastodon in the form of environment variables",
+            "default": {}
+        },
+        "extraSecretConfig": {
+            "type": "object",
+            "description": "Extra secret configuration for Mastodon in the form of environment variables",
+            "default": {}
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your default configuration for Mastodon",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "The name of an existing Secret with your default configuration for Mastodon",
+            "default": ""
+        },
+        "extraConfigExistingConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your extra configuration for Mastodon",
+            "default": ""
+        },
+        "extraConfigExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing Secret with your extra configuration for Mastodon",
+            "default": ""
+        },
+        "enableSearches": {
+            "type": "boolean",
+            "description": "Enable the search engine (uses Elasticsearch under the hood)",
+            "default": true
+        },
+        "enableS3": {
+            "type": "boolean",
+            "description": "Enable the S3 storage engine",
+            "default": true
+        },
+        "forceHttpsS3Protocol": {
+            "type": "boolean",
+            "description": "Force Mastodon's S3_PROTOCOL to be https (Useful when TLS is terminated using cert-manager/Ingress)",
+            "default": false
+        },
+        "useSecureWebSocket": {
+            "type": "boolean",
+            "description": "Set Mastodon's STREAMING_API_BASE_URL to use secure websocket (wss:// instead of ws://)",
+            "default": false
+        },
+        "local_https": {
+            "type": "boolean",
+            "description": "Set this instance to advertise itself to the fediverse using HTTPS rather than HTTP URLs. This should almost always be true.",
+            "default": true
+        },
+        "localDomain": {
+            "type": "string",
+            "description": "The domain name used by accounts on this instance. Unless you're using",
+            "default": ""
+        },
+        "webDomain": {
+            "type": "string",
+            "description": "Optional alternate domain used when you want to host Mastodon at a",
+            "default": ""
+        },
+        "defaultLocale": {
+            "type": "string",
+            "description": "Set the default locale for this instance",
+            "default": "en"
+        },
+        "s3AliasHost": {
+            "type": "string",
+            "description": "S3 alias host for Mastodon (will use 'http://webDomain/bucket' if not set)",
+            "default": ""
+        },
+        "smtp": {
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "string",
+                    "description": "SMTP server",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "SMTP port",
+                    "default": 587
+                },
+                "from_address": {
+                    "type": "string",
+                    "description": "From address for sent emails",
+                    "default": ""
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "SMTP domain",
+                    "default": ""
+                },
+                "reply_to": {
+                    "type": "string",
+                    "description": "Reply-To value for sent emails",
+                    "default": ""
+                },
+                "delivery_method": {
+                    "type": "string",
+                    "description": "SMTP delivery method",
+                    "default": "smtp"
+                },
+                "ca_file": {
+                    "type": "string",
+                    "description": "SMTP CA file location",
+                    "default": "/etc/ssl/certs/ca-certificates.crt"
+                },
+                "openssl_verify_mode": {
+                    "type": "string",
+                    "description": "OpenSSL verify mode",
+                    "default": "none"
+                },
+                "enable_starttls_auto": {
+                    "type": "boolean",
+                    "description": "Automatically enable StartTLS",
+                    "default": true
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "SMTP TLS",
+                    "default": false
+                },
+                "auth_method": {
+                    "type": "string",
+                    "description": "SMTP auth method (set to \"none\" to disable SMTP auth)",
+                    "default": "plain"
+                },
+                "login": {
+                    "type": "string",
+                    "description": "SMTP auth username",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "SMTP auth password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the SMTP",
+                    "default": ""
+                },
+                "existingSecretLoginKey": {
+                    "type": "string",
+                    "description": "Name of the key for the SMTP login credential",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of the key for the SMTP password credential",
+                    "default": ""
+                }
+            }
+        },
+        "web": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Mastodon web replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Mastodon web HTTP container port",
+                            "default": 3000
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Mastodon web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Mastodon web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Mastodon web containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mastodon web containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mastodon web containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon web pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mastodon web pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon web containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mastodon web containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mastodon web containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Mastodon web containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mastodon web pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mastodon web pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mastodon web pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `web.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `web.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mastodon web pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mastodon web pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mastodon web pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mastodon web statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mastodon web pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Mastodon web pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mastodon web container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mastodon web nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mastodon web nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mastodon web nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mastodon web pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mastodon web container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mastodon web pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mastodon web pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mastodon web service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Mastodon web service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Mastodon web service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Mastodon web service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Mastodon web service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Mastodon web service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Mastodon web service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Mastodon web service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where web requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "sidekiq": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Mastodon sidekiq replicas to deploy",
+                    "default": 1
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Mastodon sidekiq containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Mastodon sidekiq containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Mastodon sidekiq containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mastodon sidekiq containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mastodon sidekiq containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon sidekiq pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mastodon sidekiq pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon sidekiq containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mastodon sidekiq containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mastodon sidekiq containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Mastodon sidekiq containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mastodon sidekiq pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mastodon sidekiq pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mastodon sidekiq pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `sidekiq.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `sidekiq.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `sidekiq.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `sidekiq.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `sidekiq.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mastodon sidekiq pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mastodon sidekiq pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mastodon sidekiq pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mastodon sidekiq statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mastodon sidekiq pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Mastodon sidekiq pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mastodon sidekiq container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mastodon sidekiq nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mastodon sidekiq nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mastodon sidekiq nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mastodon sidekiq pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mastodon sidekiq container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mastodon sidekiq pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mastodon sidekiq pod(s)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "streaming": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Mastodon streaming replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Mastodon streaming HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Mastodon streaming containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Mastodon streaming containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Mastodon streaming containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mastodon streaming containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mastodon streaming containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon streaming pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mastodon streaming pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon streaming containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mastodon streaming containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mastodon streaming containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Mastodon streaming containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mastodon streaming pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mastodon streaming pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mastodon streaming pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `streaming.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `streaming.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `streaming.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `streaming.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `streaming.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mastodon streaming pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mastodon streaming pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mastodon streaming pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mastodon streaming statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mastodon streaming pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Mastodon streaming pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mastodon streaming container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mastodon streaming nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mastodon streaming nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mastodon streaming nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mastodon streaming pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mastodon streaming container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mastodon streaming pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mastodon streaming pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mastodon streaming service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Mastodon streaming service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Mastodon streaming service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Mastodon streaming service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Mastodon streaming service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Mastodon streaming service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Mastodon streaming service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Mastodon streaming service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where streaming requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "tootctlMediaManagement": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Cronjob to manage all media caches",
+                    "default": false
+                },
+                "removeAttachments": {
+                    "type": "boolean",
+                    "description": "Enable removing attachements",
+                    "default": true
+                },
+                "removeAttachmentsDays": {
+                    "type": "number",
+                    "description": "Number of days old media attachments must be for removal",
+                    "default": 30
+                },
+                "removeCustomEmoji": {
+                    "type": "boolean",
+                    "description": "Enable removal of cached remote emoji files",
+                    "default": false
+                },
+                "removePreviewCards": {
+                    "type": "boolean",
+                    "description": "Enable removal of cached preview cards",
+                    "default": false
+                },
+                "removePreviewCardsDays": {
+                    "type": "number",
+                    "description": "Number of days old preview cards must be for removal",
+                    "default": 30
+                },
+                "removeAvatars": {
+                    "type": "boolean",
+                    "description": "Enable removal of cached remote avatar images",
+                    "default": false
+                },
+                "removeAvatarsDays": {
+                    "type": "number",
+                    "description": "Number of days old avatar images must be for removal",
+                    "default": 30
+                },
+                "removeHeaders": {
+                    "type": "boolean",
+                    "description": "Enable removal of cached profile header images",
+                    "default": false
+                },
+                "removeHeadersDays": {
+                    "type": "number",
+                    "description": "Number of days old header images must be for removal",
+                    "default": 30
+                },
+                "removeOrphans": {
+                    "type": "boolean",
+                    "description": "Enable removal of cached orphan files",
+                    "default": false
+                },
+                "includeFollows": {
+                    "type": "boolean",
+                    "description": "Enable removal of cached avatar and header when local users are following the accounts",
+                    "default": false
+                },
+                "cronSchedule": {
+                    "type": "string",
+                    "description": "Cron job schedule to run tootctl media commands",
+                    "default": "14 3 * * *"
+                },
+                "failedJobsHistoryLimit": {
+                    "type": "number",
+                    "description": "Number of failed jobs to keep",
+                    "default": 3
+                },
+                "successfulJobsHistoryLimit": {
+                    "type": "number",
+                    "description": "Number of successful jobs to keep",
+                    "default": 3
+                },
+                "concurrencyPolicy": {
+                    "type": "string",
+                    "description": "Concurrency Policy.  Should be Allow, Forbid or Replace",
+                    "default": "Allow"
+                }
+            }
+        },
+        "initJob": {
+            "type": "object",
+            "properties": {
+                "precompileAssets": {
+                    "type": "boolean",
+                    "description": "Execute rake assets:precompile as part of the job",
+                    "default": true
+                },
+                "migrateDB": {
+                    "type": "boolean",
+                    "description": "Execute rake db:migrate as part of the job",
+                    "default": true
+                },
+                "migrateElasticsearch": {
+                    "type": "boolean",
+                    "description": "Execute rake chewy:upgrade as part of the job",
+                    "default": true
+                },
+                "createAdmin": {
+                    "type": "boolean",
+                    "description": "Create admin user as part of the job",
+                    "default": true
+                },
+                "backoffLimit": {
+                    "type": "number",
+                    "description": "set backoff limit of the job",
+                    "default": 10
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mastodon init job",
+                    "default": [],
+                    "items": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon init job containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mastodon init job containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mastodon init job containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Mastodon init job containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mastodon init job pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mastodon init job pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra env vars to configure the Mastodon init job",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars to configure the Mastodon init job",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars to configure the Mastodon init job (in case of sensitive data)",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array of extra volume mounts to be added to the Mastodon Container (evaluated as template). Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "helm": {
+                            "type": "object",
+                            "properties": {
+                                "sh/hook": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "post-install, pre-upgrade"
+                                },
+                                "sh/hook-delete-policy": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "before-hook-creation,hook-succeeded"
+                                },
+                                "sh/hook-weight": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "10"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": false
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Path to mount the volume at.",
+                    "default": "/bitnami/mastodon"
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Storage class of backing PVC",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for JupyterHub",
+                    "default": "postgres"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for JupyterHub",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "JupyterHub database name",
+                    "default": "mastodon"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": "db-password"
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Redis host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Redis port number",
+                    "default": 6379
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the Redis",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the Redis credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the Redis credentials",
+                    "default": ""
+                }
+            }
+        },
+        "externalS3": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External S3 host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External S3 port number",
+                    "default": 443
+                },
+                "accessKeyID": {
+                    "type": "string",
+                    "description": "External S3 access key ID",
+                    "default": ""
+                },
+                "accessKeySecret": {
+                    "type": "string",
+                    "description": "External S3 access key secret",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the S3 credentials",
+                    "default": ""
+                },
+                "existingSecretAccessKeyIDKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the S3 access key ID",
+                    "default": "root-user"
+                },
+                "existingSecretKeySecretKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the S3 access key secret",
+                    "default": "root-password"
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "External S3 protocol",
+                    "default": "https"
+                },
+                "bucket": {
+                    "type": "string",
+                    "description": "External S3 bucket",
+                    "default": "mastodon"
+                },
+                "region": {
+                    "type": "string",
+                    "description": "External S3 region",
+                    "default": "us-east-1"
+                }
+            }
+        },
+        "externalElasticsearch": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external elasticsearch server",
+                    "default": ""
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port of the external elasticsearch server",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the external elasticsearch server",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the elasticsearch credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the elasticsearch credentials",
+                    "default": "elasticsearch-password"
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Redis subchart",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Set Redis architecture",
+                    "default": "standalone"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a secret containing redis credentials",
+                    "default": ""
+                },
+                "master": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "redis": {
+                                            "type": "number",
+                                            "description": "Redis port",
+                                            "default": 6379
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Redis auth",
+                            "default": true
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Redis password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of a secret containing the Redis password",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_mastodon"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_mastodon"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "postgresql": {
+                                            "type": "number",
+                                            "description": "PostgreSQL service port",
+                                            "default": 5432
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "minio": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable MinIO&reg; chart installation",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootUser": {
+                            "type": "string",
+                            "description": "MinIO&reg; root username",
+                            "default": "admin"
+                        },
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for MinIO&reg; root user",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret containing the MinIO&reg; credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "defaultBuckets": {
+                    "type": "string",
+                    "description": "Comma, semi-colon or space separated list of MinIO&reg; buckets to create",
+                    "default": "s3storage"
+                },
+                "provisioning": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable MinIO&reg; provisioning job",
+                            "default": true
+                        },
+                        "extraCommands": {
+                            "type": "array",
+                            "description": "Extra commands to run on MinIO&reg; provisioning job",
+                            "default": [
+                                "mc anonymous set download provisioning/s3storage"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable MinIO&reg; TLS support",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MinIO&reg; service type",
+                            "default": "ClusterIP"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "MinIO&reg; service LoadBalancer IP",
+                            "default": ""
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "api": {
+                                    "type": "number",
+                                    "description": "MinIO&reg; service port",
+                                    "default": 80
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "elasticsearch": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a elasticsearch server to use as Mastodon's search engine",
+                    "default": true
+                },
+                "sysctlImage": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable kernel settings modifier image for Elasticsearch",
+                            "default": true
+                        }
+                    }
+                },
+                "security": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security settings for Elasticsearch",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret containing the elasticsearch credentials",
+                            "default": ""
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "restEncryption": {
+                                    "type": "boolean",
+                                    "description": "Enable TLS encryption for REST API",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "master": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch master-eligible nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "coordinating": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch coordinating-only nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch data nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "ingest": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Desired number of Elasticsearch ingest nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "restAPI": {
+                                    "type": "number",
+                                    "description": "Elasticsearch REST API port",
+                                    "default": 9200
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "apache": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Apache chart",
+                    "default": true
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Apache container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Apache service type",
+                            "default": "LoadBalancer"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Apache service LoadBalancer IP",
+                            "default": ""
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Apache service port",
+                                    "default": 80
+                                }
+                            }
+                        }
+                    }
+                },
+                "vhostsConfigMap": {
+                    "type": "string",
+                    "description": "Name of the ConfigMap containing the Apache vhost configuration",
+                    "default": "{{ include \"mastodon.apache.vhostconfigmap\" . }}"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Apache liveness probe path",
+                            "default": "/api/v1/streaming/health"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Apache readiness probe path",
+                            "default": "/api/v1/streaming/health"
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Apache startup probe path",
+                            "default": "/api/v1/streaming/health"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Ingress hostname",
+                            "default": "mastodon.local"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/matomo/values.schema.json
+++ b/bitnami/matomo/values.schema.json
@@ -1,0 +1,1208 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override matomo.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override matomo.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Matomo resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Matomo resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Matomo image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Matomo Image name",
+                    "default": "bitnami/matomo"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Matomo Image tag",
+                    "default": "4.15.1-debian-11-r17"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Matomo image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Matomo image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Matomo Pods to run (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "matomoUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "matomoPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "matomoEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "matomoWebsiteName": {
+            "type": "string",
+            "description": "Matomo application name",
+            "default": "example"
+        },
+        "matomoWebsiteHost": {
+            "type": "string",
+            "description": "Matomo application host",
+            "default": "https://example.org"
+        },
+        "matomoSkipInstall": {
+            "type": "boolean",
+            "description": "Skip Matomo installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "customPostInitScripts": {
+            "type": "object",
+            "description": "Custom post-init.d user scripts",
+            "default": {}
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": true
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Matomo pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "serviceAccountName": {
+            "type": "string",
+            "description": "Attach serviceAccountName to the pod and sidecars",
+            "default": ""
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "smtpAuth": {
+            "type": "string",
+            "description": "SMTP authentication mechanism (options: Plain, Login, Crammd5)",
+            "default": ""
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "noreplyName": {
+            "type": "string",
+            "description": "Noreply name",
+            "default": ""
+        },
+        "noreplyAddress": {
+            "type": "string",
+            "description": "Noreply address",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Matomo volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Matomo volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Matomo volume",
+                    "default": "8Gi"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume Claim",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "If defined, the matomo-data volume will mount to the specified hostPath.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for Matomo data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for Matomo containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for Matomo containers",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Matomo pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Matomo pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Matomo containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Matomo containers' Security Context",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Controller container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/matomo.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/matomo.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/matomo.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)",
+                    "default": [],
+                    "items": {}
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the Matomo Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Matomo service Cluster IP",
+                    "default": ""
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Matomo service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "matomo.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Matomo. You may need to set this to '/*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_matomo"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_matomo"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Database Persistent Volume Access Modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_matomo"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_matomo"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of a secret containing the database credentials",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a exporter side-car",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": "secret-name"
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": "secret-key"
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables (eg proxy)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by matomo's pods.",
+                            "default": false
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes matomo only accessible from a particular origin",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/mediawiki/values.schema.json
+++ b/bitnami/mediawiki/values.schema.json
@@ -1,0 +1,1150 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MediaWiki image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MediaWiki image repository",
+                    "default": "bitnami/mediawiki"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MediaWiki image tag (immutable tags are recommended)",
+                    "default": "1.40.0-debian-11-r45"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MediaWiki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable MediaWiki image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "mediawikiUser": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "mediawikiPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "mediawikiSecret": {
+            "type": "string",
+            "description": "Existing `Secret` containing the password for the `mediawikiUser` user; must contain the key `mediawiki-password` and optional key `smtp-password`",
+            "default": ""
+        },
+        "mediawikiEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "mediawikiName": {
+            "type": "string",
+            "description": "Name for the wiki",
+            "default": "My Wiki"
+        },
+        "mediawikiHost": {
+            "type": "string",
+            "description": "Mediawiki host to create application URLs",
+            "default": ""
+        },
+        "allowEmptyPassword": {
+            "type": "string",
+            "description": "Allow DB blank passwords",
+            "default": "yes"
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpHostID": {
+            "type": "string",
+            "description": "SMTP host ID",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Mediawiki container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on Mediawki container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "StrategyType can be set to RollingUpdate or OnDelete",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Mediawiki pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the volumes of the pod",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Mediawiki containers' SecurityContext",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID to run Mediawiki containers",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Mediawiki container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Mediawki container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Request path for startupProbe",
+                            "default": "/api.php?action=query&meta=siteinfo&format=none"
+                        },
+                        "httpHeaders": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port for startupProbe",
+                            "default": "http"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "httpHeaders": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Request path for livenessProbe",
+                            "default": "/api.php?action=query&meta=siteinfo&format=none"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port for livenessProbe",
+                            "default": "http"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "httpHeaders": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Request path for readinessProbe",
+                            "default": "/api.php?action=query&meta=siteinfo&format=none"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port for readinessProbe",
+                            "default": "http"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Mediawki pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Mediawki pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Mediawiki pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Mediawki pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Mediawki container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Mediawki pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Mediawki pods",
+            "default": [],
+            "items": {}
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for MediaWiki volume",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name for MediaWiki volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for MediaWiki volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "HTTPS Port. Set this to any value (recommended: 443) to enable the https service port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes http node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes https node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Mediawiki service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Mediawiki service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Mediawiki service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Mediawiki service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "mediawiki.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Mediawiki. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements.",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_mediawiki"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_mediawiki"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Persistent Volume Access Mode",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Host mount path for MariaDB volume",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Enable persistence using an existing PVC",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use existing secret (ignores previous password)",
+                    "default": ""
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_mediawiki"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_mediawiki"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.metrics.port }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Exporter resource requests/limit",
+                    "default": {}
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Metrics service port",
+                    "default": 9117
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": true
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the ServiceMonitor will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "The interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "The timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by MediaWiki's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes MediaWiki only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access MediaWiki. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access MediaWiki. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/memcached/values.schema.json
+++ b/bitnami/memcached/values.schema.json
@@ -1,0 +1,1116 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Extra objects to deploy (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment/statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment/statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Memcached image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Memcached image repository",
+                    "default": "bitnami/memcached"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Memcached image tag (immutable tags are recommended)",
+                    "default": "1.6.21-debian-11-r62"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Memcached image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "Memcached architecture. Allowed values: standalone or high-availability",
+            "default": "standalone"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Memcached authentication",
+                    "default": false
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Memcached admin user",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Memcached admin password",
+                    "default": ""
+                },
+                "existingPasswordSecret": {
+                    "type": "string",
+                    "description": "Existing secret with Memcached credentials (must contain a value for `memcached-password` key)",
+                    "default": ""
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to Memcached nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for Memcached nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for Memcached nodes",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Memcached nodes",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "memcached": {
+                    "type": "number",
+                    "description": "Memcached container port",
+                    "default": 11211
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on Memcached containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on Memcached containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on Memcached containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Memcached container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Memcached containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "The requested memory for the Memcached containers",
+                            "default": "256Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "The requested cpu for the Memcached containers",
+                            "default": "250m"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Memcached pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Memcached pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Memcached containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Memcached containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Memcached containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Memcached pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Memcached pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel`",
+            "default": "Parallel"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of the existing priority class to be used by Memcached pods, priority class needs to be created beforehand",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Kubernetes pod scheduler registry",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the memcached pod needs to terminate gracefully",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Memcached statefulset strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Memcached statefulset rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the Memcached pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Memcached container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Memcached pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Memcached pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable memcached statefulset autoscaling (requires architecture: \"high-availability\")",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "memcached statefulset autoscaling minimum number of replicas",
+                    "default": 3
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "memcached statefulset autoscaling maximum number of replicas",
+                    "default": 6
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "memcached statefulset autoscaling target CPU percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "memcached statefulset autoscaling target CPU memory",
+                    "default": 50
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Deploy a pdb object for the Memcached pod",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum available Memcached replicas",
+                    "default": ""
+                },
+                "maxUnavailable": {
+                    "type": "number",
+                    "description": "Maximum unavailable Memcached replicas",
+                    "default": 1
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "memcached": {
+                            "type": "number",
+                            "description": "Memcached service port",
+                            "default": 11211
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "memcached": {
+                            "type": "string",
+                            "description": "Node port for Memcached",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": ""
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Memcached service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Memcached service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Memcached service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Memcached service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Memcached service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the Memcached service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Memcached pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Memcached data persistence using PVC. If false, use emptyDir",
+                    "default": false
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Memcached data volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Memcached data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels for the PVC",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for Memcached's data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Memcached exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Memcached exporter image repository",
+                            "default": "bitnami/memcached-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Memcached exporter image tag (immutable tags are recommended)",
+                            "default": "0.13.0-debian-11-r75"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Memcached exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Memcached Prometheus Exporter container port",
+                            "default": 9150
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Metrics containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Metrics containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Metrics containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Memcached Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Memcached Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Memcached Prometheus exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.metrics.containerPorts.metrics }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Prometheus metrics service port",
+                                    "default": 9150
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.metrics }}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/metallb/values.schema.json
+++ b/bitnami/metallb/values.schema.json
@@ -1,0 +1,1257 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override metallb.fullname include (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override metallb.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "installCRDs": {
+            "type": "boolean",
+            "description": "Flag to install metallb CRDs",
+            "default": true
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether to install and use RBAC rules",
+                    "default": true
+                }
+            }
+        },
+        "psp": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable NetworkPolicy",
+                    "default": false
+                },
+                "ingressNSMatchLabels": {
+                    "type": "object",
+                    "description": "Allow connections from other namespaces",
+                    "default": {}
+                },
+                "ingressNSPodMatchLabels": {
+                    "type": "object",
+                    "description": "For other namespaces match by pod labels and namespace labels",
+                    "default": {}
+                }
+            }
+        },
+        "prometheusRule": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Prometheus Operator alertmanager alerts are created",
+                    "default": false
+                }
+            }
+        },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MetalLB Controller image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MetalLB Controller image repository",
+                            "default": "bitnami/metallb-controller"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MetalLB Controller  image tag (immutable tags are recommended)",
+                            "default": "0.13.11-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MetalLB Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "MetalLB Controller image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Metallb controller deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "create specifies whether to install and use RBAC rules.",
+                            "default": true
+                        }
+                    }
+                },
+                "psp": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": true
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Metallb controller pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "In seconds, time the given to the Metallb controller pod needs to terminate gracefully",
+                    "default": 0
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for controller pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for controller pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for controller pod assignment",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Controller Pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Controller Pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Controller Pod affinitypreset. Allowed values: soft, hard",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Controller Pod anti affinitypreset. Allowed values: soft, hard",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Controller Pod Node affinity preset. Allowed values: soft, hard",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Controller Pod Node affinity label key to match",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Controller Pod Node affinity label values to match",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Metallb Controller pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Metallb Controller pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Metallb Controller containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Metallb Controller containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Metallb Controller container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Enables privilege Escalation context for the pod.",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Allows the pod to mount the RootFS as ReadOnly",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Drop capabilities for the securityContext",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Metallb Controller container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variable to pass to the running container.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Metallb controller nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Metallb controller nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Metallb controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Metallb controller container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Metallb Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Metallb Controller pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "revisionHistoryLimit": {
+                    "type": "number",
+                    "description": "Configure the revisionHistoryLimit of the Controller deployment",
+                    "default": 3
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Configures the ports the MetalLB Controller listens on for metrics",
+                            "default": 7472
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Sets the controller log level. Does not work if the args are overridden",
+                    "default": "info"
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "number",
+                                    "description": "Prometheus metrics service port",
+                                    "default": 7472
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "7472"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/metrics"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Specify if a servicemonitor will be deployed for prometheus-operator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "Specify the jobLabel to use for the prometheus-operator",
+                                    "default": "app.kubernetes.io/name"
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Scrape interval. If not set, the Prometheus default scrape interval is used",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "speaker": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable BGP speakers or not",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MetalLB Speaker image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MetalLB Speaker image repository",
+                            "default": "bitnami/metallb-speaker"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MetalLB Speaker  image tag (immutable tags are recommended)",
+                            "default": "0.13.11-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MetalLB Speaker image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "MetalLB Speaker image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Speaker daemonset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "create specifies whether to install and use RBAC rules.",
+                            "default": true
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "psp": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                            "default": true
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Speaker pods' priorityClassName",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "In seconds, time the given to the Speaker pod needs to terminate gracefully",
+                    "default": 2
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for speaker pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for speaker pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for speaker pod assignment",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `speaker.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `speaker.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `speaker.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `speaker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `speaker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Speaker Pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Speaker Pod labels",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Speaker pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Speaker pod's Security Context fsGroup",
+                            "default": 0
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Speaker containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Speaker containers' Security Context runAsUser",
+                            "default": 0
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Enables privilege Escalation context for the pod.",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Allows the pod to mount the RootFS as ReadOnly",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Drop capabilities for the securityContext",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "add": {
+                                    "type": "array",
+                                    "description": "Add capabilities for the securityContext",
+                                    "default": [
+                                        "NET_ADMIN",
+                                        "NET_RAW",
+                                        "SYS_ADMIN"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Speaker container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Speaker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Speaker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "secretName": {
+                    "type": "string",
+                    "description": "References a Secret name for the member secret outside of the helm chart",
+                    "default": ""
+                },
+                "secretKey": {
+                    "type": "string",
+                    "description": "References a Secret key the member secret outside of the helm chart",
+                    "default": ""
+                },
+                "secretValue": {
+                    "type": "string",
+                    "description": "Custom value for `speaker.secretKey`",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variable to pass to the running container.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Speaker nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Speaker nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Speaker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Speaker container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "HTTP Metrics Endpoint",
+                            "default": 7472
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Sets the speaker log level. Does not work if the args are overridden",
+                    "default": "info"
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "number",
+                                    "description": "Prometheus metrics service port",
+                                    "default": 7472
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "7472"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/metrics"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable support for Prometheus Operator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "Job label for scrape target",
+                                    "default": "app.kubernetes.io/name"
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Scrape interval. If not set, the Prometheus default scrape interval is used",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "ServiceMonitor selector labels",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/metrics-server/values.schema.json
+++ b/bitnami/metrics-server/values.schema.json
@@ -1,0 +1,633 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Metrics Server image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Metrics Server image repository",
+                    "default": "bitnami/metrics-server"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Metrics Server image tag (immutable tags are recommended)",
+                    "default": "0.6.4-debian-11-r24"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Metrics Server image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Metrics Server image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Metrics Server image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "replicas": {
+            "type": "number",
+            "description": "Number of metrics-server nodes to deploy",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Set up update strategy for metrics-server installation.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable RBAC authentication",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to create",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "apiService": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether the v1beta1.metrics.k8s.io API service should be created. You can check if it is needed with `kubectl get --raw \"/apis/metrics.k8s.io/v1beta1/nodes\"`.",
+                    "default": false
+                },
+                "insecureSkipTLSVerify": {
+                    "type": "boolean",
+                    "description": "Specifies whether to skip self-verifying self-signed TLS certificates. Set to \"false\" if you are providing your own certificates.",
+                    "default": true
+                },
+                "caBundle": {
+                    "type": "string",
+                    "description": "A base64-encoded string of concatenated certificates for the CA chain for the APIService.",
+                    "default": ""
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "https": {
+                    "type": "number",
+                    "description": "Port where metrics-server will be running",
+                    "default": 8443
+                }
+            }
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Enable hostNetwork mode",
+            "default": false
+        },
+        "dnsPolicy": {
+            "type": "string",
+            "description": "Default dnsPolicy setting",
+            "default": "ClusterFirst"
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the metrics-server container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to metrics-server nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for metrics-server nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for metrics-server nodes",
+            "default": ""
+        },
+        "extraArgs": {
+            "type": "array",
+            "description": "Extra arguments to pass to metrics-server on start up",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the metrics-server pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the metrics-server pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod labels",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority class for pod scheduling",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the metrics-server pod needs to terminate gracefully",
+            "default": ""
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create a PodDisruptionBudget",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum available instances",
+                    "default": ""
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum unavailable instances",
+                    "default": ""
+                }
+            }
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology spread constraints for pod",
+            "default": [],
+            "items": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "number",
+                            "description": "Kubernetes Service port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes Service port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "metrics-server service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "LoadBalancer IP if Service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "metrics-server service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "metrics-server service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the Service",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels for the Service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom Liveness probes for metrics-server",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom Readiness probes metrics-server",
+            "default": {}
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Container security context",
+                    "default": true
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "description": "ReadOnlyRootFilesystem for the container",
+                    "default": false
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Run containers as non-root users",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set containers' Security Context runAsUser",
+                    "default": 1001
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Pod security context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set %%MAIN_CONTAINER_NAME%% pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Extra volumes",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Mount extra volume(s)",
+            "default": [],
+            "items": {}
+        }
+    }
+}

--- a/bitnami/milvus/values.schema.json
+++ b/bitnami/milvus/values.schema.json
@@ -108,7 +108,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Milvus image tag (immutable tags are recommended)",
-                            "default": "2.2.10-debian-11-r3"
+                            "default": "2.2.14-debian-11-r10"
                         },
                         "digest": {
                             "type": "string",
@@ -160,13 +160,18 @@
                             "type": "string",
                             "description": "Name of a secret containing the Milvus password",
                             "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the Milvus password",
+                            "default": ""
                         }
                     }
                 },
                 "defaultConfig": {
                     "type": "string",
                     "description": "Milvus components default configuration",
-                    "default": "# etcd configuration\netcd:\n  endpoints:\n    {{- if .Values.etcd.enabled  }}\n      {{- $replicas := $.Values.etcd.replicaCount | int }}\n      {{- range $i, $_e := until $replicas }}\n    - {{ printf \"%s://%s-%d.%s:%v\" (ternary \"https\" \"http\" $.Values.etcd.auth.client.secureTransport) (include \"milvus.etcd.fullname\" $ ) $i (include \"milvus.etcd.headlessServiceName\" $) ( include \"milvus.etcd.port\" $ ) }}          {{- end }}\n    {{- else }}\n    {{- range $node := .Values.externalEtcd.servers }}\n    - {{ ternary \"https\" \"http\" $.Values.externalEtcd.secureTransport }}://{{ printf \"%s:%v\" $node (include \"milvus.etcd.port\" $) }}\n    {{- end }}\n    {{- end }}\nmetastore:\n  type: etcd\n\n# S3 configuration\nminio:\n  address: {{ include \"milvus.s3.host\" . }}\n  port: {{ include \"milvus.s3.port\" . }}\n  accessKeyID: {{ print \"{{ MILVUS_S3_ACCESS_ID }}\" | quote }}\n  secretAccessKey: {{ print \"{{ MILVUS_S3_SECRET_ACCESS_KEY }}\" | quote }}\n  useSSL: {{ include \"milvus.s3.useSSL\" . }}\n  bucketName: {{ include \"milvus.s3.bucket\" . }}\n  rootPath: {{ include \"milvus.s3.rootPath\" . }}\n  useIAM: {{ include \"milvus.s3.useIAM\" . }}\n  {{- if not .Values.minio.enabled }}\n  cloudProvider: {{ .Values.externalS3.cloudProvider }}\n  iamEndpoint: {{ .Values.externalS3.iamEndpoint }}\n  {{- end }}\n\n# Kafka configuration\nkafka:\n  brokerList:\n    {{- if .Values.kafka.enabled  }}\n      {{- $replicas := $.Values.kafka.replicaCount | int }}\n      {{- range $i, $_e := until $replicas }}\n    - {{ printf \"%s-%d.%s:%v\" (include \"milvus.kafka.fullname\" $ ) $i (include \"milvus.kafka.headlessServiceName\" $) ( include \"milvus.kafka.port\" $ ) }}\n      {{- end }}\n    {{- else }}\n    {{- range $node := .Values.kafka.servers }}\n    - {{ printf \"%s:%v\" $node (include \"milvus.kafka.port\" $) }}\n    {{- end }}\n    {{- end }}\n  securityProtocol: {{ include \"milvus.kafka.securityProtocol\" . }}\n  {{- if include \"milvus.kafka.authEnabled\" . }}\n  saslMechanisms: {{ include \"milvus.kafka.saslMechanisms\" . }}\n  saslUsername: {{ include \"milvus.kafka.user\" . }}\n  saslPassword: {{ print \"{{ MILVUS_KAFKA_PASSWORD }}\" | quote }}\n  {{- end }}\n\n# Data coordinator\ndataCoord:\n  address: {{ include \"milvus.data-coordinator.fullname\" . }}\n  port: {{ .Values.dataCoord.service.ports.grpc }}\n\n# Root coordinator\nrootCoord:\n  address: {{ include \"milvus.root-coordinator.fullname\" . }}\n  port: {{ .Values.rootCoord.service.ports.grpc }}\n\n# Index coordinator\nindexCoord:\n  address: {{ include \"milvus.index-coordinator.fullname\" . }}\n  port: {{ .Values.indexCoord.service.ports.grpc }}\n\n# Query coordinator\nqueryCoord:\n  address: {{ include \"milvus.query-coordinator.fullname\" . }}\n  port: {{ .Values.queryCoord.service.ports.grpc }}\n\n# Data node\ndataNode:\n  port: {{ .Values.dataNode.service.ports.grpc }}\n\n# Index node\nindexNode:\n  port: {{ .Values.indexNode.service.ports.grpc }}\n\n# Query node\nqueryNode:\n  port: {{ .Values.queryNode.service.ports.grpc }}\n\nproxy:\n  port: {{ .Values.proxy.service.ports.grpc }}\n  accessLog:\n    localPath: /dev\n    filename: stdout\n  http:\n    enabled: true\n\n# Log configuration\nlog:\n  level: {{ ternary \"debug\" \"info\" .Values.milvus.image.debug }}\n  stdout: true\n\n# Common configuration\ncommon:\n  storageType: minio\n  security:\n    authorizationEnabled: {{ .Values.milvus.auth.enabled }}\n    {{- if .Values.milvus.auth.enabled }}\n    superUsers:\n      - {{ .Values.milvus.auth.username }}\n    {{- end }}\n"
+                    "default": "# etcd configuration\netcd:\n  endpoints:\n    {{- if .Values.etcd.enabled  }}\n      {{- $replicas := $.Values.etcd.replicaCount | int }}\n      {{- range $i, $_e := until $replicas }}\n    - {{ printf \"%s://%s-%d.%s:%v\" (ternary \"https\" \"http\" $.Values.etcd.auth.client.secureTransport) (include \"milvus.etcd.fullname\" $ ) $i (include \"milvus.etcd.headlessServiceName\" $) ( include \"milvus.etcd.port\" $ ) }}          {{- end }}\n    {{- else }}\n    {{- range $node := .Values.externalEtcd.servers }}\n    - {{ ternary \"https\" \"http\" $.Values.externalEtcd.secureTransport }}://{{ printf \"%s:%v\" $node (include \"milvus.etcd.port\" $) }}\n    {{- end }}\n    {{- end }}\nmetastore:\n  type: etcd\n\n# S3 configuration\nminio:\n  address: {{ include \"milvus.s3.host\" . }}\n  port: {{ include \"milvus.s3.port\" . }}\n  accessKeyID: {{ print \"{{ MILVUS_S3_ACCESS_ID }}\" | quote }}\n  secretAccessKey: {{ print \"{{ MILVUS_S3_SECRET_ACCESS_KEY }}\" | quote }}\n  useSSL: {{ include \"milvus.s3.useSSL\" . }}\n  bucketName: {{ include \"milvus.s3.bucket\" . }}\n  rootPath: {{ include \"milvus.s3.rootPath\" . }}\n  useIAM: {{ include \"milvus.s3.useIAM\" . }}\n  {{- if not .Values.minio.enabled }}\n  cloudProvider: {{ .Values.externalS3.cloudProvider }}\n  iamEndpoint: {{ .Values.externalS3.iamEndpoint }}\n  {{- end }}\n\n# Kafka configuration\nkafka:\n  brokerList:\n    {{- if .Values.kafka.enabled  }}\n      {{- $brokerReplicas := $.Values.kafka.broker.replicaCount | int }}\n      {{- $controllerReplicas := 0 }}\n      {{- if or (not .Values.kafka.kraft.enabled) (not .Values.kafka.controller.controllerOnly)}}\n      {{- $controllerReplicas = $.Values.kafka.controller.replicaCount | int }}\n      {{- end }}\n      {{- range $i, $_e := until $brokerReplicas }}\n    - {{ printf \"%s-broker-%d.%s:%v\" (include \"milvus.kafka.fullname\" $ ) $i (include \"milvus.kafka.broker.headlessServiceName\" $) ( include \"milvus.kafka.port\" $ ) }}\n      {{- end }}\n      {{- range $i, $_e := until $controllerReplicas }}\n    - {{ printf \"%s-controller-%d.%s:%v\" (include \"milvus.kafka.fullname\" $ ) $i (include \"milvus.kafka.controller.headlessServiceName\" $) ( include \"milvus.kafka.port\" $ ) }}\n      {{- end }}\n    {{- else }}\n    {{- range $node := .Values.externalKafka.servers }}\n    - {{ printf \"%s:%v\" $node (include \"milvus.kafka.port\" $) }}\n    {{- end }}\n    {{- end }}\n  securityProtocol: {{ include \"milvus.kafka.securityProtocol\" . }}\n  {{- if include \"milvus.kafka.authEnabled\" . }}\n  saslMechanisms: {{ include \"milvus.kafka.saslMechanisms\" . }}\n  saslUsername: {{ include \"milvus.kafka.user\" . }}\n  saslPassword: {{ print \"{{ MILVUS_KAFKA_PASSWORD }}\" | quote }}\n  {{- end }}\n\n# Data coordinator\ndataCoord:\n  address: {{ include \"milvus.data-coordinator.fullname\" . }}\n  port: {{ .Values.dataCoord.service.ports.grpc }}\n\n# Root coordinator\nrootCoord:\n  address: {{ include \"milvus.root-coordinator.fullname\" . }}\n  port: {{ .Values.rootCoord.service.ports.grpc }}\n\n# Index coordinator\nindexCoord:\n  address: {{ include \"milvus.index-coordinator.fullname\" . }}\n  port: {{ .Values.indexCoord.service.ports.grpc }}\n\n# Query coordinator\nqueryCoord:\n  address: {{ include \"milvus.query-coordinator.fullname\" . }}\n  port: {{ .Values.queryCoord.service.ports.grpc }}\n\n# Data node\ndataNode:\n  port: {{ .Values.dataNode.service.ports.grpc }}\n\n# Index node\nindexNode:\n  port: {{ .Values.indexNode.service.ports.grpc }}\n\n# Query node\nqueryNode:\n  port: {{ .Values.queryNode.service.ports.grpc }}\n\nproxy:\n  port: {{ .Values.proxy.service.ports.grpc }}\n  accessLog:\n    localPath: /dev\n    filename: stdout\n  http:\n    enabled: true\n\n# Log configuration\nlog:\n  level: {{ ternary \"debug\" \"info\" .Values.milvus.image.debug }}\n  stdout: true\n\n# Common configuration\ncommon:\n  storageType: minio\n  security:\n    authorizationEnabled: {{ .Values.milvus.auth.enabled }}\n    {{- if .Values.milvus.auth.enabled }}\n    superUsers:\n      - {{ .Values.milvus.auth.username }}\n    {{- end }}\n"
                 },
                 "extraConfig": {
                     "type": "object",
@@ -209,7 +214,7 @@
                         "tag": {
                             "type": "string",
                             "description": "PyMilvus image tag (immutable tags are recommended)",
-                            "default": "2.2.13-debian-11-r1"
+                            "default": "2.3.0-debian-11-r11"
                         },
                         "digest": {
                             "type": "string",
@@ -6373,7 +6378,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Attu image tag (immutable tags are recommended)",
-                            "default": "2.2.6-debian-11-r1"
+                            "default": "2.3.0-debian-11-r0"
                         },
                         "digest": {
                             "type": "string",
@@ -7105,7 +7110,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Init container wait-container image tag",
-                            "default": "11-debian-11-r2"
+                            "default": "11-debian-11-r57"
                         },
                         "digest": {
                             "type": "string",
@@ -7275,6 +7280,46 @@
                     "type": "number",
                     "description": "External Kafka port",
                     "default": 9092
+                },
+                "listener": {
+                    "type": "object",
+                    "properties": {
+                        "protocol": {
+                            "type": "string",
+                            "description": "Kafka listener protocol. Allowed protocols: PLAINTEXT, SASL_PLAINTEXT, SASL_SSL and SSL",
+                            "default": "PLAINTEXT"
+                        }
+                    }
+                },
+                "sasl": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "User for SASL authentication",
+                            "default": "user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for SASL authentication",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing a password for SASL authentication (under the key named \"client-passwords\")",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the Kafka client user password",
+                            "default": "kafka-root-password"
+                        },
+                        "enabledMechanisms": {
+                            "type": "string",
+                            "description": "Kafka enabled SASL mechanisms",
+                            "default": "PLAIN"
+                        }
+                    }
                 }
             }
         },
@@ -7426,10 +7471,15 @@
                     "description": "Enable/disable Kafka chart installation",
                     "default": true
                 },
-                "replicaCount": {
-                    "type": "number",
-                    "description": "Number of Kafka brokers",
-                    "default": 1
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Kafka controller eligible (controller+broker) nodes",
+                            "default": 1
+                        }
+                    }
                 },
                 "service": {
                     "type": "object",
@@ -7446,35 +7496,45 @@
                         }
                     }
                 },
-                "auth": {
+                "extraConfig": {
+                    "type": "string",
+                    "description": "Additional configuration to be appended at the end of the generated Kafka configuration file.",
+                    "default": "offsets.topic.replication.factor=1"
+                },
+                "listeners": {
                     "type": "object",
                     "properties": {
-                        "clientProtocol": {
-                            "type": "string",
-                            "description": "Kafka authentication protocol for the client",
-                            "default": "sasl"
-                        },
-                        "sasl": {
+                        "client": {
                             "type": "object",
                             "properties": {
-                                "mechanisms": {
+                                "protocol": {
                                     "type": "string",
-                                    "description": "Kafka authentication mechanisms for SASL",
-                                    "default": "plain"
-                                },
-                                "jaas": {
-                                    "type": "object",
-                                    "properties": {
-                                        "clientUsers": {
-                                            "type": "array",
-                                            "description": "Kafka client users",
-                                            "default": [
-                                                "user"
-                                            ],
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
+                                    "description": "Kafka authentication protocol for the client listener",
+                                    "default": "SASL_PLAINTEXT"
+                                }
+                            }
+                        }
+                    }
+                },
+                "sasl": {
+                    "type": "object",
+                    "properties": {
+                        "enabledMechanisms": {
+                            "type": "string",
+                            "description": "Kafka enabled SASL mechanisms",
+                            "default": "PLAIN"
+                        },
+                        "client": {
+                            "type": "object",
+                            "properties": {
+                                "users": {
+                                    "type": "array",
+                                    "description": "Kafka client users",
+                                    "default": [
+                                        "user"
+                                    ],
+                                    "items": {
+                                        "type": "string"
                                     }
                                 }
                             }

--- a/bitnami/minio/values.schema.json
+++ b/bitnami/minio/values.schema.json
@@ -1,0 +1,1278 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MinIO&reg; image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MinIO&reg; image repository",
+                    "default": "bitnami/minio"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MinIO&reg; image tag (immutable tags are recommended)",
+                    "default": "2023.9.7-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MinIO&reg; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "clientImage": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MinIO&reg; Client image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MinIO&reg; Client image repository",
+                    "default": "bitnami/minio-client"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MinIO&reg; Client image tag (immutable tags are recommended)",
+                    "default": "2023.9.2-debian-11-r2"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MinIO&reg; Client image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                }
+            }
+        },
+        "mode": {
+            "type": "string",
+            "description": "MinIO&reg; server mode (`standalone` or `distributed`)",
+            "default": "standalone"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "rootUser": {
+                    "type": "string",
+                    "description": "MinIO&reg; root username",
+                    "default": "admin"
+                },
+                "rootPassword": {
+                    "type": "string",
+                    "description": "Password for MinIO&reg; root user",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use existing secret for credentials details (`auth.rootUser` and `auth.rootPassword` will be ignored and picked up from this secret). The secret has to contain the keys `root-user` and `root-password`)",
+                    "default": ""
+                },
+                "forcePassword": {
+                    "type": "boolean",
+                    "description": "Force users to specify required passwords",
+                    "default": false
+                },
+                "useCredentialsFiles": {
+                    "type": "boolean",
+                    "description": "Mount credentials as a files instead of using an environment variable",
+                    "default": false
+                },
+                "forceNewKeys": {
+                    "type": "boolean",
+                    "description": "Force root credentials (user and password) to be reconfigured every time they change in the secrets",
+                    "default": false
+                }
+            }
+        },
+        "defaultBuckets": {
+            "type": "string",
+            "description": "Comma, semi-colon or space separated list of buckets to create at initialization (only in standalone mode)",
+            "default": ""
+        },
+        "disableWebUI": {
+            "type": "boolean",
+            "description": "Disable MinIO&reg; Web UI",
+            "default": false
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable tls in front of the container",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret holding the certificate information",
+                    "default": ""
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "The mount path where the secret will be located",
+                    "default": ""
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on MinIO&reg; container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Default container command (useful when using custom images). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Default container args (useful when using custom images). Use array form",
+            "default": [],
+            "items": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Specifies the schedulerName, if it's nil uses kube-scheduler",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the MinIO pod needs to terminate gracefully",
+            "default": ""
+        },
+        "deployment": {
+            "type": "object",
+            "properties": {
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Deployment strategy type",
+                            "default": "Recreate"
+                        }
+                    }
+                }
+            }
+        },
+        "statefulset": {
+            "type": "object",
+            "properties": {
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "StatefulSet strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel",
+                    "default": "Parallel"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of pods per zone (only for MinIO&reg; distributed mode). Should be even and `>= 4`",
+                    "default": 4
+                },
+                "zones": {
+                    "type": "number",
+                    "description": "Number of zones (only for MinIO&reg; distributed mode)",
+                    "default": 1
+                },
+                "drivesPerNode": {
+                    "type": "number",
+                    "description": "Number of drives attached to every node (only for MinIO&reg; distributed mode)",
+                    "default": 1
+                }
+            }
+        },
+        "provisioning": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MinIO&reg; provisioning Job",
+                    "default": false
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for MinIO&reg; provisioning",
+                    "default": ""
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for provisioning pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Provisioning Pod annotations.",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Default provisioning container command (useful when using custom images). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Default provisioning container args (useful when using custom images). Use array form",
+                    "default": [],
+                    "items": {}
+                },
+                "extraCommands": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional commands for MinIO&reg; provisioning pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for MinIO&reg; provisioning pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for MinIO&reg; provisioning container",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "policies": {
+                    "type": "array",
+                    "description": "MinIO&reg; policies provisioning",
+                    "default": [],
+                    "items": {}
+                },
+                "users": {
+                    "type": "array",
+                    "description": "MinIO&reg; users provisioning. Can be used in addition to provisioning.usersExistingSecrets.",
+                    "default": [],
+                    "items": {}
+                },
+                "usersExistingSecrets": {
+                    "type": "array",
+                    "description": "Array if existing secrets containing MinIO&reg; users to be provisioned. Can be used in addition to provisioning.users.",
+                    "default": [],
+                    "items": {}
+                },
+                "groups": {
+                    "type": "array",
+                    "description": "MinIO&reg; groups provisioning",
+                    "default": [],
+                    "items": {}
+                },
+                "buckets": {
+                    "type": "array",
+                    "description": "MinIO&reg; buckets, versioning, lifecycle, quota and tags provisioning",
+                    "default": [],
+                    "items": {}
+                },
+                "config": {
+                    "type": "array",
+                    "description": "MinIO&reg; config provisioning",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable pod Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Avoid running as root User",
+                            "default": true
+                        }
+                    }
+                },
+                "cleanupAfterFinished": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enables Cleanup for Finished Jobs",
+                            "default": false
+                        },
+                        "seconds": {
+                            "type": "number",
+                            "description": "Sets the value of ttlSecondsAfterFinished",
+                            "default": 600
+                        }
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "MinIO&reg; pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "api": {
+                    "type": "number",
+                    "description": "MinIO&reg; container port to open for MinIO&reg; API",
+                    "default": 9000
+                },
+                "console": {
+                    "type": "number",
+                    "description": "MinIO&reg; container port to open for MinIO&reg; Console",
+                    "default": 9001
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable pod Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the container",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable container Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the container",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Avoid running as root User",
+                    "default": true
+                }
+            }
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for MinIO&reg; pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for MinIO&reg; pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for MinIO&reg; pods assignment spread across your cluster among failure-domains",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "MinIO&reg; pods' priorityClassName",
+            "default": ""
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the MinIO&reg; container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the MinIO&reg; container",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the MinIO&reg container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for MinIO&reg; pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for MinIO&reg; container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the MinIO&reg; pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the MinIO&reg; pods",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "MinIO&reg; service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "number",
+                            "description": "MinIO&reg; API service port",
+                            "default": 9000
+                        },
+                        "console": {
+                            "type": "number",
+                            "description": "MinIO&reg; Console service port",
+                            "default": 9001
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "string",
+                            "description": "Specify the MinIO&reg API nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        },
+                        "console": {
+                            "type": "string",
+                            "description": "Specify the MinIO&reg Console nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP if service type is `LoadBalancer` (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Addresses that are allowed when service is LoadBalancer",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for MinIO&reg; service",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource for MinIO Console",
+                    "default": false
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "minio.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to MinIO&reg;. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "servicePort": {
+                    "type": "string",
+                    "description": "Service port to be used",
+                    "default": "minio-console"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "apiIngress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource for MinIO API",
+                    "default": false
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "minio.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to MinIO&reg;. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "servicePort": {
+                    "type": "string",
+                    "description": "Service port to be used",
+                    "default": "minio-api"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `apiIngress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the default NetworkPolicy policy",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "extraFromClauses": {
+                    "type": "array",
+                    "description": "Allows to add extra 'from' clauses to the NetworkPolicy",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MinIO&reg; data persistence using PVC. If false, use emptyDir",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for MinIO&reg; data volume",
+                    "default": ""
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Data volume mount path",
+                    "default": "/bitnami/minio/data"
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Modes for MinIO&reg; data volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for MinIO&reg; data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Name of an existing PVC to use (only in `standalone` mode)",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for MinIO&reg; pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Custom annotations for MinIO&reg; ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that must still be available after the eviction",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable after the eviction",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "prometheusAuthType": {
+                    "type": "string",
+                    "description": "Authentication mode for Prometheus (`jwt` or `public`)",
+                    "default": "public"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If the operator is installed in your cluster, set to true to create a Service Monitor Entry",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "HTTP path to scrape for metrics",
+                            "default": "/minio/v2/metrics/cluster"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Metrics relabelings to add to the scrape endpoint, applied before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "ApiVersion for the serviceMonitor Resource (defaults to \"monitoring.coreos.com/v1\")",
+                            "default": ""
+                        },
+                        "tlsConfig": {
+                            "type": "object",
+                            "description": "Additional TLS configuration for metrics endpoint with \"https\" scheme",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/mongodb-sharded/values.schema.json
+++ b/bitnami/mongodb-sharded/values.schema.json
@@ -1,0 +1,2493 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global storage class for dynamic provisioning",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Sharded image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Sharded Image name",
+                    "default": "bitnami/mongodb-sharded"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Sharded image tag (immutable tags are recommended)",
+                    "default": "6.0.9-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Sharded image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Sharded image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable authentication",
+                    "default": true
+                },
+                "rootUser": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) root user",
+                    "default": "root"
+                },
+                "rootPassword": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) root password",
+                    "default": ""
+                },
+                "replicaSetKey": {
+                    "type": "string",
+                    "description": "Key used for authentication in the replicaset (only when `architecture=replicaset`)",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-password`, `mongodb-root-password`, `mongodb-replica-set-key`)",
+                    "default": ""
+                },
+                "usePasswordFile": {
+                    "type": "boolean",
+                    "description": "Mount credentials as files instead of using environment variables",
+                    "default": false
+                }
+            }
+        },
+        "shards": {
+            "type": "number",
+            "description": "Number of shards to be created",
+            "default": 2
+        },
+        "common": {
+            "type": "object",
+            "properties": {
+                "mongodbEnableNumactl": {
+                    "type": "boolean",
+                    "description": "Enable launch MongoDB instance prefixed with \"numactl --interleave=all\"",
+                    "default": false
+                },
+                "useHostnames": {
+                    "type": "boolean",
+                    "description": "Enable DNS hostnames in the replica set config",
+                    "default": true
+                },
+                "mongodbEnableIPv6": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable IPv6 on MongoDB&reg;",
+                    "default": false
+                },
+                "mongodbDirectoryPerDB": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable DirectoryPerDB on MongoDB&reg;",
+                    "default": false
+                },
+                "mongodbSystemLogVerbosity": {
+                    "type": "number",
+                    "description": "MongoDB&reg; system log verbosity level",
+                    "default": 0
+                },
+                "mongodbDisableSystemLog": {
+                    "type": "boolean",
+                    "description": "Whether to disable MongoDB&reg; system log or not",
+                    "default": false
+                },
+                "mongodbMaxWaitTimeout": {
+                    "type": "number",
+                    "description": "Maximum time (in seconds) for MongoDB&reg; nodes to wait for another MongoDB&reg; node to be ready",
+                    "default": 120
+                },
+                "initScriptsCM": {
+                    "type": "string",
+                    "description": "Configmap with init scripts to execute",
+                    "default": ""
+                },
+                "initScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret with init scripts to execute (for sensitive data)",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of a Secret containing extra env vars",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the pod",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the pod",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array to add extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array to add extra mounts (normally used with extraVolumes)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "number",
+                            "description": "MongoDB container port",
+                            "default": 27017
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a Service Account for all pods automatically",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of a Service Account to be used by all Pods",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r45"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Init container resource requests/limit",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Specify an explicit service name",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional service annotations (evaluate as a template)",
+                    "default": {}
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Service type",
+                    "default": "ClusterIP"
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "External traffic policy",
+                    "default": "Cluster"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "number",
+                            "description": "MongoDB&reg; service port",
+                            "default": 27017
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Static clusterIP or None for headless services",
+                    "default": ""
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types.",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "External IP list to use with ClusterIP service type",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Static IP Address to use for LoadBalancer service type",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "List of IP ranges allowed access to load balancer (if supported)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "configsvr": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of nodes in the replica set (the first node will be primary)",
+                    "default": 1
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Configure pod resources",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "mongodbExtraFlags": {
+                    "type": "array",
+                    "description": "MongoDB&reg; additional command line flags",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Pod priority class name",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Config Server Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Config Server Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Config Server Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Config Server Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Config Server Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Config Server Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Config Server Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Config Server Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset's pod management policy, allows parallel startup of pods",
+                    "default": "OrderedReady"
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "updateStrategy for MongoDB&reg; Primary, Secondary and Arbiter statefulsets",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "config": {
+                    "type": "string",
+                    "description": "MongoDB&reg; configuration file",
+                    "default": ""
+                },
+                "configCM": {
+                    "type": "string",
+                    "description": "ConfigMap name with Config Server configuration file (cannot be used with configsvr.config)",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of a Secret containing extra env vars",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the pod",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the pod",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array to add extra volumes. Requires setting `extraVolumeMounts`",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array to add extra mounts (normally used with extraVolumes). Normally used with `extraVolumes`",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable pod disruption budget",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number of available config pods allowed (`0` to disable)",
+                            "default": 0
+                        },
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Maximum number of unavailable config pods allowed (`0` to disable)",
+                            "default": 1
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use a PVC to persist data",
+                            "default": true
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Path to mount the volume at",
+                            "default": "/bitnami/mongodb"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "Subdirectory of the volume to mount at (evaluated as a template)",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Storage class of backing PVC",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Use volume as ReadOnly or ReadWrite",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PersistentVolumeClaim size",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume annotations",
+                            "default": {}
+                        },
+                        "resourcePolicy": {
+                            "type": "string",
+                            "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                            "default": ""
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created for Config Server",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of a Service Account to be used by Config Server",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "external": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string",
+                            "description": "Primary node of an external Config Server replicaset",
+                            "default": ""
+                        },
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Root password of the external Config Server replicaset",
+                            "default": ""
+                        },
+                        "replicasetName": {
+                            "type": "string",
+                            "description": "Replicaset name of an external Config Server",
+                            "default": ""
+                        },
+                        "replicasetKey": {
+                            "type": "string",
+                            "description": "Replicaset key of an external Config Server",
+                            "default": ""
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [
+                        "/bin/bash",
+                        "/entrypoint/replicaset-entrypoint.sh"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Config Server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 2
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                }
+            }
+        },
+        "mongos": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of replicas",
+                    "default": 1
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Configure pod resources",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "mongodbExtraFlags": {
+                    "type": "array",
+                    "description": "MongoDB&reg; additional command line flags",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Pod priority class name",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Mongos Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Mongos Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mongos Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Mongos Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Mongos Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Mongos Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Mongos Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Mongos Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulsets pod management policy, allows parallel startup of pods",
+                    "default": "OrderedReady"
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "updateStrategy for MongoDB&reg; Primary, Secondary and Arbiter statefulsets",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "config": {
+                    "type": "string",
+                    "description": "MongoDB&reg; configuration file",
+                    "default": ""
+                },
+                "configCM": {
+                    "type": "string",
+                    "description": "ConfigMap name with MongoDB&reg; configuration file (cannot be used with mongos.config)",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of a Secret containing extra env vars",
+                    "default": ""
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the pod",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the pod",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Array to add extra volumes. Requires setting `extraVolumeMounts`",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Array to add extra volume mounts. Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "useStatefulSet": {
+                    "type": "boolean",
+                    "description": "Use StatefulSet instead of Deployment",
+                    "default": false
+                },
+                "servicePerReplica": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create one service per mongos replica (must be used with statefulset)",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional service annotations (evaluate as a template)",
+                            "default": {}
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Service type",
+                            "default": "ClusterIP"
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "External traffic policy",
+                            "default": "Cluster"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "MongoDB&reg; service port",
+                            "default": 27017
+                        },
+                        "clusterIPs": {
+                            "type": "array",
+                            "description": "Array of static clusterIPs for each MongoDB@reg; replica. Length must be the same as mongos.replicaCount",
+                            "default": [],
+                            "items": {}
+                        },
+                        "nodePorts": {
+                            "type": "array",
+                            "description": "Array of node ports used for each MongoDB@reg; replica. Length must be the same as mongos.replicaCount",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalIPs": {
+                            "type": "array",
+                            "description": "External IP list to use with ClusterIP service type",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIPs": {
+                            "type": "array",
+                            "description": "Array of static IP Address to use for each replica LoadBalancer service type. Length must be the same as mongos.replicaCount",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "List of IP ranges allowed access to load balancer (if supported)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable pod disruption budget",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number of available mongo pods allowed (`0` to disable)",
+                            "default": 0
+                        },
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Maximum number of unavailable mongo pods allowed (`0` to disable)",
+                            "default": 1
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Whether to create a Service Account for mongos automatically",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of a Service Account to be used by mongos",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mongo container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 60
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 2
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                }
+            }
+        },
+        "shardsvr": {
+            "type": "object",
+            "properties": {
+                "dataNode": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of nodes in each shard replica set (the first node will be primary)",
+                            "default": 1
+                        },
+                        "resources": {
+                            "type": "object",
+                            "description": "Configure pod resources",
+                            "default": {}
+                        },
+                        "mongodbExtraFlags": {
+                            "type": "array",
+                            "description": "MongoDB&reg; additional command line flags",
+                            "default": [],
+                            "items": {}
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array",
+                            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                            "default": [],
+                            "items": {}
+                        },
+                        "priorityClassName": {
+                            "type": "string",
+                            "description": "Pod priority class name",
+                            "default": ""
+                        },
+                        "podAffinityPreset": {
+                            "type": "string",
+                            "description": "Data nodes Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "podAntiAffinityPreset": {
+                            "type": "string",
+                            "description": "Data nodes Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": "soft"
+                        },
+                        "nodeAffinityPreset": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Data nodes Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Data nodes Node label key to match Ignored if `affinity` is set.",
+                                    "default": ""
+                                },
+                                "values": {
+                                    "type": "array",
+                                    "description": "Data nodes Node label values to match. Ignored if `affinity` is set.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "affinity": {
+                            "type": "object",
+                            "description": "Data nodes Affinity for pod assignment",
+                            "default": {}
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "description": "Data nodes Node labels for pod assignment",
+                            "default": {}
+                        },
+                        "tolerations": {
+                            "type": "array",
+                            "description": "Data nodes Tolerations for pod assignment",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podManagementPolicy": {
+                            "type": "string",
+                            "description": "podManagementPolicy for the statefulset, allows parallel startup of pods",
+                            "default": "OrderedReady"
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "updateStrategy for MongoDB&reg; Primary, Secondary and Arbiter statefulsets",
+                                    "default": "RollingUpdate"
+                                }
+                            }
+                        },
+                        "hostAliases": {
+                            "type": "array",
+                            "description": "Deployment pod host aliases",
+                            "default": [],
+                            "items": {}
+                        },
+                        "config": {
+                            "type": "string",
+                            "description": "Entries for the MongoDB&reg; config file",
+                            "default": ""
+                        },
+                        "configCM": {
+                            "type": "string",
+                            "description": "ConfigMap name with MongoDB&reg; configuration (cannot be used with shardsvr.dataNode.config)",
+                            "default": ""
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "An array to add extra env vars",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "Name of a ConfigMap containing extra env vars",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Name of a Secret containing extra env vars",
+                            "default": ""
+                        },
+                        "sidecars": {
+                            "type": "array",
+                            "description": "Attach additional containers (evaluated as a template)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "initContainers": {
+                            "type": "array",
+                            "description": "Add init containers to the pod",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Additional pod annotations",
+                            "default": {}
+                        },
+                        "podLabels": {
+                            "type": "object",
+                            "description": "Additional pod labels",
+                            "default": {}
+                        },
+                        "extraVolumes": {
+                            "type": "array",
+                            "description": "Array to add extra volumes. Requires setting `extraVolumeMounts`",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Array to add extra mounts. Normally used with `extraVolumes`",
+                            "default": [],
+                            "items": {}
+                        },
+                        "schedulerName": {
+                            "type": "string",
+                            "description": "Use an alternate scheduler, e.g. \"stork\".",
+                            "default": ""
+                        },
+                        "pdb": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Enable pod disruption budget",
+                                    "default": false
+                                },
+                                "minAvailable": {
+                                    "type": "number",
+                                    "description": "Minimum number of available data pods allowed (`0` to disable)",
+                                    "default": 0
+                                },
+                                "maxUnavailable": {
+                                    "type": "number",
+                                    "description": "Maximum number of unavailable data pods allowed (`0` to disable)",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "serviceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Specifies whether a ServiceAccount should be created for shardsvr",
+                                    "default": false
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of a Service Account to be used by shardsvr data pods",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional Service Account annotations (evaluated as a template)",
+                                    "default": {}
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Automount service account token for the server service account",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable security context",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Group ID for the container",
+                                    "default": 1001
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set containers' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set containers' Security Context runAsNonRoot",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [
+                                "/bin/bash",
+                                "/entrypoint/replicaset-entrypoint.sh"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "type": "string",
+                            "description": "Seconds Redmine pod needs to terminate gracefully",
+                            "default": ""
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "for the Data container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 60
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 30
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 20
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 2
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 30
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 20
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 0
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 30
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use a PVC to persist data",
+                            "default": true
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at, useful when using different MongoDB&reg; images.",
+                            "default": "/bitnami/mongodb"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "Subdirectory of the volume to mount at (evaluated as a template)",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Storage class of backing PVC",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Use volume as ReadOnly or ReadWrite",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PersistentVolumeClaim size",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional volume annotations",
+                            "default": {}
+                        },
+                        "resourcePolicy": {
+                            "type": "string",
+                            "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                            "default": ""
+                        }
+                    }
+                },
+                "arbiter": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of arbiters in each shard replica set (the first node will be primary)",
+                            "default": 0
+                        },
+                        "hostAliases": {
+                            "type": "array",
+                            "description": "Deployment pod host aliases",
+                            "default": [],
+                            "items": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "description": "Configure pod resources",
+                            "default": {}
+                        },
+                        "mongodbExtraFlags": {
+                            "type": "array",
+                            "description": "MongoDB&reg; additional command line flags",
+                            "default": [],
+                            "items": {}
+                        },
+                        "topologySpreadConstraints": {
+                            "type": "array",
+                            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                            "default": [],
+                            "items": {}
+                        },
+                        "priorityClassName": {
+                            "type": "string",
+                            "description": "Pod priority class name",
+                            "default": ""
+                        },
+                        "podAffinityPreset": {
+                            "type": "string",
+                            "description": "Arbiter's Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "podAntiAffinityPreset": {
+                            "type": "string",
+                            "description": "Arbiter's Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": "soft"
+                        },
+                        "nodeAffinityPreset": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Arbiter's Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Arbiter's Node label key to match Ignored if `affinity` is set.",
+                                    "default": ""
+                                },
+                                "values": {
+                                    "type": "array",
+                                    "description": "Arbiter's Node label values to match. Ignored if `affinity` is set.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "affinity": {
+                            "type": "object",
+                            "description": "Arbiter's Affinity for pod assignment",
+                            "default": {}
+                        },
+                        "nodeSelector": {
+                            "type": "object",
+                            "description": "Arbiter's Node labels for pod assignment",
+                            "default": {}
+                        },
+                        "tolerations": {
+                            "type": "array",
+                            "description": "Arbiter's Tolerations for pod assignment",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podManagementPolicy": {
+                            "type": "string",
+                            "description": "Statefulset's pod management policy, allows parallel startup of pods",
+                            "default": "OrderedReady"
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "updateStrategy for MongoDB&reg; Primary, Secondary and Arbiter statefulsets",
+                                    "default": "RollingUpdate"
+                                }
+                            }
+                        },
+                        "config": {
+                            "type": "string",
+                            "description": "MongoDB&reg; configuration file",
+                            "default": ""
+                        },
+                        "configCM": {
+                            "type": "string",
+                            "description": "ConfigMap name with MongoDB&reg; configuration file (cannot be used with shardsvr.arbiter.config)",
+                            "default": ""
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "An array to add extra env vars",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "Name of a ConfigMap containing extra env vars",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Name of a Secret containing extra env vars",
+                            "default": ""
+                        },
+                        "sidecars": {
+                            "type": "array",
+                            "description": "Add sidecars to the pod",
+                            "default": [],
+                            "items": {}
+                        },
+                        "initContainers": {
+                            "type": "array",
+                            "description": "Add init containers to the pod",
+                            "default": [],
+                            "items": {}
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Additional pod annotations",
+                            "default": {}
+                        },
+                        "podLabels": {
+                            "type": "object",
+                            "description": "Additional pod labels",
+                            "default": {}
+                        },
+                        "extraVolumes": {
+                            "type": "array",
+                            "description": "Array to add extra volumes",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Array to add extra mounts (normally used with extraVolumes)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "schedulerName": {
+                            "type": "string",
+                            "description": "Use an alternate scheduler, e.g. \"stork\".",
+                            "default": ""
+                        },
+                        "serviceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Specifies whether a ServiceAccount should be created for shardsvr arbiter nodes",
+                                    "default": false
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of a Service Account to be used by shardsvr arbiter pods",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional Service Account annotations (evaluated as a template)",
+                                    "default": {}
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Automount service account token for the server service account",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable security context",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Group ID for the container",
+                                    "default": 1001
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set containers' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set containers' Security Context runAsNonRoot",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "type": "string",
+                            "description": "Seconds Redmine pod needs to terminate gracefully",
+                            "default": ""
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "for the arbiter container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 60
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 30
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 20
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 2
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 30
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 20
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 6
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 0
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 30
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MongoDB&reg; exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MongoDB&reg; exporter image name",
+                            "default": "bitnami/mongodb-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MongoDB&reg; exporter image tag",
+                            "default": "0.39.0-debian-11-r79"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MongoDB&reg; exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "MongoDB&reg; exporter image pull policy",
+                            "default": "Always"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "MongoDB&reg; exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "useTLS": {
+                    "type": "boolean",
+                    "description": "Whether to connect to MongoDB&reg; with TLS",
+                    "default": false
+                },
+                "extraArgs": {
+                    "type": "string",
+                    "description": "String with extra arguments to the metrics exporter",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 2
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Port of the Prometheus metrics container",
+                            "default": 9216
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.metrics.containerPort }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create PodMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace where podmonitor resource should be created",
+                            "default": "monitoring"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PodMonitors will be discovered by Prometheus",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/mongodb/values.schema.json
+++ b/bitnami/mongodb/values.schema.json
@@ -1,173 +1,3092 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "architecture": {
-      "type": "string",
-      "title": "MongoDB&reg; architecture",
-      "form": true,
-      "description": "Allowed values: `standalone` or `replicaset`"
-    },
-    "auth": {
-      "type": "object",
-      "title": "Authentication configuration",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Authentication",
-          "form": true
-        },
-        "rootUser": {
-          "type": "string",
-          "title": "MongoDB&reg; admin user",
-          "form": true,
-          "description": "Name of the admin user. Default is root"
-        },
-        "rootPassword": {
-          "type": "string",
-          "title": "MongoDB&reg; admin password",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "hidden": {
-            "value": false,
-            "path": "auth/enabled"
-          }
-        },
-        "database": {
-          "type": "string",
-          "title": "MongoDB&reg; custom database",
-          "description": "Name of the custom database to be created during the 1st initialization of MongoDB&reg;",
-          "form": true
-        },
-        "username": {
-          "type": "string",
-          "title": "MongoDB&reg; custom user",
-          "description": "Name of the custom user to be created during the 1st initialization of MongoDB&reg;. This user only has permissions on the MongoDB&reg; custom database",
-          "form": true
-        },
-        "password": {
-          "type": "string",
-          "title": "Password for MongoDB&reg; custom user",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "hidden": {
-            "value": false,
-            "path": "auth/enabled"
-          }
-        },
-        "replicaSetKey": {
-          "type": "string",
-          "title": "Key used for replica set authentication",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        }
-      }
-    },
-    "replicaCount": {
-      "type": "integer",
-      "form": true,
-      "title": "Number of MongoDB&reg; replicas",
-      "hidden": {
-        "value": "standalone",
-        "path": "architecture"
-      }
-    },
-    "configuration": {
-      "type": "string",
-      "title": "MongoDB&reg; Custom Configuration",
-      "form": true,
-      "render": "textArea"
-    },
-    "arbiter": {
-      "type": "object",
-      "title": "Arbiter configuration",
-      "form": true,
-      "properties": {
-        "configuration": {
-          "type": "string",
-          "title": "Arbiter Custom Configuration",
-          "form": true,
-          "render": "textArea",
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        }
-      }
-    },
-    "persistence": {
-      "type": "object",
-      "title": "Persistence configuration",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable persistence",
-          "description": "Enable persistence using Persistent Volume Claims"
-        },
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi",
-          "hidden": {
-            "value": false,
-            "path": "persistence/enabled"
-          }
-        }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "hidden": {
-        "value": false,
-        "path": "persistence/enabled"
-      },
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
-        },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "namespaceOverride": {
+                    "type": "string",
+                    "description": "Override the namespace for resource deployed by the chart, but can itself be overridden by the local namespaceOverride",
+                    "default": ""
+                }
             }
-          }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override mongodb.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override mongodb.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Mongo resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "topologyKey": {
+            "type": "string",
+            "description": "Override common lib default topology key. If empty - \"kubernetes.io/hostname\" is used",
+            "default": ""
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) image registry",
+                    "default": "bitnami/mongodb"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) image tag (immutable tags are recommended)",
+                    "default": "6.0.9-debian-11-r5"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Set to true if you would like to see extra information on logs",
+                    "default": false
+                }
+            }
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the scheduler (other than default) to dispatch pods",
+            "default": ""
+        },
+        "architecture": {
+            "type": "string",
+            "description": "MongoDB(&reg;) architecture (`standalone` or `replicaset`)",
+            "default": "standalone"
+        },
+        "useStatefulSet": {
+            "type": "boolean",
+            "description": "Set to true to use a StatefulSet instead of a Deployment (only when `architecture=standalone`)",
+            "default": false
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable authentication",
+                    "default": true
+                },
+                "rootUser": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) root user",
+                    "default": "root"
+                },
+                "rootPassword": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) root password",
+                    "default": ""
+                },
+                "usernames": {
+                    "type": "array",
+                    "description": "List of custom users to be created during the initialization",
+                    "default": [],
+                    "items": {}
+                },
+                "passwords": {
+                    "type": "array",
+                    "description": "List of passwords for the custom users set at `auth.usernames`",
+                    "default": [],
+                    "items": {}
+                },
+                "databases": {
+                    "type": "array",
+                    "description": "List of custom databases to be created during the initialization",
+                    "default": [],
+                    "items": {}
+                },
+                "username": {
+                    "type": "string",
+                    "description": "DEPRECATED: use `auth.usernames` instead",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "DEPRECATED: use `auth.passwords` instead",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "DEPRECATED: use `auth.databases` instead",
+                    "default": ""
+                },
+                "replicaSetKey": {
+                    "type": "string",
+                    "description": "Key used for authentication in the replicaset (only when `architecture=replicaset`)",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MongoDB(&reg;) TLS support between nodes in the cluster as well as between mongo clients and nodes",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate a custom CA and self-signed certificates",
+                    "default": true
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret with TLS certificates (keys: `mongodb-ca-cert`, `mongodb-ca-key`)",
+                    "default": ""
+                },
+                "caCert": {
+                    "type": "string",
+                    "description": "Custom CA certificated (base64 encoded)",
+                    "default": ""
+                },
+                "caKey": {
+                    "type": "string",
+                    "description": "CA certificate private key (base64 encoded)",
+                    "default": ""
+                },
+                "pemChainIncluded": {
+                    "type": "boolean",
+                    "description": "Flag to denote that the Certificate Authority (CA) certificates are bundled with the endpoint cert.",
+                    "default": false
+                },
+                "standalone": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret with TLS certificates (`tls.key`, `tls.crt`, `ca.crt`) or (`tls.key`, `tls.crt`) with tls.pemChainIncluded set as enabled.",
+                            "default": ""
+                        }
+                    }
+                },
+                "replicaset": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecrets": {
+                            "type": "array",
+                            "description": "Array of existing secrets with TLS certificates (`tls.key`, `tls.crt`, `ca.crt`) or (`tls.key`, `tls.crt`) with tls.pemChainIncluded set as enabled.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "hidden": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecrets": {
+                            "type": "array",
+                            "description": "Array of existing secrets with TLS certificates (`tls.key`, `tls.crt`, `ca.crt`) or (`tls.key`, `tls.crt`) with tls.pemChainIncluded set as enabled.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "arbiter": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret with TLS certificates (`tls.key`, `tls.crt`, `ca.crt`) or (`tls.key`, `tls.crt`) with tls.pemChainIncluded set as enabled.",
+                            "default": ""
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container TLS certs setup image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container TLS certs setup image repository",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container TLS certs setup image tag (immutable tags are recommended)",
+                            "default": "1.25.2-debian-11-r11"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container TLS certs setup image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container TLS certs setup image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container TLS certs specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraDnsNames": {
+                    "type": "array",
+                    "description": "Add extra dns names to the CA, can solve x509 auth issue for pod clients",
+                    "default": [],
+                    "items": {}
+                },
+                "mode": {
+                    "type": "string",
+                    "description": "Allows to set the tls mode which should be used when tls is enabled (options: `allowTLS`, `preferTLS`, `requireTLS`)",
+                    "default": "requireTLS"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container generate-tls-certs resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container generate-tls-certs resource requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "replicaSetName": {
+            "type": "string",
+            "description": "Name of the replica set (only when `architecture=replicaset`)",
+            "default": "rs0"
+        },
+        "replicaSetHostnames": {
+            "type": "boolean",
+            "description": "Enable DNS hostnames in the replicaset config (only when `architecture=replicaset`)",
+            "default": true
+        },
+        "enableIPv6": {
+            "type": "boolean",
+            "description": "Switch to enable/disable IPv6 on MongoDB(&reg;)",
+            "default": false
+        },
+        "directoryPerDB": {
+            "type": "boolean",
+            "description": "Switch to enable/disable DirectoryPerDB on MongoDB(&reg;)",
+            "default": false
+        },
+        "systemLogVerbosity": {
+            "type": "number",
+            "description": "MongoDB(&reg;) system log verbosity level",
+            "default": 0
+        },
+        "disableSystemLog": {
+            "type": "boolean",
+            "description": "Switch to enable/disable MongoDB(&reg;) system log",
+            "default": false
+        },
+        "disableJavascript": {
+            "type": "boolean",
+            "description": "Switch to enable/disable MongoDB(&reg;) server-side JavaScript execution",
+            "default": false
+        },
+        "enableJournal": {
+            "type": "boolean",
+            "description": "Switch to enable/disable MongoDB(&reg;) Journaling",
+            "default": true
+        },
+        "configuration": {
+            "type": "string",
+            "description": "MongoDB(&reg;) configuration file to be used for Primary and Secondary nodes",
+            "default": ""
+        },
+        "replicaSetConfigurationSettings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MongoDB(&reg;) Switch to enable/disable configuring MongoDB(&reg;) run time rs.conf settings",
+                    "default": false
+                },
+                "configuration": {
+                    "type": "object",
+                    "description": "run-time rs.conf settings",
+                    "default": {}
+                }
+            }
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "Name of existing ConfigMap with MongoDB(&reg;) configuration for Primary and Secondary nodes",
+            "default": ""
+        },
+        "initdbScripts": {
+            "type": "object",
+            "description": "Dictionary of initdb scripts",
+            "default": {}
+        },
+        "initdbScriptsConfigMap": {
+            "type": "string",
+            "description": "Existing ConfigMap with custom initdb scripts",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraFlags": {
+            "type": "array",
+            "description": "MongoDB(&reg;) additional command line flags",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to add to MongoDB(&reg;) pods",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "annotations": {
+            "type": "object",
+            "description": "Additional labels to be added to the MongoDB(&reg;) statefulset. Evaluated as a template",
+            "default": {}
+        },
+        "labels": {
+            "type": "object",
+            "description": "Annotations to be added to the MongoDB(&reg;) statefulset. Evaluated as a template",
+            "default": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of MongoDB(&reg;) nodes (only when `architecture=replicaset`)",
+            "default": 2
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Strategy to use to replace existing MongoDB(&reg;) pods. When architecture=standalone and useStatefulSet=false,",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Pod management policy for MongoDB(&reg;)",
+            "default": "OrderedReady"
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "MongoDB(&reg;) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "MongoDB(&reg;) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "MongoDB(&reg;) Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "MongoDB(&reg;) Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "MongoDB(&reg;) Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "MongoDB(&reg;) Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "MongoDB(&reg;) Spread Constraints for Pods",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook for the MongoDB(&reg;) container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "MongoDB(&reg;) Termination Grace Period",
+            "default": ""
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "MongoDB(&reg;) pod labels",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "MongoDB(&reg;) Pod annotations",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of the existing priority class to be used by MongoDB(&reg;) pod(s)",
+            "default": ""
+        },
+        "runtimeClassName": {
+            "type": "string",
+            "description": "Name of the runtime class to be used by MongoDB(&reg;) pod(s)",
+            "default": ""
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MongoDB(&reg;) pod(s)' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the volumes of the MongoDB(&reg;) pod(s)",
+                    "default": 1001
+                },
+                "sysctls": {
+                    "type": "array",
+                    "description": "sysctl settings of the MongoDB(&reg;) pod(s)'",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MongoDB(&reg;) container(s)' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the MongoDB(&reg;) container",
+                    "default": 1001
+                },
+                "runAsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the MongoDB(&reg;) container",
+                    "default": 0
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set MongoDB(&reg;) container's Security Context runAsNonRoot",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Is it possible to escalate MongoDB(&reg;) pod(s) privileges",
+                    "default": false
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set MongoDB(&reg;) container's Security Context seccompProfile type",
+                            "default": "RuntimeDefault"
+                        }
+                    }
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "description": "Set MongoDB(&reg;) container's Security Context capabilities to drop",
+                            "default": [
+                                "ALL"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for MongoDB(&reg;) containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for MongoDB(&reg;) containers",
+                    "default": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "mongodb": {
+                    "type": "number",
+                    "description": "MongoDB(&reg;) container port",
+                    "default": 27017
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 10
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 10
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 30
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe for MongoDB(&reg;) containers",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe for MongoDB(&reg;) containers",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe for MongoDB(&reg;) containers",
+            "default": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers for the hidden node pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers for the MongoDB(&reg;) pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the MongoDB(&reg;) container(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes to the MongoDB(&reg;) statefulset",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation for MongoDB(&reg;) pod(s)",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of MongoDB(&reg;) pods that must still be available after the eviction",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of MongoDB(&reg;) pods that may be made unavailable after the eviction",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "nameOverride": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) service name",
+                    "default": ""
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type (only for standalone architecture)",
+                    "default": "ClusterIP"
+                },
+                "portName": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) service port name (only for standalone architecture)",
+                    "default": "mongodb"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "number",
+                            "description": "MongoDB(&reg;) service port.",
+                            "default": 27017
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "string",
+                            "description": "Port to bind to for NodePort and LoadBalancer service types (only for standalone architecture)",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "MongoDB(&reg;) service cluster IP (only for standalone architecture)",
+                    "default": ""
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "Specify the externalIP value ClusterIP service type (only for standalone architecture)",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for MongoDB(&reg;) Service (only for standalone architecture)",
+                    "default": ""
+                },
+                "loadBalancerClass": {
+                    "type": "string",
+                    "description": "loadBalancerClass for MongoDB(&reg;) Service (only for standalone architecture)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Address(es) that are allowed when service is LoadBalancer (only for standalone architecture)",
+                    "default": [],
+                    "items": {}
+                },
+                "allocateLoadBalancerNodePorts": {
+                    "type": "boolean",
+                    "description": "Wheter to allocate node ports when service type is LoadBalancer",
+                    "default": true
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations that may be required",
+                    "default": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "service external traffic policy (only for standalone architecture)",
+                    "default": "Local"
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "externalAccess": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Kubernetes external cluster access to MongoDB(&reg;) nodes (only for replicaset architecture)",
+                    "default": false
+                },
+                "autoDiscovery": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable using an init container to auto-detect external IPs by querying the K8s API",
+                            "default": false
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image repository",
+                                    "default": "bitnami/kubectl"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image tag (immutable tags are recommended)",
+                                    "default": "1.25.13-debian-11-r5"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Init container auto-discovery image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Init container auto-discovery image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "Init container auto-discovery resource limits",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "Init container auto-discovery resource requests",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalMaster": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use external master for bootstrapping",
+                            "default": false
+                        },
+                        "host": {
+                            "type": "string",
+                            "description": "External master host to bootstrap from",
+                            "default": ""
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Port for MongoDB(&reg;) service external master host",
+                            "default": 27017
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type for external access. Allowed values: NodePort, LoadBalancer or ClusterIP",
+                            "default": "LoadBalancer"
+                        },
+                        "portName": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) port name used for external access when service type is LoadBalancer",
+                            "default": "mongodb"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mongodb": {
+                                    "type": "number",
+                                    "description": "MongoDB(&reg;) port used for external access when service type is LoadBalancer",
+                                    "default": 27017
+                                }
+                            }
+                        },
+                        "loadBalancerIPs": {
+                            "type": "array",
+                            "description": "Array of load balancer IPs for MongoDB(&reg;) nodes",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerClass": {
+                            "type": "string",
+                            "description": "loadBalancerClass when service type is LoadBalancer",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address(es) that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "allocateLoadBalancerNodePorts": {
+                            "type": "boolean",
+                            "description": "Wheter to allocate node ports when service type is LoadBalancer",
+                            "default": true
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) service external traffic policy",
+                            "default": "Local"
+                        },
+                        "nodePorts": {
+                            "type": "array",
+                            "description": "Array of node ports used to configure MongoDB(&reg;) advertised hostname when service type is NodePort",
+                            "default": [],
+                            "items": {}
+                        },
+                        "domain": {
+                            "type": "string",
+                            "description": "Domain or external IP used to configure MongoDB(&reg;) advertised hostname when service type is NodePort",
+                            "default": ""
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Service annotations for external access",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "hidden": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kubernetes external cluster access to MongoDB(&reg;) hidden nodes",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Kubernetes Service type for external access. Allowed values: NodePort or LoadBalancer",
+                                    "default": "LoadBalancer"
+                                },
+                                "portName": {
+                                    "type": "string",
+                                    "description": "MongoDB(&reg;) port name used for external access when service type is LoadBalancer",
+                                    "default": "mongodb"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "mongodb": {
+                                            "type": "number",
+                                            "description": "MongoDB(&reg;) port used for external access when service type is LoadBalancer",
+                                            "default": 27017
+                                        }
+                                    }
+                                },
+                                "loadBalancerIPs": {
+                                    "type": "array",
+                                    "description": "Array of load balancer IPs for MongoDB(&reg;) nodes",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerClass": {
+                                    "type": "string",
+                                    "description": "loadBalancerClass when service type is LoadBalancer",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Address(es) that are allowed when service is LoadBalancer",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "allocateLoadBalancerNodePorts": {
+                                    "type": "boolean",
+                                    "description": "Wheter to allocate node ports when service type is LoadBalancer",
+                                    "default": true
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "MongoDB(&reg;) service external traffic policy",
+                                    "default": "Local"
+                                },
+                                "nodePorts": {
+                                    "type": "array",
+                                    "description": "Array of node ports used to configure MongoDB(&reg;) advertised hostname when service type is NodePort. Length must be the same as replicaCount",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "domain": {
+                                    "type": "string",
+                                    "description": "Domain or external IP used to configure MongoDB(&reg;) advertised hostname when service type is NodePort",
+                                    "default": ""
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Service annotations for external access",
+                                    "default": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MongoDB(&reg;) data persistence using PVC",
+                    "default": true
+                },
+                "medium": {
+                    "type": "string",
+                    "description": "Provide a medium for `emptyDir` volumes.",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)",
+                    "default": ""
+                },
+                "resourcePolicy": {
+                    "type": "string",
+                    "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for MongoDB(&reg;) data volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PV Access Mode",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for MongoDB(&reg;) data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "PVC annotations",
+                    "default": {}
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Path to mount the volume at",
+                    "default": "/bitnami/mongodb"
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "Subdirectory of the volume to mount at",
+                    "default": ""
+                },
+                "volumeClaimTemplates": {
+                    "type": "object",
+                    "properties": {
+                        "selector": {
+                            "type": "object",
+                            "description": "A label query over volumes to consider for binding (e.g. when using local volumes)",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Custom PVC requests attributes",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Add dataSource to the VolumeClaimTemplate",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "backup": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the logical dump of the database \"regularly\"",
+                    "default": false
+                },
+                "cronjob": {
+                    "type": "object",
+                    "properties": {
+                        "schedule": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter schedule",
+                            "default": "@daily"
+                        },
+                        "concurrencyPolicy": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter concurrencyPolicy",
+                            "default": "Allow"
+                        },
+                        "failedJobsHistoryLimit": {
+                            "type": "number",
+                            "description": "Set the cronjob parameter failedJobsHistoryLimit",
+                            "default": 1
+                        },
+                        "successfulJobsHistoryLimit": {
+                            "type": "number",
+                            "description": "Set the cronjob parameter successfulJobsHistoryLimit",
+                            "default": 3
+                        },
+                        "startingDeadlineSeconds": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter startingDeadlineSeconds",
+                            "default": ""
+                        },
+                        "ttlSecondsAfterFinished": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter ttlSecondsAfterFinished",
+                            "default": ""
+                        },
+                        "restartPolicy": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter restartPolicy",
+                            "default": "OnFailure"
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "User ID for the backup container",
+                                    "default": 1001
+                                },
+                                "runAsGroup": {
+                                    "type": "number",
+                                    "description": "Group ID for the backup container",
+                                    "default": 0
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set backup container's Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Is the container itself readonly",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Is it possible to escalate backup pod(s) privileges",
+                                    "default": false
+                                },
+                                "seccompProfile": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Set backup container's Security Context seccompProfile type",
+                                            "default": "RuntimeDefault"
+                                        }
+                                    }
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set backup container's Security Context capabilities to drop",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Set backup container's command to run",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Set the cronjob labels",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Set the cronjob annotations",
+                            "default": {}
+                        },
+                        "storage": {
+                            "type": "object",
+                            "properties": {
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)",
+                                    "default": ""
+                                },
+                                "resourcePolicy": {
+                                    "type": "string",
+                                    "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                                    "default": ""
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class for the backup data volume",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "PV Access Mode",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "PVC Storage Request for the backup data volume",
+                                    "default": "8Gi"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "PVC annotations",
+                                    "default": {}
+                                },
+                                "mountPath": {
+                                    "type": "string",
+                                    "description": "Path to mount the volume at ",
+                                    "default": "/backup/mongodb"
+                                },
+                                "subPath": {
+                                    "type": "string",
+                                    "description": "Subdirectory of the volume to mount at",
+                                    "default": ""
+                                },
+                                "volumeClaimTemplates": {
+                                    "type": "object",
+                                    "properties": {
+                                        "selector": {
+                                            "type": "object",
+                                            "description": "A label query over volumes to consider for binding (e.g. when using local volumes)",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for MongoDB(&reg;) pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created serviceAccount",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create & use RBAC resources or not",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom rules to create following the role specification",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Enable privilege escalation",
+                    "default": false
+                },
+                "privileged": {
+                    "type": "boolean",
+                    "description": "Allow privileged",
+                    "default": false
+                },
+                "spec": {
+                    "type": "object",
+                    "description": "Specify the full spec to use for Pod Security Policy",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r51"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the volumePermissions container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "arbiter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable deploying the arbiter",
+                    "default": true
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Arbiter configuration file to be used",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Arbiter configuration",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Arbiter additional command line flags",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to Arbiter pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional labels to be added to the Arbiter statefulset",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Annotations to be added to the Arbiter statefulset",
+                    "default": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "MongoDB(&reg;) Spread Constraints for arbiter Pods",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the Arbiter container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Arbiter Termination Grace Period",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Strategy that will be employed to update Pods in the StatefulSet",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Pod management policy for MongoDB(&reg;)",
+                    "default": "OrderedReady"
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the scheduler (other than default) to dispatch pods",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Arbiter Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Arbiter Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Arbiter Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Arbiter Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Arbiter Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Arbiter Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Arbiter Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Arbiter Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Arbiter pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Arbiter Pod annotations",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Name of the existing priority class to be used by Arbiter pod(s)",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by Arbiter pod(s)",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Arbiter pod(s)' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the volumes of the Arbiter pod(s)",
+                            "default": 1001
+                        },
+                        "sysctls": {
+                            "type": "array",
+                            "description": "sysctl settings of the Arbiter pod(s)'",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Arbiter container(s)' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Arbiter container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the Arbiter container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Arbiter containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Is it possible to escalate Arbiter pod(s) privileges",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Arbiter container's Security Context seccompProfile type",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Arbiter container's Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Arbiter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Arbiter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "number",
+                            "description": "MongoDB(&reg;) arbiter container port",
+                            "default": 27017
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for Arbiter containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for Arbiter containers",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for Arbiter containers",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers for the Arbiter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers for the Arbiter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Arbiter container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes to the Arbiter statefulset",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Arbiter pod(s)",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of Arbiter pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of Arbiter pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "nameOverride": {
+                            "type": "string",
+                            "description": "The arbiter service name",
+                            "default": ""
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mongodb": {
+                                    "type": "number",
+                                    "description": "MongoDB(&reg;) service port",
+                                    "default": 27017
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations that may be required",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "hidden": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable deploying the hidden nodes",
+                    "default": false
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Hidden node configuration file to be used",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Hidden node configuration",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Hidden node additional command line flags",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to Hidden node pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars (in case of sensitive data)",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional labels to be added to thehidden node statefulset",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Annotations to be added to the hidden node statefulset",
+                    "default": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "MongoDB(&reg;) Spread Constraints for hidden Pods",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook for the Hidden container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of hidden nodes (only when `architecture=replicaset`)",
+                    "default": 1
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Hidden Termination Grace Period",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Strategy that will be employed to update Pods in the StatefulSet",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Pod management policy for hidden node",
+                    "default": "OrderedReady"
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the scheduler (other than default) to dispatch pods",
+                    "default": ""
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Hidden node Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Hidden node Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Hidden Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Hidden Node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Hidden Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Hidden node Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Hidden node Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Hidden node Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Hidden node pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Hidden node Pod annotations",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Name of the existing priority class to be used by hidden node pod(s)",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "Name of the runtime class to be used by hidden node pod(s)",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Hidden pod(s)' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the volumes of the Hidden pod(s)",
+                            "default": 1001
+                        },
+                        "sysctls": {
+                            "type": "array",
+                            "description": "sysctl settings of the Hidden pod(s)'",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Hidden container(s)' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Hidden container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the Hidden container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Hidden containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Hidden containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Hidden container's Security Context seccompProfile type",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Hidden container's Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for hidden node containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for hidden node containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "mongodb": {
+                            "type": "number",
+                            "description": "MongoDB(&reg;) hidden container port",
+                            "default": 27017
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for hidden node containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for hidden node containers",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for MongoDB(&reg;) containers",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the MongoDB(&reg;) Hidden pods.",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers for the hidden node pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the hidden node container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes to the hidden node statefulset",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for hidden node pod(s)",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of hidden node pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of hidden node pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable hidden node data persistence using PVC",
+                            "default": true
+                        },
+                        "medium": {
+                            "type": "string",
+                            "description": "Provide a medium for `emptyDir` volumes.",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for hidden node data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PV Access Mode",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for hidden node data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "PVC annotations",
+                            "default": {}
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at, useful when using different MongoDB(&reg;) images.",
+                            "default": "/bitnami/mongodb"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to, useful in dev environments",
+                            "default": ""
+                        },
+                        "volumeClaimTemplates": {
+                            "type": "object",
+                            "properties": {
+                                "selector": {
+                                    "type": "object",
+                                    "description": "A label query over volumes to consider for binding (e.g. when using local volumes)",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "Custom PVC requests attributes",
+                                    "default": {}
+                                },
+                                "dataSource": {
+                                    "type": "object",
+                                    "description": "Set volumeClaimTemplate dataSource",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "portName": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) service port name",
+                            "default": "mongodb"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mongodb": {
+                                    "type": "number",
+                                    "description": "MongoDB(&reg;) service port",
+                                    "default": 27017
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations that may be required",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable using a sidecar Prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) Prometheus exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) Prometheus exporter image repository",
+                            "default": "bitnami/mongodb-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) Prometheus exporter image tag (immutable tags are recommended)",
+                            "default": "0.39.0-debian-11-r85"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "MongoDB(&reg;) Prometheus exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "username": {
+                    "type": "string",
+                    "description": "String with username for the metrics exporter",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "String with password for the metrics exporter",
+                    "default": ""
+                },
+                "compatibleMode": {
+                    "type": "boolean",
+                    "description": "Enables old style mongodb-exporter metrics",
+                    "default": true
+                },
+                "collector": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean",
+                            "description": "Enable all collectors. Same as enabling all individual metrics",
+                            "default": false
+                        },
+                        "diagnosticdata": {
+                            "type": "boolean",
+                            "description": "Boolean Enable collecting metrics from getDiagnosticData",
+                            "default": true
+                        },
+                        "replicasetstatus": {
+                            "type": "boolean",
+                            "description": "Boolean Enable collecting metrics from replSetGetStatus",
+                            "default": true
+                        },
+                        "dbstats": {
+                            "type": "boolean",
+                            "description": "Boolean Enable collecting metrics from dbStats",
+                            "default": false
+                        },
+                        "topmetrics": {
+                            "type": "boolean",
+                            "description": "Boolean Enable collecting metrics from top admin command",
+                            "default": false
+                        },
+                        "indexstats": {
+                            "type": "boolean",
+                            "description": "Boolean Enable collecting metrics from $indexStats",
+                            "default": false
+                        },
+                        "collstats": {
+                            "type": "boolean",
+                            "description": "Boolean Enable collecting metrics from $collStats",
+                            "default": false
+                        },
+                        "collstatsColls": {
+                            "type": "array",
+                            "description": "List of \\<databases\\>.\\<collections\\> to get $collStats",
+                            "default": [],
+                            "items": {}
+                        },
+                        "indexstatsColls": {
+                            "type": "array",
+                            "description": "List - List of \\<databases\\>.\\<collections\\> to get $indexStats",
+                            "default": [],
+                            "items": {}
+                        },
+                        "collstatsLimit": {
+                            "type": "number",
+                            "description": "Number - Disable collstats, dbstats, topmetrics and indexstats collector if there are more than \\<n\\> collections. 0=No limit",
+                            "default": 0
+                        }
+                    }
+                },
+                "extraFlags": {
+                    "type": "string",
+                    "description": "String with extra flags to the metrics exporter",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for Prometheus exporter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for Prometheus exporter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Port of the Prometheus metrics container",
+                    "default": 9216
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.metrics }}"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Type of the Prometheus metrics service",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Port of the Prometheus metrics service",
+                                    "default": 9216
+                                }
+                            }
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 30
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for MongoDB(&reg;) containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for MongoDB(&reg;) containers",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for MongoDB(&reg;) containers",
+                    "default": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the metrics container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricsRelabelConfigs to apply to samples before ingestion.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set this to true to create prometheusRules for Prometheus operator",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRules will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace where prometheusRules resource should be created",
+                            "default": ""
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Rules to be created, check values for an example",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/moodle/values.schema.json
+++ b/bitnami/moodle/values.schema.json
@@ -1,0 +1,1280 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override moodle.fullname template",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override moodle.fullname template",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Harbor resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Harbor resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array with extra yaml to deploy with the chart. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Moodle image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Moodle image repository",
+                    "default": "bitnami/moodle"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Moodle image tag (immutable tags are recommended)",
+                    "default": "4.2.2-debian-11-r5"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Moodle image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Moodle image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Moodle replicas (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "moodleSkipInstall": {
+            "type": "boolean",
+            "description": "Skip Moodle&trade; installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "moodleSiteName": {
+            "type": "string",
+            "description": "Site name",
+            "default": ""
+        },
+        "moodleLang": {
+            "type": "string",
+            "description": "Site language",
+            "default": ""
+        },
+        "moodleUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "moodlePassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "moodleEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": true
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra env vars",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Extra init containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Extra sidecar containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Moodle&trade; pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Moodle&trade; pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "sessionAffinity": {
+            "type": "string",
+            "description": "Control where client requests go, to the same pod or round-robin",
+            "default": "None"
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "customStorageClass": {
+                    "type": "object",
+                    "description": "Create a custom storage class",
+                    "default": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Moodle",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Moodle",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Moodle",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "Host mount path for Moodle",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity type",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Map of node/pod affinities",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "description": "CPU/Memory resource limits",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Moodle&trade; pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Moodle&trade; pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Moodle&trade; containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Moodle&trade; containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Moodle&trade; containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/login/index.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/login/index.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/login/index.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "string",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": ""
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes HTTPS node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service load balancer source ranges",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the Moodle&trade; Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Moodle&trade; service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the ingress is enabled, a host pointing to this will be created",
+                    "default": "moodle.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Moodle&trade;. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_moodle"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_moodle"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "PVC Access Modes for Moodle&trade; volume",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of the existing database",
+                    "default": ""
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_moodle"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_moodle"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Apache exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus metrics service type",
+                            "default": "LoadBalancer"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Prometheus metrics service port",
+                            "default": 9117
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`, otherwise leave blank",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Prometheus metrics service service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Prometheus metrics service Cluster IP",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Prometheus metrics service service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.metrics.service.port }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Exporter resource requests/limit",
+                    "default": {}
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables (eg proxy)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by Moodle's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Moodle only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Moodle. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Moodle. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/multus-cni/values.schema.json
+++ b/bitnami/multus-cni/values.schema.json
@@ -1,0 +1,505 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override multus-cni.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override multus-cni.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Multus CNI resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Multus CNI resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Multus CNI image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Multus CNI Image name",
+                    "default": "bitnami/multus-cni"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Multus CNI Image tag",
+                    "default": "4.0.2-debian-11-r81"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Multus CNI image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Multus CNI image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "CNIVersion": {
+            "type": "string",
+            "description": "CNI version",
+            "default": "0.3.0"
+        },
+        "hostCNIBinDir": {
+            "type": "string",
+            "description": "CNI binary dir in the host machine to mount",
+            "default": "/opt/cni/bin"
+        },
+        "hostCNINetDir": {
+            "type": "string",
+            "description": "CNI net.d dir in the host machine to mount",
+            "default": "/etc/cni/net.d"
+        },
+        "CNIMountPath": {
+            "type": "string",
+            "description": "Path inside the container to mount the CNI dirs",
+            "default": "/bitnami/multus-cni/host"
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Multus CNI pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the init container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Multus CNI pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Multus CNI pods' group ID",
+                    "default": 0
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Multus CNI containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Multus CNI containers' Security Context",
+                    "default": 0
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Multus CNI container's Security Context runAsNonRoot",
+                    "default": false
+                },
+                "privileged": {
+                    "type": "boolean",
+                    "description": "Set Multus CNI container's Security Context privileged",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Multus CNI pod",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/mxnet/values.schema.json
+++ b/bitnami/mxnet/values.schema.json
@@ -1,0 +1,1798 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace template",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Apache MXNet (Incubating) image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Apache MXNet (Incubating) image repository",
+                    "default": "bitnami/mxnet"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Apache MXNet (Incubating) image tag (immutable tags are recommended)",
+                    "default": "1.9.1-debian-11-r379"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Apache MXNet (Incubating) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Apache MXNet (Incubating) image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "entrypoint": {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "description": "",
+                    "default": ""
+                },
+                "workDir": {
+                    "type": "string",
+                    "description": "",
+                    "default": "/app"
+                },
+                "args": {
+                    "type": "string",
+                    "description": "",
+                    "default": ""
+                }
+            }
+        },
+        "mode": {
+            "type": "string",
+            "description": "Apache MXNet (Incubating) deployment mode. Can be `standalone` or `distributed`",
+            "default": "standalone"
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with sensitive data to mount in the pods",
+            "default": ""
+        },
+        "configMap": {
+            "type": "string",
+            "description": "Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating)",
+            "default": ""
+        },
+        "cloneFilesFromGit": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable in order to download files from git repository",
+                    "default": false
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Repository to clone",
+                    "default": ""
+                },
+                "revision": {
+                    "type": "string",
+                    "description": "Branch name to clone",
+                    "default": "master"
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Add extra volume mounts for the GIT container",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Use a PVC to persist data",
+                    "default": false
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "discourse & sidekiq data Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Use a existing PVC which must be created manually before bound",
+                    "default": ""
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Path to mount the volume at",
+                    "default": "/bitnami/mxnet"
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Mode",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume annotations",
+                    "default": {}
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to all the pods",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for all the pods",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for all the pods",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array to add extra volumes (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array to add extra mounts (normally used with extraVolumes, evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pods (scheduler, worker and server nodes)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Attach additional init containers to the pods (scheduler, worker and server nodes)",
+            "default": [],
+            "items": {}
+        },
+        "standalone": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mxnet standalone pods assignment",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `standalone.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `standalone.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `standalone.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mxnet standalone pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `standalone.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `standalone.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mxnet standalone pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mxnet standalone pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mxnet standalone pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mxnet standalone pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet standalone pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mxnet standalone pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet standalone containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mxnet standalone containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mxnet standalone container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mxnet standalone container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mxnet standalone nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mxnet standalone nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mxnet standalone nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mxnet standalone pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mxnet standalone container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "mxnet": {
+                            "type": "number",
+                            "description": "Mxnet container port",
+                            "default": 9092
+                        }
+                    }
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mxnet standalone pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mxnet standalone pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mxnet standalone deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mxnet standalone pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Mxnet standalone pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mxnet container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mxnet container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Server nodes that will execute your code",
+                    "default": 1
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mxnet server pods assignment",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `server.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `server.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mxnet server pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mxnet server pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mxnet server pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mxnet server pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mxnet server pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mxnet server pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mxnet server containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mxnet server container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mxnet server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mxnet server nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mxnet server nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mxnet server nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mxnet server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mxnet server container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mxnet server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mxnet server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mxnet server deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mxnet server pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Mxnet server pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Mxnet server pods",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mxnet container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mxnet container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                }
+            }
+        },
+        "worker": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Worker nodes that will execute your code",
+                    "default": 1
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mxnet worker pods assignment",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `worker.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `worker.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mxnet worker pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mxnet worker pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mxnet worker pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mxnet worker pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mxnet worker pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet worker pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mxnet worker pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet worker containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mxnet worker containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mxnet worker container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mxnet worker container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mxnet worker nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mxnet worker nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mxnet worker nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mxnet worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mxnet worker container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mxnet worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mxnet worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mxnet worker deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mxnet worker pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Mxnet worker pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of Mxnet worker pods",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mxnet container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mxnet container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                }
+            }
+        },
+        "scheduler": {
+            "type": "object",
+            "properties": {
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "mxnet": {
+                            "type": "number",
+                            "description": "The port used to communicate with the scheduler",
+                            "default": 9092
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Mxnet scheduler pods assignment",
+                    "default": {}
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `scheduler.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `scheduler.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Mxnet scheduler pods assignment",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Mxnet scheduler pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Mxnet scheduler pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Mxnet scheduler pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Mxnet scheduler pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet scheduler pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Mxnet scheduler pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Mxnet scheduler containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Mxnet scheduler containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Mxnet scheduler container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Mxnet scheduler container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Mxnet scheduler nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Mxnet scheduler nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Mxnet scheduler nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Mxnet scheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Mxnet scheduler container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Mxnet scheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Mxnet scheduler pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Mxnet scheduler deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Mxnet scheduler pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the Mxnet scheduler pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Mxnet container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Mxnet container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mxnet": {
+                                    "type": "number",
+                                    "description": "Scheduler Service port",
+                                    "default": 9092
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "mxnet": {
+                                    "type": "string",
+                                    "description": "Node port for Mxnet scheduler",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Scheduler service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Scheduler service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Scheduler service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Scheduler service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Scheduler service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "git": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Git image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Git image repository",
+                    "default": "bitnami/git"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Git image tag (immutable tags are recommended)",
+                    "default": "2.42.0-debian-11-r11"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Git image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/mysql/values.schema.json
+++ b/bitnami/mysql/values.schema.json
@@ -1,195 +1,1670 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "architecture": {
-      "type": "string",
-      "title": "MySQL architecture",
-      "form": true,
-      "description": "Allowed values: `standalone` or `replication`",
-      "enum": ["standalone", "replication"]
-    },
-    "auth": {
-      "type": "object",
-      "title": "Authentication configuration",
-      "form": true,
-      "required": ["username", "password"],
-      "if": {
-        "properties": {
-          "createDatabase":  { "enum": [ true ] }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Cluster domain",
+            "default": "cluster.local"
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all MySQL resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all MySQL resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array with extra yaml to deploy with the chart. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "MySQL image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "MySQL image repository",
+                    "default": "bitnami/mysql"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "MySQL image tag (immutable tags are recommended)",
+                    "default": "8.0.34-debian-11-r31"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "MySQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "MySQL image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "MySQL architecture (`standalone` or `replication`)",
+            "default": "standalone"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "rootPassword": {
+                    "type": "string",
+                    "description": "Password for the `root` user. Ignored if existing secret is provided",
+                    "default": ""
+                },
+                "createDatabase": {
+                    "type": "boolean",
+                    "description": "Whether to create the .Values.auth.database or not",
+                    "default": true
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name for a custom database to create",
+                    "default": "my_database"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Name for a custom user to create",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the new user. Ignored if existing secret is provided",
+                    "default": ""
+                },
+                "replicationUser": {
+                    "type": "string",
+                    "description": "MySQL replication user",
+                    "default": "replicator"
+                },
+                "replicationPassword": {
+                    "type": "string",
+                    "description": "MySQL replication user password. Ignored if existing secret is provided",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use existing secret for password details. The secret has to contain the keys `mysql-root-password`, `mysql-replication-password` and `mysql-password`",
+                    "default": ""
+                },
+                "usePasswordFiles": {
+                    "type": "boolean",
+                    "description": "Mount credentials as files instead of using an environment variable",
+                    "default": false
+                },
+                "customPasswordFiles": {
+                    "type": "object",
+                    "description": "Use custom password files when `auth.usePasswordFiles` is set to `true`. Define path for keys `root` and `user`, also define `replicator` if `architecture` is set to `replication`",
+                    "default": {}
+                }
+            }
+        },
+        "initdbScripts": {
+            "type": "object",
+            "description": "Dictionary of initdb scripts",
+            "default": {}
+        },
+        "initdbScriptsConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)",
+            "default": ""
+        },
+        "startdbScripts": {
+            "type": "object",
+            "description": "Dictionary of startdb scripts",
+            "default": {}
+        },
+        "startdbScriptsConfigMap": {
+            "type": "string",
+            "description": "ConfigMap with the startdb scripts (Note: Overrides `startdbScripts`)",
+            "default": ""
+        },
+        "primary": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the primary database (eg primary, master, leader, ...)",
+                    "default": "primary"
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command on MySQL Primary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args on MySQL Primary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the MySQL Primary container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Configure MySQL Primary with a custom my.cnf file",
+                    "default": "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-name-resolve\nexplicit_defaults_for_timestamp\nbasedir=/opt/bitnami/mysql\nplugin_dir=/opt/bitnami/mysql/lib/plugin\nport=3306\nsocket=/opt/bitnami/mysql/tmp/mysql.sock\ndatadir=/bitnami/mysql/data\ntmpdir=/opt/bitnami/mysql/tmp\nmax_allowed_packet=16M\nbind-address=*\npid-file=/opt/bitnami/mysql/tmp/mysqld.pid\nlog-error=/opt/bitnami/mysql/logs/mysqld.log\ncharacter-set-server=UTF8\ncollation-server=utf8_general_ci\nslow_query_log=0\nlong_query_time=10.0\n\n[client]\nport=3306\nsocket=/opt/bitnami/mysql/tmp/mysql.sock\ndefault-character-set=UTF8\nplugin_dir=/opt/bitnami/mysql/lib/plugin\n\n[manager]\nport=3306\nsocket=/opt/bitnami/mysql/tmp/mysql.sock\npid-file=/opt/bitnami/mysql/tmp/mysqld.pid"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with MySQL Primary configuration.",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for the MySQL primary statefulset",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations for MySQL primary pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "MySQL primary pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "MySQL primary pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MySQL primary node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "MySQL primary node label key to match Ignored if `primary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "MySQL primary node label values to match. Ignored if `primary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for MySQL primary pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for MySQL primary pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for MySQL primary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "MySQL primary pods' priorityClassName",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "MySQL primary pods' runtimeClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the MySQL primary pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of MySQL primary pods",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for MySQL primary pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the mounted volumes' filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "MySQL primary container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the MySQL primary container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set MySQL primary container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for MySQL primary containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for MySQL primary containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for MySQL primary containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for MySQL primary containers",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for MySQL primary containers",
+                    "default": {}
+                },
+                "extraFlags": {
+                    "type": "string",
+                    "description": "MySQL primary additional command line flags",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on MySQL primary containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for MySQL primary containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for MySQL primary containers",
+                    "default": ""
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on MySQL primary replicas using a `PersistentVolumeClaim`. If false, use emptyDir",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing `PersistentVolumeClaim` for MySQL primary replicas",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The name of a volume's sub path to mount for persistence",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "MySQL primary persistent volume storage Class",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "MySQL primary persistent volume claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "MySQL primary persistent volume access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "MySQL primary persistent volume size",
+                            "default": "8Gi"
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes to the MySQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the MySQL Primary container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers for the MySQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers for the MySQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MySQL Primary K8s service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "number",
+                                    "description": "MySQL Primary K8s service port",
+                                    "default": 3306
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "string",
+                                    "description": "MySQL Primary K8s service node port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "MySQL Primary K8s service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "MySQL Primary loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when MySQL Primary service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for MySQL primary service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for headless MySQL primary service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for MySQL primary pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of MySQL primary pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of MySQL primary pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "MySQL Primary pod label. If labels are same as commonLabels , this will take precedence",
+                    "default": {}
+                }
+            }
+        },
+        "secondary": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the secondary database (eg secondary, slave, ...)",
+                    "default": "secondary"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of MySQL secondary replicas",
+                    "default": 1
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command on MySQL Secondary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args on MySQL Secondary container(s) (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the MySQL Secondary container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Configure MySQL Secondary with a custom my.cnf file",
+                    "default": "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-name-resolve\nexplicit_defaults_for_timestamp\nbasedir=/opt/bitnami/mysql\nplugin_dir=/opt/bitnami/mysql/lib/plugin\nport=3306\nsocket=/opt/bitnami/mysql/tmp/mysql.sock\ndatadir=/bitnami/mysql/data\ntmpdir=/opt/bitnami/mysql/tmp\nmax_allowed_packet=16M\nbind-address=*\npid-file=/opt/bitnami/mysql/tmp/mysqld.pid\nlog-error=/opt/bitnami/mysql/logs/mysqld.log\ncharacter-set-server=UTF8\ncollation-server=utf8_general_ci\nslow_query_log=0\nlong_query_time=10.0\n\n[client]\nport=3306\nsocket=/opt/bitnami/mysql/tmp/mysql.sock\ndefault-character-set=UTF8\nplugin_dir=/opt/bitnami/mysql/lib/plugin\n\n[manager]\nport=3306\nsocket=/opt/bitnami/mysql/tmp/mysql.sock\npid-file=/opt/bitnami/mysql/tmp/mysqld.pid"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with MySQL Secondary configuration.",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for the MySQL secondary statefulset",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations for MySQL secondary pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "MySQL secondary pod affinity preset. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "MySQL secondary pod anti-affinity preset. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MySQL secondary node affinity preset type. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "MySQL secondary node label key to match Ignored if `secondary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "MySQL secondary node label values to match. Ignored if `secondary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for MySQL secondary pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for MySQL secondary pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for MySQL secondary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "MySQL secondary pods' priorityClassName",
+                    "default": ""
+                },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "MySQL secondary pods' runtimeClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the MySQL secondary pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of MySQL secondary pods",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for MySQL secondary pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the mounted volumes' filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "MySQL secondary container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the MySQL secondary container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set MySQL secondary container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for MySQL secondary containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for MySQL secondary containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe for MySQL secondary containers",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe for MySQL secondary containers",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe for MySQL secondary containers",
+                    "default": {}
+                },
+                "extraFlags": {
+                    "type": "string",
+                    "description": "MySQL secondary additional command line flags",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra environment variables on MySQL secondary containers",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for MySQL secondary containers",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for MySQL secondary containers",
+                    "default": ""
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on MySQL secondary replicas using a `PersistentVolumeClaim`",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing `PersistentVolumeClaim` for MySQL secondary replicas",
+                            "default": ""
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The name of a volume's sub path to mount for persistence",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "MySQL secondary persistent volume storage Class",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "MySQL secondary persistent volume claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "MySQL secondary persistent volume access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "MySQL secondary persistent volume size",
+                            "default": "8Gi"
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes to the MySQL secondary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the MySQL secondary container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers for the MySQL secondary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers for the MySQL secondary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "MySQL secondary Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "number",
+                                    "description": "MySQL secondary Kubernetes service port",
+                                    "default": 3306
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "mysql": {
+                                    "type": "string",
+                                    "description": "MySQL secondary Kubernetes service node port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "MySQL secondary Kubernetes service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "MySQL secondary loadBalancerIP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when MySQL secondary service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for MySQL secondary service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for headless MySQL secondary service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for MySQL secondary pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of MySQL secondary pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of MySQL secondary pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels for MySQL secondary pods",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for MySQL pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for MySQL Service Account",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create & use RBAC resources or not",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "The Policy model to apply.",
+                    "default": true
+                },
+                "explicitNamespacesSelector": {
+                    "type": "object",
+                    "description": "A Kubernetes LabelSelector to explicitly select namespaces from which ingress traffic could be allowed to MySQL",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Init container volume-permissions resources",
+                    "default": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Exporter image repository",
+                            "default": "bitnami/mysqld-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Exporter image tag (immutable tags are recommended)",
+                            "default": "0.15.0-debian-11-r24"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "MySQL metrics container securityContext",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the MySQL metrics container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set MySQL metrics container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type for MySQL Prometheus Exporter",
+                            "default": "ClusterIP"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Kubernetes service clusterIP for MySQL Prometheus Exporter",
+                            "default": ""
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "MySQL Prometheus Exporter service port",
+                            "default": 9104
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "properties": {
+                        "primary": {
+                            "type": "array",
+                            "description": "Extra args to be passed to mysqld_exporter on Primary pods",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secondary": {
+                            "type": "array",
+                            "description": "Extra args to be passed to mysqld_exporter on Secondary pods",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for MySQL prometheus exporter containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for MySQL prometheus exporter containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Specify the namespace in which the serviceMonitor resource will be created",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "ServiceMonitor annotations",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a Prometheus Operator prometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the prometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
         }
-      },
-      "then": {
-        "properties": {
-          "database": {
-            "pattern": "[a-zA-Z0-9]{1,64}"
-          }
-        }
-      },
-      "properties": {
-        "rootPassword": {
-          "type": "string",
-          "title": "MySQL root password",
-          "description": "Defaults to a random 10-character alphanumeric string if not set"
-        },
-        "database": {
-          "type": "string",
-          "title": "MySQL custom database name",
-          "maxLength": 64
-        },
-        "username": {
-          "type": "string",
-          "title": "MySQL custom username"
-        },
-        "password": {
-          "type": "string",
-          "title": "MySQL custom password"
-        },
-        "replicationUser": {
-          "type": "string",
-          "title": "MySQL replication username"
-        },
-        "replicationPassword": {
-          "type": "string",
-          "title": "MySQL replication password"
-        },
-        "createDatabase": {
-          "type": "boolean",
-          "title": "MySQL create custom database"
-        }
-      }
-    },
-    "primary": {
-      "type": "object",
-      "title": "Primary database configuration",
-      "form": true,
-      "properties": {
-        "podSecurityContext": {
-          "type": "object",
-          "title": "MySQL primary Pod security context",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false
-            },
-            "fsGroup": {
-              "type": "integer",
-              "default": 1001,
-              "hidden": {
-                "value": false,
-                "path": "primary/podSecurityContext/enabled"
-              }
-            }
-          }
-        },
-        "containerSecurityContext": {
-          "type": "object",
-          "title": "MySQL primary container security context",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false
-            },
-            "runAsUser": {
-              "type": "integer",
-              "default": 1001,
-              "hidden": {
-                "value": false,
-                "path": "primary/containerSecurityContext/enabled"
-              }
-            }
-          }
-        },
-        "persistence": {
-          "type": "object",
-          "title": "Enable persistence using Persistent Volume Claims",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": true,
-              "title": "If true, use a Persistent Volume Claim, If false, use emptyDir"
-            },
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderUnit": "Gi",
-              "hidden": {
-                "value": false,
-                "path": "primary/persistence/enabled"
-              }
-            }
-          }
-        }
-      }
-    },
-    "secondary": {
-      "type": "object",
-      "title": "Secondary database configuration",
-      "form": true,
-      "properties": {
-        "podSecurityContext": {
-          "type": "object",
-          "title": "MySQL secondary Pod security context",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false
-            },
-            "fsGroup": {
-              "type": "integer",
-              "default": 1001,
-              "hidden": {
-                "value": false,
-                "path": "secondary/podSecurityContext/enabled"
-              }
-            }
-          }
-        },
-        "containerSecurityContext": {
-          "type": "object",
-          "title": "MySQL secondary container security context",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false
-            },
-            "runAsUser": {
-              "type": "integer",
-              "default": 1001,
-              "hidden": {
-                "value": false,
-                "path": "secondary/containerSecurityContext/enabled"
-              }
-            }
-          }
-        },
-        "persistence": {
-          "type": "object",
-          "title": "Enable persistence using Persistent Volume Claims",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": true,
-              "title": "If true, use a Persistent Volume Claim, If false, use emptyDir"
-            },
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderUnit": "Gi",
-              "hidden": {
-                "value": false,
-                "path": "secondary/persistence/enabled"
-              }
-            }
-          }
-        }
-      }
     }
-  }
 }

--- a/bitnami/nats/values.schema.json
+++ b/bitnami/nats/values.schema.json
@@ -1,0 +1,1049 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "NATS image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "NATS image repository",
+                    "default": "bitnami/nats"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "NATS image tag (immutable tags are recommended)",
+                    "default": "2.9.22-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "NATS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "NATS image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "NATS image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable NATS image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable client authentication",
+                    "default": true
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Client authentication user",
+                    "default": "nats_client"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Client authentication password",
+                    "default": ""
+                },
+                "token": {
+                    "type": "string",
+                    "description": "Client authentication token",
+                    "default": ""
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": "Client authentication timeout (seconds)",
+                    "default": 1
+                },
+                "usersCredentials": {
+                    "type": "array",
+                    "description": "Client authentication users credentials collection",
+                    "default": [],
+                    "items": {}
+                },
+                "noAuthUser": {
+                    "type": "string",
+                    "description": "Client authentication username from auth.usersCredentials map to be used when no credentials provided",
+                    "default": ""
+                }
+            }
+        },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Cluster name",
+                    "default": "nats"
+                },
+                "connectRetries": {
+                    "type": "string",
+                    "description": "Configure number of connect retries for implicit routes, otherwise leave blank",
+                    "default": ""
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Switch to enable/disable cluster authentication",
+                            "default": true
+                        },
+                        "user": {
+                            "type": "string",
+                            "description": "Cluster authentication user",
+                            "default": "nats_cluster"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Cluster authentication password",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "jetstream": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable JetStream",
+                    "default": false
+                },
+                "maxMemory": {
+                    "type": "string",
+                    "description": "Max memory usage for JetStream",
+                    "default": "1G"
+                }
+            }
+        },
+        "debug": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable debug on logging",
+                    "default": false
+                },
+                "trace": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable trace debug level on logging",
+                    "default": false
+                },
+                "logtime": {
+                    "type": "boolean",
+                    "description": "Switch to enable/disable logtime on logging",
+                    "default": false
+                }
+            }
+        },
+        "maxConnections": {
+            "type": "string",
+            "description": "Max. number of client connections",
+            "default": ""
+        },
+        "maxControlLine": {
+            "type": "string",
+            "description": "Max. protocol control line",
+            "default": ""
+        },
+        "maxPayload": {
+            "type": "string",
+            "description": "Max. payload",
+            "default": ""
+        },
+        "writeDeadline": {
+            "type": "string",
+            "description": "Duration the server can block on a socket write to a client",
+            "default": ""
+        },
+        "natsFilename": {
+            "type": "string",
+            "description": "Filename used by several NATS files (binary, configuration file, and pid file)",
+            "default": "nats-server"
+        },
+        "configuration": {
+            "type": "string",
+            "description": "Specify content for NATS configuration file (generated based on other parameters otherwise)",
+            "default": "{{- $authPwd := default (include \"nats.randomPassword\" .) .Values.auth.password -}}\n{{- $clusterAuthPwd := default (include \"nats.randomPassword\" .) .Values.cluster.auth.password -}}\n{{- if eq .Values.resourceType \"statefulset\" }}\nserver_name: $NATS_SERVER_NAME\n{{- end }}\nlisten: 0.0.0.0:{{ .Values.containerPorts.client }}\nhttp: 0.0.0.0:{{ .Values.containerPorts.monitoring }}\n\n# Authorization for client connections\n{{- if .Values.auth.enabled }}\nauthorization {\n  {{- if .Values.auth.user }}\n  user: {{ .Values.auth.user | quote }}\n  password: {{ $authPwd | quote }}\n  {{- else if .Values.auth.token }}\n  token: {{ .Values.auth.token | quote }}\n  {{- else if .Values.auth.usersCredentials }}\n  users: [\n    {{- range $user := .Values.auth.usersCredentials }}\n      { user: {{ $user.username | quote }}, password: {{ $user.password | quote }} },\n    {{- end }}\n  ],\n  {{- end }}\n  timeout:  {{ int .Values.auth.timeout }}\n}\n{{- if .Values.auth.noAuthUser }}\nno_auth_user: {{ .Values.auth.noAuthUser | quote }}\n{{- end }}\n{{- end }}\n\n# Logging options\ndebug: {{ ternary \"true\" \"false\" (or .Values.debug.enabled .Values.diagnosticMode.enabled) }}\ntrace: {{ ternary \"true\" \"false\" (or .Values.debug.trace .Values.diagnosticMode.enabled) }}\nlogtime: {{ ternary \"true\" \"false\" (or .Values.debug.logtime .Values.diagnosticMode.enabled) }}\n# Pid file\npid_file: \"/opt/bitnami/nats/tmp/{{ .Values.natsFilename }}.pid\"\n\n# Some system overrides\n{{- if .Values.maxConnections }}\nmax_connections: {{ int .Values.maxConnections }}\n{{- end }}\n{{- if .Values.maxControlLine }}\nmax_control_line: {{ int .Values.maxControlLine }}\n{{- end }}\n{{- if .Values.maxPayload }}\nmax_payload: {{ int .Values.maxPayload }}\n{{- end }}\n{{- if .Values.writeDeadline }}\nwrite_deadline: {{ .Values.writeDeadline | quote }}\n{{- end }}\n\n# Clustering definition\ncluster {\n  name: {{ .Values.cluster.name | quote }}\n  listen: 0.0.0.0:{{ .Values.containerPorts.cluster }}\n  {{- if .Values.cluster.auth.enabled }}\n  # Authorization for cluster connections\n  authorization {\n    user: {{ .Values.cluster.auth.user | quote }}\n    password: {{ $clusterAuthPwd | quote }}\n    timeout:  1\n  }\n  {{- end }}\n  # Routes are actively solicited and connected to from this server.\n  # Other servers can connect to us if they supply the correct credentials\n  # in their routes definitions from above\n  routes = [\n    {{- if .Values.cluster.auth.enabled }}\n    nats://{{ .Values.cluster.auth.user }}:{{ $clusterAuthPwd }}@{{ include \"common.names.fullname\" . }}:{{ .Values.service.ports.cluster }}\n    {{- else }}\n    nats://{{ template \"common.names.fullname\" . }}:{{ .Values.service.ports.cluster }}\n    {{- end }}\n  ]\n  {{- if .Values.cluster.connectRetries }}\n  # Configure number of connect retries for implicit routes\n  connect_retries: {{ .Values.cluster.connectRetries }}\n  {{- end }}\n}\n\n{{- if .Values.jetstream.enabled }}\n# JetStream configuration\njetstream: enabled\njetstream {\n  store_dir: /data/jetstream\n  max_memory_store: {{ .Values.jetstream.maxMemory }}\n  max_file_store: {{ .Values.persistence.size }}\n}\n{{- end }}"
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "The name of an existing Secret with your custom configuration for NATS",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on NATS container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "resourceType": {
+            "type": "string",
+            "description": "NATS cluster resource type under Kubernetes. Allowed values: `statefulset` (default) or `deployment`",
+            "default": "statefulset"
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of NATS nodes",
+            "default": 1
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Use an alternate scheduler, e.g. \"stork\".",
+            "default": ""
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of pod priority class",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "StrategyType. Can be set to RollingUpdate or OnDelete",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "client": {
+                    "type": "number",
+                    "description": "NATS client container port",
+                    "default": 4222
+                },
+                "cluster": {
+                    "type": "number",
+                    "description": "NATS cluster container port",
+                    "default": 6222
+                },
+                "monitoring": {
+                    "type": "number",
+                    "description": "NATS monitoring container port",
+                    "default": 8222
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled NATS pods' Security Context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set NATS pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled NATS containers' Security Context",
+                    "default": false
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set NATS containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set NATS containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the NATS containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the NATS containers",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on NATS containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for NATS pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for NATS pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for NATS pods assignment spread across your cluster among failure-domains",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the NATS container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for NATS pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for NATS container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the NATS pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the NATS pods",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "NATS service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "number",
+                            "description": "NATS client service port",
+                            "default": 4222
+                        },
+                        "cluster": {
+                            "type": "number",
+                            "description": "NATS cluster service port",
+                            "default": 6222
+                        },
+                        "monitoring": {
+                            "type": "number",
+                            "description": "NATS monitoring service port",
+                            "default": 8222
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "string",
+                            "description": "Node port for clients",
+                            "default": ""
+                        },
+                        "cluster": {
+                            "type": "string",
+                            "description": "Node port for clustering",
+                            "default": ""
+                        },
+                        "monitoring": {
+                            "type": "string",
+                            "description": "Node port for monitoring",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "NATS service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "NATS service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "NATS service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "NATS service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for NATS service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the NATS service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress Path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the ingress is enabled, a host pointing to this will be created",
+                    "default": "nats.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to NATS. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "The Policy model to apply",
+                    "default": true
+                },
+                "additionalRules": {
+                    "type": "object",
+                    "description": "Additional NetworkPolicy Ingress \"from\" rules to set. Note that all rules are OR-ed.",
+                    "default": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus metrics via exporter side-car",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Prometheus metrics exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Prometheus metrics exporter image repository",
+                            "default": "bitnami/nats-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Prometheus metrics exporter image tag (immutable tags are recommended)",
+                            "default": "0.12.0-debian-11-r66"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "NATS Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Prometheus metrics image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Prometheus metrics image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Prometheus metrics exporter port",
+                    "default": 7777
+                },
+                "flags": {
+                    "type": "array",
+                    "description": "Flags to be passed to Prometheus metrics",
+                    "default": [
+                        "-connz",
+                        "-routez",
+                        "-subz",
+                        "-varz"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Prometheus metrics service port",
+                            "default": 7777
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for Prometheus metrics service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Specify if a ServiceMonitor will be deployed for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": "monitoring"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "How frequently to scrape metrics",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable NATS data persistence using PVC(s)",
+                    "default": false
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for NATS data volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for NATS data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for NATS's data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        }
+    }
+}

--- a/bitnami/nginx-ingress-controller/values.schema.json
+++ b/bitnami/nginx-ingress-controller/values.schema.json
@@ -1,0 +1,1469 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Nginx Ingress Controller image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Nginx Ingress Controller image repository",
+                    "default": "bitnami/nginx-ingress-controller"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Nginx Ingress Controller image tag (immutable tags are recommended)",
+                    "default": "1.8.1-debian-11-r48"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Nginx Ingress Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Nginx Ingress Controller image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 80
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 443
+                },
+                "metrics": {
+                    "type": "number",
+                    "description": "",
+                    "default": 10254
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "config": {
+            "type": "object",
+            "description": "Custom configuration options for NGINX",
+            "default": {}
+        },
+        "proxySetHeaders": {
+            "type": "object",
+            "description": "Custom headers before sending traffic to backends",
+            "default": {}
+        },
+        "addHeaders": {
+            "type": "object",
+            "description": "Custom headers before sending response traffic to the client",
+            "default": {}
+        },
+        "defaultBackendService": {
+            "type": "string",
+            "description": "Default 404 backend service; required only if `defaultBackend.enabled = false`",
+            "default": ""
+        },
+        "electionID": {
+            "type": "string",
+            "description": "Election ID to use for status update",
+            "default": "ingress-controller-leader"
+        },
+        "reportNodeInternalIp": {
+            "type": "boolean",
+            "description": "If using `hostNetwork=true`, setting `reportNodeInternalIp=true`, will pass the flag `report-node-internal-ip-address` to Nginx Ingress Controller",
+            "default": false
+        },
+        "watchIngressWithoutClass": {
+            "type": "boolean",
+            "description": "Process Ingress objects without ingressClass annotation/ingressClassName field",
+            "default": false
+        },
+        "ingressClassResource": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the IngressClass resource",
+                    "default": "nginx"
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create the IngressClass resource",
+                    "default": true
+                },
+                "default": {
+                    "type": "boolean",
+                    "description": "Set the created IngressClass resource as default class",
+                    "default": false
+                },
+                "controllerClass": {
+                    "type": "string",
+                    "description": "IngressClass identifier for the controller",
+                    "default": "k8s.io/ingress-nginx"
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "Optional parameters for the controller",
+                    "default": {}
+                }
+            }
+        },
+        "publishService": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set the endpoint records on the Ingress objects to reflect those on the service",
+                    "default": false
+                },
+                "pathOverride": {
+                    "type": "string",
+                    "description": "Allows overriding of the publish service to bind to",
+                    "default": ""
+                }
+            }
+        },
+        "scope": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Limit the scope of the controller.",
+                    "default": false
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Scope namespace. Defaults to `.Release.Namespace`",
+                    "default": ""
+                }
+            }
+        },
+        "configMapNamespace": {
+            "type": "string",
+            "description": "Allows customization of the configmap / nginx-configmap namespace",
+            "default": ""
+        },
+        "tcpConfigMapNamespace": {
+            "type": "string",
+            "description": "Allows customization of the tcp-services-configmap namespace",
+            "default": ""
+        },
+        "udpConfigMapNamespace": {
+            "type": "string",
+            "description": "Allows customization of the udp-services-configmap namespace",
+            "default": ""
+        },
+        "maxmindLicenseKey": {
+            "type": "string",
+            "description": "License key used to download Geolite2 database",
+            "default": ""
+        },
+        "dhParam": {
+            "type": "string",
+            "description": "A base64ed Diffie-Hellman parameter",
+            "default": ""
+        },
+        "tcp": {
+            "type": "object",
+            "description": "TCP service key:value pairs",
+            "default": {}
+        },
+        "udp": {
+            "type": "object",
+            "description": "UDP service key:value pairs",
+            "default": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the %%MAIN_CONTAINER_NAME%% container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraArgs": {
+            "type": "object",
+            "description": "Additional command line arguments to pass to nginx-ingress-controller",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on Nginx Ingress container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of a existing ConfigMap containing extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of a existing Secret containing extra environment variables",
+            "default": ""
+        },
+        "kind": {
+            "type": "string",
+            "description": "Install as Deployment or DaemonSet",
+            "default": "Deployment"
+        },
+        "daemonset": {
+            "type": "object",
+            "properties": {
+                "useHostPort": {
+                    "type": "boolean",
+                    "description": "If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`",
+                    "default": false
+                },
+                "hostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "",
+                            "default": 443
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Desired number of Controller pods",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "description": "Strategy to use to update Pods",
+            "default": {}
+        },
+        "revisionHistoryLimit": {
+            "type": "number",
+            "description": "The number of old history to retain to allow rollback",
+            "default": 10
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Controller pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the container filesystem",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Controller containers' Security Context",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Switch to allow priviledge escalation on the Controller container",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the Controller container",
+                    "default": 1001
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "description": "Linux Kernel capabilities that should be dropped",
+                            "default": [
+                                "ALL"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "add": {
+                            "type": "array",
+                            "description": "Linux Kernel capabilities that should be added",
+                            "default": [
+                                "NET_BIND_SERVICE"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "minReadySeconds": {
+            "type": "number",
+            "description": "How many seconds a pod needs to be ready before killing the next, during update",
+            "default": 0
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Controller container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the Controller container",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "lifecycle": {
+            "type": "object",
+            "description": "LifecycleHooks to set additional configuration at startup",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Controller pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Controller pods",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Controller priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "If the Nginx deployment / daemonset should run on the host's network namespace",
+            "default": false
+        },
+        "dnsPolicy": {
+            "type": "string",
+            "description": "By default, while using host network, name resolution uses the host's DNS",
+            "default": "ClusterFirst"
+        },
+        "dnsConfig": {
+            "type": "object",
+            "description": "is an object with optional parameters to pass to the DNS resolver",
+            "default": {}
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "number",
+            "description": "How many seconds to wait before terminating a pod",
+            "default": 60
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Controller pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Controller container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add init containers to the controller pods",
+            "default": [],
+            "items": {}
+        },
+        "customTemplate": {
+            "type": "object",
+            "properties": {
+                "configMapName": {
+                    "type": "string",
+                    "description": "",
+                    "default": ""
+                },
+                "configMapKey": {
+                    "type": "string",
+                    "description": "",
+                    "default": ""
+                }
+            }
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add sidecars to the controller pods.",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "defaultBackend": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable a default backend based on NGINX",
+                    "default": true
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Default backend image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Default backend image repository",
+                            "default": "bitnami/nginx"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Default backend image tag (immutable tags are recommended)",
+                            "default": "1.25.2-debian-11-r2"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "description": "Additional command line arguments to pass to Nginx container",
+                    "default": {}
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "HTTP container port number",
+                    "default": 8080
+                },
+                "serverBlockConfig": {
+                    "type": "string",
+                    "description": "NGINX backend default server block configuration",
+                    "default": "location /healthz {\n  return 200;\n}\n\nlocation / {\n  return 404;\n}"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Desired number of default backend pods",
+                    "default": 1
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Default backend pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Default backend containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Default backend container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Default backend container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Default backend container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom liveness probe for the Web component",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readiness probe for the Web component",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Controller pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Controller pods",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "In seconds, time the given to the pod to terminate gracefully",
+                    "default": 60
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the %%MAIN_CONTAINER_NAME%% container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to %%MAIN_CONTAINER_NAME%% nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the %%MAIN_CONTAINER_NAME%% pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the %%MAIN_CONTAINER_NAME%% container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the %%MAIN_CONTAINER_NAME%% pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type for default backend",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Default backend service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the default backend service",
+                            "default": {}
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Default backend",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of Default backend pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of Default backend pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "",
+                            "default": 443
+                        }
+                    }
+                },
+                "targetPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": "http"
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": "https"
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "tcp": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        },
+                        "udp": {
+                            "type": "object",
+                            "description": "",
+                            "default": {}
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type for Controller",
+                    "default": "LoadBalancer"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for controller service",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels for controller service",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Controller Internal Cluster Service IP (optional)",
+                    "default": ""
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "Controller Service external IP addresses",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "List of IP CIDRs allowed access to load balancer (if supported)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Set external traffic policy to: \"Local\" to preserve source IP on providers supporting it",
+                    "default": ""
+                },
+                "healthCheckNodePort": {
+                    "type": "number",
+                    "description": "Set this to the managed health-check port the kube-proxy will expose. If blank, a random port in the `NodePort` range will be assigned",
+                    "default": 0
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Controller pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account.",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC rules should be created",
+                    "default": true
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation for Controller",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of Controller pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of Controller pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable autoscaling for Controller",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of Controller replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of Controller replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "string",
+                    "description": "Target CPU utilization percentage",
+                    "default": ""
+                },
+                "targetMemory": {
+                    "type": "string",
+                    "description": "Target Memory utilization percentage",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ coalesce .Values.metrics.service.ports.metrics .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Type of Prometheus metrics service to create",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Service HTTP management port",
+                                    "default": 9913
+                                }
+                            }
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the Prometheus exporter service",
+                            "default": {}
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable exposing Controller statistics",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create PrometheusRules resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Used to pass Labels that are required by the Installed Prometheus Operator",
+                            "default": {}
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Rules to be prometheus in YAML format, check values for an example",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/nginx/values.schema.json
+++ b/bitnami/nginx/values.schema.json
@@ -1,81 +1,1180 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the NGINX installation."
-        },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\""
-        }
-      }
-    },
-    "replicaCount": {
-      "type": "integer",
-      "form": true,
-      "title": "Number of replicas",
-      "description": "Number of replicas to deploy"
-    },
-    "serverBlock": {
-      "type": "string",
-      "form": true,
-      "title": "Custom server block",
-      "description": "Custom server block to be added to NGINX configuration"
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
-        },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
             }
-          }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override nginx.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override nginx.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Extra objects to deploy (value evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "NGINX image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "NGINX image repository",
+                    "default": "bitnami/nginx"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "NGINX image tag (immutable tags are recommended)",
+                    "default": "1.25.2-debian-11-r3"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "NGINX image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Set to true if you would like to see extra information on logs",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on NGINX containers",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of NGINX replicas to deploy",
+            "default": 1
+        },
+        "revisionHistoryLimit": {
+            "type": "number",
+            "description": "The number of old history to retain to allow rollback",
+            "default": 10
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "NGINX deployment strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "NGINX deployment rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Additional labels for NGINX pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for NGINX pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Specify if host network should be enabled for NGINX pod",
+            "default": false
+        },
+        "hostIPC": {
+            "type": "boolean",
+            "description": "Specify if host IPC should be enabled for NGINX pod",
+            "default": false
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "NGINX pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the NGINX pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled NGINX pods' Security Context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set NGINX pod's Security Context fsGroup",
+                    "default": 1001
+                },
+                "sysctls": {
+                    "type": "array",
+                    "description": "sysctl settings of the NGINX pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled NGINX containers' Security Context",
+                    "default": false
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set NGINX container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set NGINX container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Sets http port inside NGINX container",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "string",
+                    "description": "Sets https port inside NGINX container",
+                    "default": ""
+                }
+            }
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Array of additional container ports for the Nginx container",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the NGINX container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the NGINX container",
+                    "default": {}
+                }
+            }
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Optional lifecycleHooks for the NGINX container",
+            "default": {}
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Web component",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable autoscaling for NGINX deployment",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "string",
+                    "description": "Minimum number of replicas to scale back",
+                    "default": ""
+                },
+                "maxReplicas": {
+                    "type": "string",
+                    "description": "Maximum number of replicas to scale out",
+                    "default": ""
+                },
+                "targetCPU": {
+                    "type": "string",
+                    "description": "Target CPU utilization percentage",
+                    "default": ""
+                },
+                "targetMemory": {
+                    "type": "string",
+                    "description": "Target Memory utilization percentage",
+                    "default": ""
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array to add extra volumes",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array to add extra mount",
+            "default": [],
+            "items": {}
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for nginx pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template.",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Auto-mount the service account token in the pod",
+                    "default": false
+                }
+            }
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Sidecar parameters",
+            "default": [],
+            "items": {}
+        },
+        "sidecarSingleProcessNamespace": {
+            "type": "boolean",
+            "description": "Enable sharing the process namespace with sidecars",
+            "default": false
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Extra init containers",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Created a PodDisruptionBudget",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Min number of pods that must still be available after the eviction.",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "number",
+                    "description": "Max number of pods that can be unavailable after the eviction.",
+                    "default": 0
+                }
+            }
+        },
+        "cloneStaticSiteFromGit": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Get the server static content from a Git repository",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Git image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Git image repository",
+                            "default": "bitnami/git"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Git image tag (immutable tags are recommended)",
+                            "default": "2.41.0-debian-11-r76"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Git image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Git Repository to clone static content from",
+                    "default": ""
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Git branch to checkout",
+                    "default": ""
+                },
+                "interval": {
+                    "type": "number",
+                    "description": "Interval for sidecar container pull from the Git repository",
+                    "default": 60
+                },
+                "gitClone": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command for git-clone-repository",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args for git-clone-repository",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "gitSync": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command for git-repo-syncer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args for git-repo-syncer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the git-repo-syncer container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the git-repo-syncer container",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Additional environment variables to set for the in the containers that clone static site from git",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Add extra volume mounts for the Git containers",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serverBlock": {
+            "type": "string",
+            "description": "Custom server block to be added to NGINX configuration",
+            "default": ""
+        },
+        "existingServerBlockConfigmap": {
+            "type": "string",
+            "description": "ConfigMap with custom server block to be added to NGINX configuration",
+            "default": ""
+        },
+        "staticSiteConfigmap": {
+            "type": "string",
+            "description": "Name of existing ConfigMap with the server static site content",
+            "default": ""
+        },
+        "staticSitePVC": {
+            "type": "string",
+            "description": "Name of existing PVC with the server static site content",
+            "default": ""
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                        }
+                    }
+                },
+                "targetPort": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "",
+                            "default": "http"
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "",
+                            "default": "https"
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "NGINX service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "LoadBalancer service IP address",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "NGINX service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Service annotations",
+                    "default": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "nginx.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Nginx. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "Set the ingerssClassName on the ingress record for k8s 1.18+",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Create TLS Secret",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "healthIngress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable health ingress record generation",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the health ingress is enabled, a host pointing to this will be created",
+                    "default": "example.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `healthIngress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostnames to be covered",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "TLS Secret configuration",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a Prometheus exporter sidecar container",
+                    "default": false
+                },
+                "port": {
+                    "type": "string",
+                    "description": "NGINX Container Status Port scraped by Prometheus Exporter",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "NGINX Prometheus exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "NGINX Prometheus exporter image repository",
+                            "default": "bitnami/nginx-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "NGINX Prometheus exporter image tag (immutable tags are recommended)",
+                            "default": "0.11.0-debian-11-r324"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "NGINX Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "NGINX Prometheus exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional annotations for NGINX Prometheus exporter pod(s)",
+                    "default": {}
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled NGINX Exporter containers' Security Context",
+                            "default": false
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set NGINX Exporter container's Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "NGINX Prometheus exporter service port",
+                            "default": 9113
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the NGINX Prometheus exporter container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the NGINX Prometheus exporter container",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PodMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Prometheus Rule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/node-exporter/values.schema.json
+++ b/bitnami/node-exporter/values.schema.json
@@ -1,0 +1,673 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override `common.names.fullname` template with a string",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": true
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy and bound it with RBAC. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Node Exporter image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Node Exporter image repository",
+                    "default": "bitnami/node-exporter"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Node Exporter image tag (immutable tags are recommended)",
+                    "default": "1.6.1-debian-11-r32"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Node Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Node Exporter image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "type": "number",
+                    "description": "Node Exporter container port",
+                    "default": 9100
+                }
+            }
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Node exporter pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Node exporter pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraArgs": {
+            "type": "object",
+            "description": "Additional command line arguments to pass to node-exporter",
+            "default": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Node exporter container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to Node exporter container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for Node exporter container",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for Node exporter container",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Additional volumes to the node-exporter pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Additional volumeMounts to the node-exporter container",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Node exporter pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Node exporter pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Node exporter containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Node exporter containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Node exporter container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Node Exporter metrics service port",
+                            "default": 9100
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Specific cluster IP when service type is cluster IP. Use `None` for headless service",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "`loadBalancerIP` if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Address that are allowed when service is `LoadBalancer`",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Node exporter service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "addPrometheusScrapeAnnotation": {
+                    "type": "boolean",
+                    "description": "Add the `prometheus.io/scrape: \"true\"` annotation to the service",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for Node Exporter service",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Additional labels for Node Exporter service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The update strategy type to apply to the DaemonSet",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "number",
+                            "description": "Maximum number of pods that may be made unavailable",
+                            "default": 1
+                        }
+                    }
+                }
+            }
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Expose the service to the host network",
+            "default": true
+        },
+        "hostPID": {
+            "type": "boolean",
+            "description": "Allows visibility of processes on the host, potentially leaking information such as environment variables and configuration",
+            "default": true
+        },
+        "minReadySeconds": {
+            "type": "number",
+            "description": "`minReadySeconds` to avoid killing pods before we are ready",
+            "default": 0
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority class assigned to the Pods",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time the given to the Node exporter pod needs to terminate gracefully",
+            "default": ""
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod labels",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Node exporter container",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe for the Node exporter container",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readiness probe for the Node exporter container",
+            "default": {}
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Creates a ServiceMonitor to monitor Node Exporter",
+                    "default": false
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace in which Prometheus is running",
+                    "default": ""
+                },
+                "jobLabel": {
+                    "type": "string",
+                    "description": "The name of the label on the target service to use as the job name in prometheus.",
+                    "default": ""
+                },
+                "interval": {
+                    "type": "string",
+                    "description": "Scrape interval (use by default, falling back to Prometheus' default)",
+                    "default": ""
+                },
+                "scrapeTimeout": {
+                    "type": "string",
+                    "description": "Timeout after which the scrape is ended",
+                    "default": ""
+                },
+                "basicAuth": {
+                    "type": "object",
+                    "description": "Use basic auth for scraping",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "ServiceMonitor selector labels",
+                    "default": {}
+                },
+                "relabelings": {
+                    "type": "array",
+                    "description": "RelabelConfigs to apply to samples before scraping",
+                    "default": [],
+                    "items": {}
+                },
+                "metricRelabelings": {
+                    "type": "array",
+                    "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                    "default": [],
+                    "items": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Extra labels for the ServiceMonitor",
+                    "default": {}
+                },
+                "honorLabels": {
+                    "type": "boolean",
+                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                    "default": false
+                },
+                "attachMetadata": {
+                    "type": "object",
+                    "description": "Attaches node metadata to discovered targets",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/oauth2-proxy/values.schema.json
+++ b/bitnami/oauth2-proxy/values.schema.json
@@ -1,0 +1,915 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy service type",
+                    "default": "ClusterIP"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "OAuth2 Proxy service HTTP port",
+                    "default": 80
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "OAuth2 Proxy service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for OAuth2 Proxy service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for OAuth2 Proxy",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "oaut2-proxy.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "certManager": {
+                    "type": "boolean",
+                    "description": "Add the corresponding annotations for cert-manager integration",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "existingSecretName": {
+                    "type": "string",
+                    "description": "If you're providing your own certificate and want to manage the secret yourself",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy image repository",
+                    "default": "bitnami/oauth2-proxy"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy image tag (immutable tags are recommended)",
+                    "default": "7.5.0-debian-11-r3"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "OAuth2 Proxy image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "clientID": {
+                    "type": "string",
+                    "description": "OAuth client ID",
+                    "default": "XXXXXXX"
+                },
+                "clientSecret": {
+                    "type": "string",
+                    "description": "OAuth client secret",
+                    "default": "XXXXXXXX"
+                },
+                "cookieSecret": {
+                    "type": "string",
+                    "description": "OAuth cookie secret",
+                    "default": "XXXXXXXXXXXXXXXX"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Secret with the client ID, secret and cookie secret",
+                    "default": ""
+                },
+                "google": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Google service account",
+                            "default": false
+                        },
+                        "adminEmail": {
+                            "type": "string",
+                            "description": "Google admin email",
+                            "default": ""
+                        },
+                        "groups": {
+                            "type": "array",
+                            "description": "Restrict logins to members of these google groups",
+                            "default": [],
+                            "items": {}
+                        },
+                        "serviceAccountJson": {
+                            "type": "string",
+                            "description": "Google Service account JSON",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing Google Service Account",
+                            "default": ""
+                        }
+                    }
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Default configuration",
+                    "default": "email_domains = [ \"*\" ]\nupstreams = [ \"file:///dev/null\" ]\n"
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Configmap with the OAuth2 Proxy configuration",
+                    "default": ""
+                },
+                "authenticatedEmailsFile": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable authenticated emails file",
+                            "default": false
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Restricted access list (one email per line)",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Secret with the authenticated emails file",
+                            "default": ""
+                        }
+                    }
+                },
+                "htpasswdFile": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable htpasswd file",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret for htpasswd file",
+                            "default": ""
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "htpasswd file entries (one row per user)",
+                            "default": ""
+                        }
+                    }
+                },
+                "oidcIssuerUrl": {
+                    "type": "string",
+                    "description": "OpenID Connect issuer URL",
+                    "default": ""
+                },
+                "redirectUrl": {
+                    "type": "string",
+                    "description": "OAuth Redirect URL",
+                    "default": ""
+                },
+                "whiteList": {
+                    "type": "string",
+                    "description": "Allowed domains for redirection after authentication. Prefix domain with a . or a *. to allow subdomains",
+                    "default": ""
+                }
+            }
+        },
+        "containerPort": {
+            "type": "number",
+            "description": "OAuth2 Proxy port number",
+            "default": 4180
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Array of additional container ports for the OAuth2 Proxy container",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of OAuth2 Proxy replicas to deploy",
+            "default": 1
+        },
+        "extraArgs": {
+            "type": "array",
+            "description": "add extra args to the default command",
+            "default": [],
+            "items": {}
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on OAuth2 Proxy nodes",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on OAuth2 Proxy nodes",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on OAuth2 Proxy nodes",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the OAuth2 Proxy containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the OAuth2 Proxy containers",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled OAuth2 Proxy pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set OAuth2 Proxy pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled OAuth2 Proxy containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set OAuth2 Proxy containers' Security Context runAsUser",
+                    "default": 1001
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "OAuth2 Proxy pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for OAuth2 Proxy pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for OAuth2 Proxy pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for OAuth2 Proxy pods assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for OAuth2 Proxy pods assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for OAuth2 Proxy pods assignment",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "OAuth2 Proxy statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "OAuth2 Proxy pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the OAuth2 Proxy container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to OAuth2 Proxy nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for OAuth2 Proxy nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for OAuth2 Proxy nodes",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the OAuth2 Proxy pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the OAuth2 Proxy container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the OAuth2 Proxy pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the OAuth2 Proxy pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "dnsPolicy": {
+            "type": "string",
+            "description": "Pod DNS policy. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.",
+            "default": ""
+        },
+        "dnsConfig": {
+            "type": "object",
+            "description": "Pod DNS configuration.",
+            "default": {}
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "externalRedis": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External Redis&reg; server host",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External Redis&reg; user password",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Redis&reg; server port",
+                    "default": 6379
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of an existing secret with Redis&reg; credentials",
+                    "default": ""
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Redis&reg; sub-chart",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "Redis&reg; architecture",
+                    "default": "standalone"
+                },
+                "master": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "number",
+                                    "description": "Redis&reg; (without Sentinel) service port",
+                                    "default": 6379
+                                }
+                            }
+                        }
+                    }
+                },
+                "replica": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Redis&reg; replicas",
+                            "default": 3
+                        }
+                    }
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Redis&reg; authentication",
+                            "default": true
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Secret with Redis&reg; credentials",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "description": "Key inside the existing secret with Redis&reg; credentials",
+                            "default": ""
+                        },
+                        "sentinel": {
+                            "type": "boolean",
+                            "description": "Enable authentication in the Sentinel nodes",
+                            "default": true
+                        }
+                    }
+                },
+                "sentinel": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Redis&reg; sentinel in the deployment",
+                            "default": false
+                        },
+                        "masterSet": {
+                            "type": "string",
+                            "description": "Name of the Redis&reg; Sentinel master set",
+                            "default": "mymaster"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "number",
+                                    "description": "Redis&reg; (with Sentinel) service port",
+                                    "default": 6379
+                                },
+                                "sentinelPort": {
+                                    "type": "number",
+                                    "description": "Redis&reg; (with Sentinel) sentinel service port",
+                                    "default": 26379
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/odoo/values.schema.json
+++ b/bitnami/odoo/values.schema.json
@@ -1,0 +1,1073 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Odoo image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Odoo image repository",
+                    "default": "bitnami/odoo"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Odoo image tag (immutable tags are recommended)",
+                    "default": "16.0.20230815-debian-11-r18"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Odoo image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Odoo image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Odoo image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "odooEmail": {
+            "type": "string",
+            "description": "Odoo user email",
+            "default": "user@example.com"
+        },
+        "odooPassword": {
+            "type": "string",
+            "description": "Odoo user password",
+            "default": ""
+        },
+        "odooSkipInstall": {
+            "type": "boolean",
+            "description": "Skip Odoo installation wizard",
+            "default": false
+        },
+        "loadDemoData": {
+            "type": "boolean",
+            "description": "Whether to load demo data for all modules during initialization",
+            "default": false
+        },
+        "customPostInitScripts": {
+            "type": "object",
+            "description": "Custom post-init.d user scripts",
+            "default": {}
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP server host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP server port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP username",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP user password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing Odoo credentials",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow the container to be started with blank passwords",
+            "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the Odoo container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Odoo replicas to deploy",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Odoo HTTP container port",
+                    "default": 8069
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Odoo container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Odoo pods' Security Context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Odoo pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Odoo containers' Security Context",
+                    "default": false
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Odoo container's Security Context runAsUser",
+                    "default": 1001
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for to check for livenessProbe",
+                    "default": "/web/health"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 30
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to check for readinessProbe",
+                    "default": "/web/health"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to check for startupProbe",
+                    "default": "/web/health"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 300
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHooks to set additional configuration at startup",
+            "default": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Odoo pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Odoo pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Odoo pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Odoo pods' Priority Class Name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Use an alternate scheduler, e.g. \"stork\".",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Odoo pod needs to terminate gracefully",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Odoo deployment strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Odoo deployment rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Odoo pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Odoo container(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional ports for Odoo container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Odoo pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Odoo pods",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Odoo service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Odoo service HTTP port",
+                            "default": 80
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "NodePort for the Odoo HTTP endpoint",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Odoo service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Odoo service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Odoo service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Odoo service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Odoo service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Odoo service",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Odoo",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "odoo.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "resourcePolicy": {
+                    "type": "string",
+                    "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "accessMode": {
+                    "type": "string",
+                    "description": "Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)",
+                    "default": "ReadWriteOnce"
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "10Gi"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable init container's Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to create (name generated using common.names.fullname template otherwise)",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Auto-mount the service account token in the pod",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for Odoo",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of Odoo replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of Odoo replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_odoo"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_odoo"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Keycloak",
+                    "default": "bn_odoo"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Keycloak",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Keycloak database name",
+                    "default": "bitnami_odoo"
+                },
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable PostgreSQL user and database creation (when using an external db)",
+                    "default": true
+                },
+                "postgresqlPostgresUser": {
+                    "type": "string",
+                    "description": "External Database admin username",
+                    "default": "postgres"
+                },
+                "postgresqlPostgresPassword": {
+                    "type": "string",
+                    "description": "External Database admin password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the non-root credentials",
+                    "default": ""
+                },
+                "existingSecretPostgresPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the admin credentials",
+                    "default": ""
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by Odoo's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Odoo only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Odoo. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Odoo. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/opencart/values.schema.json
+++ b/bitnami/opencart/values.schema.json
@@ -1,0 +1,1218 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override opencart.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override opencart.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all OpenCart resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all OpenCart resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "OpenCart image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "OpenCart image repository",
+                    "default": "bitnami/opencart"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "OpenCart image tag (immutable tags are recommended)",
+                    "default": "4.0.2-2-debian-11-r36"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "OpenCart image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "OpenCart image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "opencartSkipInstall": {
+            "type": "boolean",
+            "description": "Skip OpenCart installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "opencartHost": {
+            "type": "string",
+            "description": "OpenCart host to create application URLs",
+            "default": ""
+        },
+        "opencartUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "opencartPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "opencartEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "opencartEnableHttps": {
+            "type": "boolean",
+            "description": "Whether to use HTTPS by default, default is false.",
+            "default": false
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": true
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "OpenCart pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra env vars",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Extra volumes to add to the deployment. Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Extra volume mounts to add to the container. Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Extra init containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Extra sidecar containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "OpenCart Data Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for OpenCart volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for OpenCart volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "Host mount path for OpenCart volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable OpenCart pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "OpenCart pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable OpenCart containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "OpenCart containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "OpenCart containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/administration/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/administration/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/administration/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "lifecycleHooks for the container to automate configuration before or after startup",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes HTTPS node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "OpenCart service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "OpenCart service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "OpenCart service Load Balancer IP",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for OpenCart service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "opencart.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Opencart. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_opencart"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_opencart"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Database Persistent Volume Access Modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_opencart"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_opencart"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by OpenCart's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes OpenCart only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access OpenCart. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access OpenCart. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/opensearch/values.schema.json
+++ b/bitnami/opensearch/values.schema.json
@@ -1,0 +1,3818 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "clusterName": {
+            "type": "string",
+            "description": "OpenSearch cluster name",
+            "default": "open"
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "restAPI": {
+                    "type": "number",
+                    "description": "OpenSearch REST API port",
+                    "default": 9200
+                },
+                "transport": {
+                    "type": "number",
+                    "description": "OpenSearch Transport port",
+                    "default": 9300
+                }
+            }
+        },
+        "plugins": {
+            "type": "string",
+            "description": "Comma, semi-colon or space separated list of plugins to install at initialization",
+            "default": ""
+        },
+        "snapshotRepoPath": {
+            "type": "string",
+            "description": "File System snapshot repository path",
+            "default": ""
+        },
+        "config": {
+            "type": "object",
+            "description": "Override opensearch configuration",
+            "default": {}
+        },
+        "extraConfig": {
+            "type": "object",
+            "description": "Append extra configuration to the opensearch node configuration",
+            "default": {}
+        },
+        "extraHosts": {
+            "type": "array",
+            "description": "A list of external hosts which are part of this cluster",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "A list of volumes to be added to the pod",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "A list of volume mounts to be added to the pod",
+            "default": [],
+            "items": {}
+        },
+        "initScripts": {
+            "type": "object",
+            "description": "Dictionary of init scripts. Evaluated as a template.",
+            "default": {}
+        },
+        "initScriptsCM": {
+            "type": "string",
+            "description": "ConfigMap with the init scripts. Evaluated as a template.",
+            "default": ""
+        },
+        "initScriptsSecret": {
+            "type": "string",
+            "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+            "default": ""
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array containing extra env vars to be added to all pods (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars to be added to all pods (evaluated as a template)",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars to be added to all pods (evaluated as a template)",
+            "default": ""
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the all opensearch node pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the all opensearch node pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "useIstioLabels": {
+            "type": "boolean",
+            "description": "Use this variable to add Istio labels to all pods",
+            "default": true
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "OpenSearch image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "OpenSearch image repository",
+                    "default": "bitnami/opensearch"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "OpenSearch image tag (immutable tags are recommended)",
+                    "default": "2.9.0-debian-11-r23"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "OpenSearch image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "OpenSearch image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "OpenSearch image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable OpenSearch image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "security": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable X-Pack Security settings",
+                    "default": false
+                },
+                "adminPassword": {
+                    "type": "string",
+                    "description": "Password for 'admin' user",
+                    "default": ""
+                },
+                "logstashPassword": {
+                    "type": "string",
+                    "description": "Password for Logstash",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of the existing secret containing the OpenSearch password and",
+                    "default": ""
+                },
+                "fipsMode": {
+                    "type": "boolean",
+                    "description": "Configure opensearch with FIPS 140 compliant mode",
+                    "default": false
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "admin": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for admin",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "restEncryption": {
+                            "type": "boolean",
+                            "description": "Enable SSL/TLS encryption for OpenSearch REST API.",
+                            "default": false
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Create self-signed TLS certificates.",
+                            "default": true
+                        },
+                        "verificationMode": {
+                            "type": "string",
+                            "description": "Verification mode for SSL communications.",
+                            "default": "full"
+                        },
+                        "master": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the master nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the data nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "ingest": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the ingest nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "coordinating": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Existing secret containing the certificates for the coordinating nodes",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "keystoreFilename": {
+                            "type": "string",
+                            "description": "Name of the keystore file",
+                            "default": "opensearch.keystore.jks"
+                        },
+                        "truststoreFilename": {
+                            "type": "string",
+                            "description": "Name of the truststore",
+                            "default": "opensearch.truststore.jks"
+                        },
+                        "usePemCerts": {
+                            "type": "boolean",
+                            "description": "Use this variable if your secrets contain PEM certificates instead of JKS/PKCS12",
+                            "default": false
+                        },
+                        "passwordsSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing the Keystore and Truststore passwords, or key password if PEM certs are used",
+                            "default": ""
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access the JKS/PKCS12 keystore or PEM key when they are password-protected.",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access the JKS/PKCS12 truststore when they are password-protected.",
+                            "default": ""
+                        },
+                        "keyPassword": {
+                            "type": "string",
+                            "description": "Password to access the PEM key when they are password-protected.",
+                            "default": ""
+                        },
+                        "secretKeystoreKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the Keystore password",
+                            "default": ""
+                        },
+                        "secretTruststoreKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the Truststore password",
+                            "default": ""
+                        },
+                        "secretKey": {
+                            "type": "string",
+                            "description": "Name of the secret key containing the PEM key password",
+                            "default": ""
+                        },
+                        "nodesDN": {
+                            "type": "string",
+                            "description": "A comma separated list of DN for nodes",
+                            "default": ""
+                        },
+                        "adminDN": {
+                            "type": "string",
+                            "description": "A comma separated list of DN for admins",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "OpenSearch service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "restAPI": {
+                            "type": "number",
+                            "description": "OpenSearch service REST API port",
+                            "default": 9200
+                        },
+                        "transport": {
+                            "type": "number",
+                            "description": "OpenSearch service transport port",
+                            "default": 9300
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "restAPI": {
+                            "type": "string",
+                            "description": "Node port for REST API",
+                            "default": ""
+                        },
+                        "transport": {
+                            "type": "string",
+                            "description": "Node port for REST API",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "OpenSearch service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "OpenSearch service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "OpenSearch service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "OpenSearch service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for OpenSearch service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in OpenSearch service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for OpenSearch",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "opensearch.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "master": {
+            "type": "object",
+            "properties": {
+                "masterOnly": {
+                    "type": "boolean",
+                    "description": "Deploy the OpenSearch master-elegible nodes as master-only nodes. Recommended for high-demand deployments.",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of master-elegible replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override opensearch.master.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.master.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.master.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Master-elegible nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for opensearch containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for opensearch containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "OpenSearch master-eligible node heap size.",
+                    "default": "128m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled master-elegible pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set master-elegible pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Proxy container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled master-elegible containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set master-elegible containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set master-elegible containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set APISIX container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "master-elegible pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for master-elegible pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for master-elegible pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `master.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `master.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for master-elegible pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for master-elegible pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for master-elegible pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "master-elegible pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for master-elegible pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the OpenSearch Master pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of OpenSearch master pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (master nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (master nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (master nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (master nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (master nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (master-eligible nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (master-eligible nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (master-eligible nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (master-eligible nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (master-eligible nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (master-eligible nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (master-eligible nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (master-eligible nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (master-eligible nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (master-eligible nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the master-elegible container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to master-elegible nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for master-elegible nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for master-elegible nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the master-elegible pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the master-elegible container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the master-elegible pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the master-elegible pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using a `PersistentVolumeClaim`",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume Storage Class",
+                            "default": ""
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume Claim",
+                            "default": ""
+                        },
+                        "existingVolume": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume for use as volume match label selector to the `volumeClaimTemplate`. Ignored when `master.persistence.selector` is set.",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Configure custom selector for existing Persistent Volume. Overwrites `master.persistence.existingVolume`",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume Size",
+                            "default": "8Gi"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable creation of NetworkPolicy resources",
+                            "default": false
+                        },
+                        "allowExternal": {
+                            "type": "boolean",
+                            "description": "The Policy model to apply",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEgress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "vpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable VPA",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for VPA resource",
+                                    "default": {}
+                                },
+                                "controlledResources": {
+                                    "type": "array",
+                                    "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "maxAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Max allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "minAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Min allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "updatePolicy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "updateMode": {
+                                            "type": "string",
+                                            "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                            "default": "Auto"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable HPA for APISIX Data Plane",
+                                    "default": false
+                                },
+                                "minReplicas": {
+                                    "type": "number",
+                                    "description": "Minimum number of APISIX Data Plane replicas",
+                                    "default": 3
+                                },
+                                "maxReplicas": {
+                                    "type": "number",
+                                    "description": "Maximum number of APISIX Data Plane replicas",
+                                    "default": 11
+                                },
+                                "targetCPU": {
+                                    "type": "string",
+                                    "description": "Target CPU utilization percentage",
+                                    "default": ""
+                                },
+                                "targetMemory": {
+                                    "type": "string",
+                                    "description": "Target Memory utilization percentage",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of data-only replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override opensearch.data.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.data.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.data.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Data-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the data containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "2048Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "OpenSearch data node heap size.",
+                    "default": "1024m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled data pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set data pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Proxy container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled data containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set data containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set data containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set APISIX container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "data pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for data pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for data pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `data.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `data.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `data.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `data.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `data.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for data pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for data pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for data pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "data pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for data pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the OpenSearch data pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of OpenSearch data pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (data nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (data nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (data nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (data nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (data nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (data nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the data container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to data nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for data nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for data nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the data container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using a `PersistentVolumeClaim`",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume Storage Class",
+                            "default": ""
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume Claim",
+                            "default": ""
+                        },
+                        "existingVolume": {
+                            "type": "string",
+                            "description": "Existing Persistent Volume for use as volume match label selector to the `volumeClaimTemplate`. Ignored when `data.persistence.selector` is set.",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Configure custom selector for existing Persistent Volume. Overwrites `data.persistence.existingVolume`",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume Size",
+                            "default": "8Gi"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable creation of NetworkPolicy resources",
+                            "default": false
+                        },
+                        "allowExternal": {
+                            "type": "boolean",
+                            "description": "The Policy model to apply",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEgress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "vpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable VPA",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for VPA resource",
+                                    "default": {}
+                                },
+                                "controlledResources": {
+                                    "type": "array",
+                                    "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "maxAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Max allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "minAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Min allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "updatePolicy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "updateMode": {
+                                            "type": "string",
+                                            "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                            "default": "Auto"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable HPA for APISIX Data Plane",
+                                    "default": false
+                                },
+                                "minReplicas": {
+                                    "type": "number",
+                                    "description": "Minimum number of APISIX Data Plane replicas",
+                                    "default": 3
+                                },
+                                "maxReplicas": {
+                                    "type": "number",
+                                    "description": "Maximum number of APISIX Data Plane replicas",
+                                    "default": 11
+                                },
+                                "targetCPU": {
+                                    "type": "string",
+                                    "description": "Target CPU utilization percentage",
+                                    "default": ""
+                                },
+                                "targetMemory": {
+                                    "type": "string",
+                                    "description": "Target Memory utilization percentage",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "coordinating": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of coordinating-only replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override opensearch.coordinating.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.coordinating.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.coordinating.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Coordinating-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the coordinating-only containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "256Mi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "OpenSearch coordinating node heap size.",
+                    "default": "128m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled coordinating-only pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set coordinating-only pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Proxy container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled coordinating-only containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set coordinating-only containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set coordinating-only containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set APISIX container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "coordinating-only pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for coordinating-only pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for coordinating-only pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `coordinating.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `coordinating.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `coordinating.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `coordinating.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `coordinating.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for coordinating-only pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for coordinating-only pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for coordinating-only pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "coordinating-only pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for coordinating-only pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the OpenSearch coordinating pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of OpenSearch coordinating pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (coordinating-only nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (coordinating-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (coordinating-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (coordinating-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (coordinating-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (coordinating-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (coordinating-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (coordinating-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (coordinating-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (coordinating-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (coordinating-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (coordinating-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (coordinating-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (coordinating-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (coordinating-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the coordinating-only container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to coordinating-only nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for coordinating-only nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for coordinating-only nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the coordinating-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the coordinating-only container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the coordinating-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the coordinating-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable creation of NetworkPolicy resources",
+                            "default": false
+                        },
+                        "allowExternal": {
+                            "type": "boolean",
+                            "description": "The Policy model to apply",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEgress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "vpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable VPA",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for VPA resource",
+                                    "default": {}
+                                },
+                                "controlledResources": {
+                                    "type": "array",
+                                    "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "maxAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Max allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "minAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Min allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "updatePolicy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "updateMode": {
+                                            "type": "string",
+                                            "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                            "default": "Auto"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable HPA for APISIX Data Plane",
+                                    "default": false
+                                },
+                                "minReplicas": {
+                                    "type": "number",
+                                    "description": "Minimum number of APISIX Data Plane replicas",
+                                    "default": 3
+                                },
+                                "maxReplicas": {
+                                    "type": "number",
+                                    "description": "Maximum number of APISIX Data Plane replicas",
+                                    "default": 11
+                                },
+                                "targetCPU": {
+                                    "type": "string",
+                                    "description": "Target CPU utilization percentage",
+                                    "default": ""
+                                },
+                                "targetMemory": {
+                                    "type": "string",
+                                    "description": "Target Memory utilization percentage",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ingest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingest nodes",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of ingest-only replicas to deploy",
+                    "default": 2
+                },
+                "extraRoles": {
+                    "type": "array",
+                    "description": "Append extra roles to the node role",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override opensearch.ingest.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.ingest.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override ingest.master.servicename",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Ingest-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "256Mi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the ingest-only containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "OpenSearch ingest-only node heap size.",
+                    "default": "128m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled ingest-only pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set ingest-only pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Proxy container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled ingest-only containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set ingest-only containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set ingest-only containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set APISIX container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "ingest-only pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for ingest-only pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for ingest-only pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `ingest.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `ingest.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `ingest.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `ingest.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `ingest.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for ingest-only pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for ingest-only pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for ingest-only pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "ingest-only pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for ingest-only pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the OpenSearch ingest pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of OpenSearch ingest pods",
+                    "default": "Parallel"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (ingest-only nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (ingest-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (ingest-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (ingest-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (ingest-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (ingest-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (ingest-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (ingest-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (ingest-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (ingest-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (ingest-only nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (ingest-only nodes pod)",
+                            "default": 90
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (ingest-only nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (ingest-only nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (ingest-only nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the ingest-only container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to ingest-only nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for ingest-only nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for ingest-only nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the ingest-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the ingest-only container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the ingest-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the ingest-only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable creation of NetworkPolicy resources",
+                            "default": false
+                        },
+                        "allowExternal": {
+                            "type": "boolean",
+                            "description": "The Policy model to apply",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEgress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "vpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable VPA",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for VPA resource",
+                                    "default": {}
+                                },
+                                "controlledResources": {
+                                    "type": "array",
+                                    "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "maxAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Max allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "minAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Min allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "updatePolicy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "updateMode": {
+                                            "type": "string",
+                                            "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                            "default": "Auto"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable HPA for APISIX Data Plane",
+                                    "default": false
+                                },
+                                "minReplicas": {
+                                    "type": "number",
+                                    "description": "Minimum number of APISIX Data Plane replicas",
+                                    "default": 3
+                                },
+                                "maxReplicas": {
+                                    "type": "number",
+                                    "description": "Maximum number of APISIX Data Plane replicas",
+                                    "default": 11
+                                },
+                                "targetCPU": {
+                                    "type": "string",
+                                    "description": "Target CPU utilization percentage",
+                                    "default": ""
+                                },
+                                "targetMemory": {
+                                    "type": "string",
+                                    "description": "Target Memory utilization percentage",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Ingest-only service",
+                            "default": false
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "OpenSearch ingest-only service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "restAPI": {
+                                    "type": "number",
+                                    "description": "OpenSearch service REST API port",
+                                    "default": 9200
+                                },
+                                "transport": {
+                                    "type": "number",
+                                    "description": "OpenSearch service transport port",
+                                    "default": 9300
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "restAPI": {
+                                    "type": "string",
+                                    "description": "Node port for REST API",
+                                    "default": ""
+                                },
+                                "transport": {
+                                    "type": "string",
+                                    "description": "Node port for REST API",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "OpenSearch ingest-only service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "OpenSearch ingest-only service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "OpenSearch ingest-only service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "OpenSearch ingest-only service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for OpenSearch ingest-only service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for OpenSearch",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "opensearch-ingest.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "sysctlImage": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable kernel settings modifier image",
+                    "default": true
+                },
+                "registry": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image repository",
+                    "default": "bitnami/os-shell"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image tag",
+                    "default": "11-debian-11-r43"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Kernel settings modifier image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Kernel settings modifier image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "dashboards": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enables OpenSearch Dashboards deployment",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards image repository",
+                            "default": "bitnami/opensearch-dashboards"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards image tag (immutable tags are recommended)",
+                            "default": "2.9.0-debian-11-r23"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OpenSearch Dashboards image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable OpenSearch Dashboards image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "OpenSearch Dashboards service web UI port",
+                                    "default": 5601
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for web UI",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "OpenSearch Dashboards service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "OpenSearch Dashboards service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for OpenSearch Dashboards service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in OpenSearch Dashboards service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "OpenSearch Dashboards HTTP port",
+                            "default": 5601
+                        }
+                    }
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for OpenSearch Dashboards",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of data-only replicas to deploy",
+                    "default": 1
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "String to partially override opensearch.dashboards.fullname",
+                    "default": ""
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.dashboards.fullname",
+                    "default": ""
+                },
+                "servicenameOverride": {
+                    "type": "string",
+                    "description": "String to fully override opensearch.dashboards.servicename",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "25m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "2048Mi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the data containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Data-only nodes statefulset stategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "heapSize": {
+                    "type": "string",
+                    "description": "OpenSearch data node heap size.",
+                    "default": "1024m"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled data pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set dashboards pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Proxy container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled data containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set data containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set data containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set APISIX container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "data pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for data pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for data pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `dashboards.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `dashboards.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `dashboards.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `dashboards.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `dashboards.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for data pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for data pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for data pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "data pods' priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for data pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the OpenSearch data pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the startup probe (data nodes pod)",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before startup probe is initiated (data nodes pod)",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the liveness probe (data nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before liveness probe is initiated (data nodes pod)",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 8
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable/disable the readiness probe (data nodes pod)",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Delay before readiness probe is initiated (data nodes pod)",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "How often to perform the probe (data nodes pod)",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "When the probe times out (data nodes pod)",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded",
+                            "default": 5
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the data container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to data nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for data nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for data nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the data container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the data pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                            "default": {}
+                        }
+                    }
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable creation of NetworkPolicy resources",
+                            "default": false
+                        },
+                        "allowExternal": {
+                            "type": "boolean",
+                            "description": "The Policy model to apply",
+                            "default": true
+                        },
+                        "extraIngress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEgress": {
+                            "type": "array",
+                            "description": "Add extra ingress rules to the NetworkPolicy",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "vpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable VPA",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for VPA resource",
+                                    "default": {}
+                                },
+                                "controlledResources": {
+                                    "type": "array",
+                                    "description": "VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "maxAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Max allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "minAllowed": {
+                                    "type": "object",
+                                    "description": "VPA Min allowed resources for the pod",
+                                    "default": {}
+                                },
+                                "updatePolicy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "updateMode": {
+                                            "type": "string",
+                                            "description": "Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod",
+                                            "default": "Auto"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hpa": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable HPA for APISIX Data Plane",
+                                    "default": false
+                                },
+                                "minReplicas": {
+                                    "type": "number",
+                                    "description": "Minimum number of APISIX Data Plane replicas",
+                                    "default": 3
+                                },
+                                "maxReplicas": {
+                                    "type": "number",
+                                    "description": "Maximum number of APISIX Data Plane replicas",
+                                    "default": 11
+                                },
+                                "targetCPU": {
+                                    "type": "string",
+                                    "description": "Target CPU utilization percentage",
+                                    "default": ""
+                                },
+                                "targetMemory": {
+                                    "type": "string",
+                                    "description": "Target Memory utilization percentage",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS for OpenSearch Dashboards webserver",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing the certificates for OpenSearch Dashboards webserver",
+                            "default": ""
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Create self-signed TLS certificates.",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/osclass/values.schema.json
+++ b/bitnami/osclass/values.schema.json
@@ -1,0 +1,1340 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Osclass image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Osclass image repository",
+                    "default": "bitnami/osclass"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Osclass image tag (immutable tags are recommended)",
+                    "default": "8.1.2-debian-11-r54"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Osclass image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Osclass image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Osclass image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Bitnami debug mode in Osclass image",
+                    "default": false
+                }
+            }
+        },
+        "osclassSkipInstall": {
+            "type": "boolean",
+            "description": "Skip wizard installation",
+            "default": false
+        },
+        "osclassUsername": {
+            "type": "string",
+            "description": "Osclass username",
+            "default": "user"
+        },
+        "osclassSiteTitle": {
+            "type": "string",
+            "description": "Osclass site title",
+            "default": "user"
+        },
+        "osclassPassword": {
+            "type": "string",
+            "description": "Osclass user password",
+            "default": ""
+        },
+        "osclassEmail": {
+            "type": "string",
+            "description": "Osclass user email",
+            "default": "user@example.com"
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing Osclass credentials",
+            "default": ""
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow the container to be started with blank passwords",
+            "default": true
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP server host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP server port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP username",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP user password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol",
+            "default": ""
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Osclass pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Osclass pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Osclass containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Osclass container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Osclass container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the HTTP probe",
+                    "default": "/oc-admin"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the HTTP probe",
+                    "default": "/oc-admin"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the HTTP probe",
+                    "default": "/oc-admin"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "name of the secret with custom certificates",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "name of the secret with the chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "key of the secret with the chain",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location of the certificate inside the container",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location of the certificate key inside the container",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location of the certificate chain inside the container",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Array with custom CAs",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override certificate container command",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override certificate container args",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache Exporter image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache Exporter image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Apache Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Apache Exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "lifecycleHooks for the container to automate configuration before or after startup.",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Osclass pods",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Osclass pods",
+            "default": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Osclass replicas to deploy",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Osclass HTTP container port",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Osclass HTTPS container port",
+                    "default": 8443
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Osclass deployment strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Osclass deployment rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the Osclass container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Osclass pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Osclass container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Osclass pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Osclass pod",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Osclass container",
+                    "default": {}
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Osclass pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Osclass service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Osclass service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Osclass service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Osclass service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Osclass service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Osclass service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Osclass service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Osclass service external traffic policy",
+                    "default": "Cluster"
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Osclass",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "osclass.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External Database server host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Database server port",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "External Database username",
+                    "default": "bn_osclass"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External Database user password",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "External Database database name",
+                    "default": "bitnami_osclass"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password",
+                    "default": ""
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a MariaDB server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "MariaDB root password",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "MariaDB custom database",
+                            "default": "bitnami_osclass"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "MariaDB custom user name",
+                            "default": "bn_osclass"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MariaDB custom user password",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable persistence on MariaDB using PVC(s)",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "Persistent Volume storage class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Persistent Volume access modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Persistent Volume size",
+                                    "default": "8Gi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "If defined, the osclass-data volume will mount to the specified hostPath.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for Osclass",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of Osclass replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of Osclass replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a sidecar prometheus exporter to expose metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache Exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache Exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Apache Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Apache Exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Prometheus exporter container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Prometheus exporter container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations to add",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Metrics service type",
+                            "default": "ClusterIP"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Metrics service port",
+                            "default": 9117
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the ServiceMonitor will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "The interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "The timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Labels to honor to add to the scrape endpoint",
+                            "default": false
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by Osclass's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Osclass only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Osclass. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Osclass. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/parse/values.schema.json
+++ b/bitnami/parse/values.schema.json
@@ -1,0 +1,1344 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilites if not set)",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Parse image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Parse image repository",
+                            "default": "bitnami/parse"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Parse image tag (immutable tags are recommended)",
+                            "default": "6.2.2-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Parse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Parse pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Parse pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Parse Dashboard pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Parse Dashboard pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Parse Dashboard containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Parse Dashboard containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Parse Dashboard containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Parse Dashboard containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Parse server port",
+                            "default": 1337
+                        }
+                    }
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Parse server API mount path",
+                    "default": "/parse"
+                },
+                "appId": {
+                    "type": "string",
+                    "description": "Parse server App ID",
+                    "default": "myappID"
+                },
+                "masterKey": {
+                    "type": "string",
+                    "description": "Parse server Master Key",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of a Secret containing extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Parse pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Parse container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Parse pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Parse pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "enableCloudCode": {
+                    "type": "boolean",
+                    "description": "Enable Parse Cloud Code",
+                    "default": false
+                },
+                "cloudCodeScripts": {
+                    "type": "object",
+                    "description": "Cloud Code scripts",
+                    "default": {}
+                },
+                "existingCloudCodeScriptsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with Cloud Code scripts (Note: Overrides `cloudCodeScripts`).",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Parse Server pods' resource requests and limits",
+                    "default": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Parse containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 3
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Parse server pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Parse server pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Parse server node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Parse server node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Parse server node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Parse server affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Parse server node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Parse server tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Parse statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Parse pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Parse pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Parse container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "LoadBalancer"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Service HTTP port (Dashboard)",
+                                    "default": 1337
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Kubernetes HTTP node port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "dashboard": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable parse dashboard",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Dashboard image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Dashboard image repository",
+                            "default": "bitnami/parse-dashboard"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Dashboard image tag (immutable tags are recommended)",
+                            "default": "5.1.0-debian-11-r118"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Dashboard image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Parse Dashboard image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Parse Dashboard replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Parse Dashboard HTTP container port",
+                            "default": 4040
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Parse Dashboard pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Parse Dashboard pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Parse Dashboard containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Parse Dashboard containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Parse Dashboard containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Parse Dashboard containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Parse Dashboard application username",
+                    "default": "user"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Parse Dashboard application password",
+                    "default": ""
+                },
+                "appName": {
+                    "type": "string",
+                    "description": "Parse Dashboard application name",
+                    "default": "MyDashboard"
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Parse Dashboard pods' resource requests and limits",
+                    "default": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 240
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Parse Dashboard containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 0
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 3
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 2
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Parse Dashboard pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Parse Dashboard pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Parse dashboard pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Parse dashboard pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Parse dashboard node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Parse dashboard node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Parse dashboard node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Parse dashboard affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Parse dashboard node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Parse dashboard tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Parse statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Parse pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Parse pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Parse container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "parseServerUrlProtocol": {
+                    "type": "string",
+                    "description": "Protocol used by Parse Dashboard to form the URLs to Parse server",
+                    "default": "http"
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of a ConfigMap containing extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of a Secret containing extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Parse pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Parse container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Parse pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Parse pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "LoadBalancer"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Service HTTP port (Dashboard)",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Kubernetes HTTP node port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "dashboard": {
+                    "type": "object",
+                    "properties": {
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "parse-dashboard.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The Path to WordPress. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "parse-server.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress resource*' in order to use this with ALB ingress controllers.",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Parse persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Parse volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for Parse volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Parse volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image name",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "The resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "mongodb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable MongoDB&reg; chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable MongoDB&reg; password authentication",
+                            "default": true
+                        },
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "MongoDB&reg; admin password",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "MongoDB&reg; user",
+                            "default": "bn_parse"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MongoDB&reg; user password",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "MongoDB&reg; database",
+                            "default": "bitnami_parse"
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable MongoDB&reg; persistence using PVC",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for MongoDB&reg; volume",
+                            "default": ""
+                        },
+                        "accessMode": {
+                            "type": "string",
+                            "description": "PVC Access Mode for MongoDB&reg; volume",
+                            "default": "ReadWriteOnce"
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for MongoDB&reg; volume",
+                            "default": "8Gi"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/phpbb/values.schema.json
+++ b/bitnami/phpbb/values.schema.json
@@ -1,0 +1,1083 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all phpBB resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all phpBB resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "phpBB image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "phpBB image repository",
+                    "default": "bitnami/phpbb"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "phpBB image tag (immutable tags are recommended)",
+                    "default": "3.3.10-debian-11-r75"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "phpBB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "phpBB image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "phpbbSkipInstall": {
+            "type": "string",
+            "description": "Skip phpBB installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": "no"
+        },
+        "phpbbDisableSessionValidation": {
+            "type": "string",
+            "description": "Disable session validation",
+            "default": "yes"
+        },
+        "phpbbUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "phpbbPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "phpbbEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "allowEmptyPassword": {
+            "type": "string",
+            "description": "Allow DB blank passwords",
+            "default": "no"
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra env vars",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Extra volumes to add to the deployment. Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Extra volume mounts to add to the container. Normally used with `extraVolumes`",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Extra init containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Extra sidecar containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Use existing secret for the application password",
+            "default": ""
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Database data Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for phpBB volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for phpBB volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume Claim",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "Host mount path for phpBB volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable phpBB pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "phpBB pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable phpBB containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "phpBB containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "phpBB containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Define the priority class name to use for the phpbb pods",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration before or after startup",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod extra labels",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes HTTPS node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "phpbb service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "phpbb service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "phpbb service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for phpbb service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "phpbb.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to phpBB. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_phpbb"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_phpbb"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "PVC Access Modes for phpBB volume",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Host mount path for MariaDB volume",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Use existing secret (ignores previous password)",
+                    "default": ""
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external db",
+                    "default": "bn_phpbb"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_phpbb"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by phpBB's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes phpBB only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access phpBB. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access phpBB. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/phpmyadmin/values.schema.json
+++ b/bitnami/phpmyadmin/values.schema.json
@@ -1,0 +1,1026 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "phpMyAdmin image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "phpMyAdmin image repository",
+                    "default": "bitnami/phpmyadmin"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "phpMyAdmin image tag (immutable tags are recommended)",
+                    "default": "5.2.1-debian-11-r78"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "phpMyAdmin image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable phpmyadmin image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the phpmyadmin container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on PhpMyAdmin container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of a existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of a existing Secret containing extra env vars",
+            "default": ""
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "HTTP port to expose at container level",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "HTTPS port to expose at container level",
+                    "default": 8443
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Strategy to use to update Pods",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable phpMyAdmin pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "User ID for the container",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable phpMyAdmin containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Group ID for the volumes of the pod",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set phpmyadmin container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the PhpMyAdmin container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the PhpMyAdmin container",
+                    "default": {}
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Request path for startupProbe",
+                            "default": "/"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port for startupProbe",
+                            "default": "http"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 30
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Request path for livenessProbe",
+                            "default": "/"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port for livenessProbe",
+                            "default": "http"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 30
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Request path for readinessProbe",
+                            "default": "/"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "Port for readinessProbe",
+                            "default": "http"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 30
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for PhpMyAdmin pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for PhpMyAdmin pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "phpmyadmin pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for PhpMyAdmin pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for PhpMyAdmin container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add init containers to the PhpMyAdmin pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add sidecar containers to the PhpMyAdmin pods",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes http node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes https node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "PhpMyAdmin service clusterIP IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Load balancer IP for the phpMyAdmin Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Addresses that are allowed when service is LoadBalancer",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations that may be required for the PhpMyAdmin service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation",
+                    "default": false
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the ingress is enabled, a host pointing to this will be created",
+                    "default": "phpmyadmin.local"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates and want to manage the secret via helm,",
+                    "default": [],
+                    "items": {}
+                },
+                "existingSecretName": {
+                    "type": "string",
+                    "description": "If you're providing your own certificate and want to manage the secret yourself,",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "db": {
+            "type": "object",
+            "properties": {
+                "allowArbitraryServer": {
+                    "type": "boolean",
+                    "description": "Enable connection to arbitrary MySQL server",
+                    "default": true
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port to use to connect",
+                    "default": 3306
+                },
+                "chartName": {
+                    "type": "string",
+                    "description": "Database suffix if included in the same release",
+                    "default": ""
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Database Hostname. Ignored when `db.chartName` is set.",
+                    "default": ""
+                },
+                "bundleTestDB": {
+                    "type": "boolean",
+                    "description": "Deploy a MariaDB instance for testing purposes",
+                    "default": false
+                },
+                "enableSsl": {
+                    "type": "boolean",
+                    "description": "Enable SSL for the connection between phpMyAdmin and the database",
+                    "default": false
+                },
+                "ssl": {
+                    "type": "object",
+                    "properties": {
+                        "clientKey": {
+                            "type": "string",
+                            "description": "Client key file when using SSL",
+                            "default": ""
+                        },
+                        "clientCertificate": {
+                            "type": "string",
+                            "description": "Client certificate file when using SSL",
+                            "default": ""
+                        },
+                        "caCertificate": {
+                            "type": "string",
+                            "description": "CA file when using SSL",
+                            "default": ""
+                        },
+                        "ciphers": {
+                            "type": "array",
+                            "description": "List of allowable ciphers for connections when using SSL",
+                            "default": [],
+                            "items": {}
+                        },
+                        "verify": {
+                            "type": "boolean",
+                            "description": "Enable SSL certificate validation",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "description": "MariaDB chart configuration",
+            "default": {}
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for PhpMyAdmin pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus metrics service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Prometheus metrics service port",
+                            "default": 9117
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "phpmyadmin service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "phpmyadmin service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "phpmyadmin service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Specify the namespace in which the serviceMonitor resource will be created",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify Metric Relabelings to add to the scrape endpoint",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by phpMyAdmin's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes phpMyAdmin only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access phpMyAdmin. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access phpMyAdmin. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/pinniped/values.schema.json
+++ b/bitnami/pinniped/values.schema.json
@@ -1,0 +1,1315 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Pinniped image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Pinniped image repository",
+                    "default": "bitnami/pinniped"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Pinniped image tag (immutable tags are recommended)",
+                    "default": "0.25.0-debian-11-r9"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Pinniped image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Pinniped image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Pinniped image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "concierge": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Concierge",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Concierge replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "number",
+                            "description": "Concierge API container port",
+                            "default": 10250
+                        },
+                        "proxy": {
+                            "type": "number",
+                            "description": "Concierge Proxy container port",
+                            "default": 8444
+                        }
+                    }
+                },
+                "configurationPorts": {
+                    "type": "object",
+                    "properties": {
+                        "aggregatedAPIServerPort": {
+                            "type": "number",
+                            "description": "Concierge API configuration port",
+                            "default": 10250
+                        },
+                        "impersonationProxyServerPort": {
+                            "type": "number",
+                            "description": "Concierge Proxy configuration port",
+                            "default": 8444
+                        }
+                    }
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Concierge API and Proxy container hostNetwork",
+                    "default": false
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Concierge API and Proxy container dnsPolicy",
+                    "default": ""
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Concierge pinniped.yaml configuration file",
+                    "default": "discovery:\n  url: null\napi:\n  servingCertificate:\n    durationSeconds: 2592000\n    renewBeforeSeconds: 2160000\napiGroupSuffix: pinniped.dev\n{{- if .Values.concierge.configurationPorts.aggregatedAPIServerPort }}\naggregatedAPIServerPort: {{ .Values.concierge.configurationPorts.aggregatedAPIServerPort }}\n{{- end }}\n{{- if .Values.concierge.configurationPorts.impersonationProxyServerPort }}\nimpersonationProxyServerPort: {{ .Values.concierge.configurationPorts.impersonationProxyServerPort }}\n{{- end }}\nnames:\n  servingCertificateSecret: {{ printf \"%s-%s\" (include \"pinniped.concierge.api.fullname\" .) \"tls-serving-certificate\" | trunc 63 | trimSuffix \"-\" }}\n  credentialIssuer: {{ template \"pinniped.concierge.fullname\" . }}\n  apiService: {{ template \"pinniped.concierge.api.fullname\" . }}\n  impersonationLoadBalancerService: {{ printf \"%s-%s\" (include \"pinniped.concierge.impersonation-proxy.fullname\" .) \"load-balancer\" | trunc 63 | trimSuffix \"-\" }}\n  impersonationClusterIPService: {{ printf \"%s-%s\" (include \"pinniped.concierge.impersonation-proxy.fullname\" .) \"cluster-ip\" | trunc 63 | trimSuffix \"-\" }}\n  impersonationTLSCertificateSecret: {{ printf \"%s-%s\" (include \"pinniped.concierge.impersonation-proxy.fullname\" .) \"tls-serving-certificate\" | trunc 63 | trimSuffix \"-\" }}\n  impersonationCACertificateSecret: {{ printf \"%s-%s\" (include \"pinniped.concierge.impersonation-proxy.fullname\" .) \"ca-certificate\" | trunc 63 | trimSuffix \"-\" }}\n  impersonationSignerSecret: {{ printf \"%s-%s\" (include \"pinniped.concierge.impersonation-proxy.fullname\" .) \"signer-ca-certificate\" | trunc 63 | trimSuffix \"-\" }}\n  agentServiceAccount: {{ template \"pinniped.concierge.kube-cert-agent.fullname\" . }}\nlabels: {\"app\":\"pinniped-concierge\",\"app.kubernetes.io/part-of\":\"pinniped\", \"app.kubernetes.io/component\": \"concierge\", \"app.kubernetes.io/instance\": \"{{ .Release.Name }}\"}\nkubeCertAgent:\n  namePrefix: {{ printf \"%s-%s\" (include \"pinniped.concierge.fullname\" .) \"kube-cert-agent\" | trunc 63 | trimSuffix \"-\" }}-\n  image: {{ template \"pinniped.image\" . }}\n"
+                },
+                "credentialIssuerConfig": {
+                    "type": "string",
+                    "description": "Configuration for the credential issuer",
+                    "default": "impersonationProxy:\n  mode: auto\n  service:\n    type: LoadBalancer\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: \"4000\"\n"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Concierge containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Concierge containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Concierge containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Concierge containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Concierge containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Concierge pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Concierge pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Concierge containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Concierge containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Concierge containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Enable readOnlyRootFilesystem",
+                            "default": false
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with your custom configuration for Concierge",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "deployAPIService": {
+                    "type": "boolean",
+                    "description": "Deploy the APIService objects",
+                    "default": true
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Concierge pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Concierge pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Concierge pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `concierge.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `concierge.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `concierge.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `concierge.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `concierge.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Concierge pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Concierge pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Concierge pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Concierge statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Concierge pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "object",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Concierge pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Concierge container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Concierge nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Concierge nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Concierge nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Concierge pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Concierge container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Concierge pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Concierge pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create Concierge RBAC objects",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "concierge": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of an existing Service Account for the Concierge Deployment",
+                                    "default": ""
+                                },
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Create a Service Account for the Concierge Deployment",
+                                    "default": true
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Auto mount token for the Concierge Deployment Service Account",
+                                    "default": true
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the Concierge Service Account",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "impersonationProxy": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of an existing Service Account for the Concierge Impersonator",
+                                    "default": ""
+                                },
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Create a Service Account for the Concierge Impersonator",
+                                    "default": true
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Auto mount token for the Concierge Impersonator Service Account",
+                                    "default": true
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the Concierge Service Account",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "kubeCertAgentService": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of an existing Service Account for the Concierge kube-cert-agent-service",
+                                    "default": ""
+                                },
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "Create a Service Account for the Concierge kube-cert-agent-service",
+                                    "default": true
+                                },
+                                "automountServiceAccountToken": {
+                                    "type": "boolean",
+                                    "description": "Auto mount token for the Concierge kube-cert-agent-service Service Account",
+                                    "default": true
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the Concierge Service Account",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Concierge service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "https": {
+                                    "type": "number",
+                                    "description": "Concierge service HTTPS port",
+                                    "default": 443
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "https": {
+                                    "type": "string",
+                                    "description": "Node port for HTTPS",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Concierge service Cluster IP",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Add labels to the service",
+                            "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Concierge service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Concierge service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Concierge service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Concierge service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Concierge service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "supervisor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy Supervisor",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supervisor replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "number",
+                            "description": "Supervisor HTTP container port",
+                            "default": 8443
+                        }
+                    }
+                },
+                "deployAPIService": {
+                    "type": "boolean",
+                    "description": "Deploy the APIService objects",
+                    "default": true
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Supervisor pinniped.yaml configuration file",
+                    "default": "apiGroupSuffix: pinniped.dev\nnames:\n  defaultTLSCertificateSecret: {{ printf \"%s-%s\" (include \"pinniped.supervisor.fullname\" .) \"default-tls-certificate\" | trunc 63 | trimSuffix \"-\" }}\n  apiService: {{ template \"pinniped.supervisor.api.fullname\" . }}\nlabels: {\"app.kubernetes.io/part-of\":\"pinniped\", \"app.kubernetes.io/component\": \"supervisor\", \"app.kubernetes.io/instance\": \"{{ .Release.Name }}\"}\ninsecureAcceptExternalUnencryptedHttpRequests: false\n"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supervisor containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supervisor containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supervisor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supervisor containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supervisor containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supervisor pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supervisor pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supervisor containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supervisor containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supervisor containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Enable readOnlyRootFilesystem",
+                            "default": false
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with your custom configuration for Supervisor",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supervisor pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supervisor pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supervisor pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `supervisor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `supervisor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `supervisor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `supervisor.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `supervisor.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supervisor pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supervisor pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supervisor pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supervisor statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supervisor pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "object",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supervisor pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supervisor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supervisor nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supervisor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supervisor nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supervisor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supervisor container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supervisor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supervisor pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create Supervisor RBAC objects",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of an existing Service Account for the Supervisor Deployment",
+                            "default": ""
+                        },
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a Service Account for the Supervisor Deployment",
+                            "default": true
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Auto mount token for the Supervisor Deployment Service Account",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the Supervisor Service Account",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "api": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Supervisor API service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "https": {
+                                            "type": "number",
+                                            "description": "Supervisor API service HTTPS port",
+                                            "default": 443
+                                        },
+                                        "aggregatedAPIServer": {
+                                            "type": "number",
+                                            "description": "Supervisor aggregated API server port",
+                                            "default": 10250
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "https": {
+                                            "type": "string",
+                                            "description": "Node port for HTTPS",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Supervisor service Cluster IP",
+                                    "default": ""
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Add labels to the service",
+                                    "default": {}
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Supervisor service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Supervisor service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Supervisor service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Supervisor service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Supervisor service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "public": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Supervisor user-facing service type",
+                                    "default": "LoadBalancer"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "https": {
+                                            "type": "number",
+                                            "description": "Supervisor user-facing service HTTPS port",
+                                            "default": 443
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "https": {
+                                            "type": "string",
+                                            "description": "Node port for HTTPS",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Supervisor service Cluster IP",
+                                    "default": ""
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Add labels to the service",
+                                    "default": {}
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Supervisor service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Supervisor service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Supervisor service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Supervisor service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Supervisor service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where client requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Pinniped Supervisor",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "pinniped-supervisor.local"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/postgresql-ha/values.schema.json
+++ b/bitnami/postgresql-ha/values.schema.json
@@ -1,0 +1,2924 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "postgresql": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "PostgreSQL username (overrides `postgresql.username`)",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "PostgreSQL password (overrides `postgresql.password`)",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "PostgreSQL database (overrides `postgresql.database`)",
+                            "default": ""
+                        },
+                        "repmgrUsername": {
+                            "type": "string",
+                            "description": "PostgreSQL repmgr username (overrides `postgresql.repmgrUsername`)",
+                            "default": ""
+                        },
+                        "repmgrPassword": {
+                            "type": "string",
+                            "description": "PostgreSQL repmgr password (overrides `postgresql.repmgrpassword`)",
+                            "default": ""
+                        },
+                        "repmgrDatabase": {
+                            "type": "string",
+                            "description": "PostgreSQL repmgr database (overrides `postgresql.repmgrDatabase`)",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL passwords (overrides `postgresql.existingSecret`)",
+                            "default": ""
+                        }
+                    }
+                },
+                "ldap": {
+                    "type": "object",
+                    "properties": {
+                        "bindpw": {
+                            "type": "string",
+                            "description": "LDAP bind password (overrides `ldap.bindpw`)",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for LDAP passwords (overrides `ldap.existingSecret`)",
+                            "default": ""
+                        }
+                    }
+                },
+                "pgpool": {
+                    "type": "object",
+                    "properties": {
+                        "adminUsername": {
+                            "type": "string",
+                            "description": "Pgpool Admin username (overrides `pgpool.adminUsername`)",
+                            "default": ""
+                        },
+                        "adminPassword": {
+                            "type": "string",
+                            "description": "Pgpool Admin password (overrides `pgpool.adminPassword`)",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Pgpool existing secret",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL with Repmgr image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL with Repmgr image repository",
+                            "default": "bitnami/postgresql-repmgr"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL with Repmgr image tag",
+                            "default": "15.4.0-debian-11-r19"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "PostgreSQL with Repmgr image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Specify if debug logs should be enabled",
+                            "default": false
+                        }
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels to add to the StatefulSet. Evaluated as template",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Labels to add to the StatefulSet pods. Evaluated as template",
+                    "default": {}
+                },
+                "serviceAnnotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations for PostgreSQL service",
+                    "default": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of replicas to deploy. Use an odd number. Having 3 replicas is the minimum to get quorum when promoting a new primary.",
+                    "default": 3
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Postgresql statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "postgresql": {
+                            "type": "number",
+                            "description": "PostgreSQL port",
+                            "default": 5432
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for PostgreSQL pod",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for PostgreSQL pod",
+                    "default": false
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL pod affinity preset. Ignored if `postgresql.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL pod anti-affinity preset. Ignored if `postgresql.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL node affinity preset type. Ignored if `postgresql.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "PostgreSQL node label key to match Ignored if `postgresql.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "PostgreSQL node label values to match. Ignored if `postgresql.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for PostgreSQL pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for PostgreSQL pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for PostgreSQL pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Pod priority class",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds PostgreSQL pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for PostgreSQL with Repmgr",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the PostgreSQL with Repmgr filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the PostgreSQL with Repmgr container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the PostgreSQL with Repmgr container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL with Repmgr containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL with Repmgr containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL with Repmgr container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set PostgreSQL with Repmgr container's Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set PostgreSQL with Repmgr container's Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook to set additional configuration at startup, e.g. LDAP settings via REST API. Evaluated as a template",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the container. Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Extra init containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra sidecar containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether to create a Pod disruption budget for PostgreSQL with Repmgr",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number / percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number / percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "username": {
+                    "type": "string",
+                    "description": "PostgreSQL username",
+                    "default": "postgres"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "PostgreSQL password",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "PostgreSQL database",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "PostgreSQL password using existing secret",
+                    "default": ""
+                },
+                "postgresPassword": {
+                    "type": "string",
+                    "description": "PostgreSQL password for the `postgres` user when `username` is not `postgres`",
+                    "default": ""
+                },
+                "usePasswordFile": {
+                    "type": "string",
+                    "description": "Set to `true` to mount PostgreSQL secret as a file instead of passing environment variable",
+                    "default": ""
+                },
+                "repmgrUsePassfile": {
+                    "type": "string",
+                    "description": "Set to `true` to configure repmgrl to use `passfile` instead of `password` vars*:*:*:username:password\" and use it to configure Repmgr instead of using password (Requires Postgresql 10+, otherwise ignored)",
+                    "default": ""
+                },
+                "repmgrPassfilePath": {
+                    "type": "string",
+                    "description": "Custom path where `passfile` will be stored",
+                    "default": ""
+                },
+                "upgradeRepmgrExtension": {
+                    "type": "boolean",
+                    "description": "Upgrade repmgr extension in the database",
+                    "default": false
+                },
+                "pgHbaTrustAll": {
+                    "type": "boolean",
+                    "description": "Configures PostgreSQL HBA to trust every user",
+                    "default": false
+                },
+                "syncReplication": {
+                    "type": "boolean",
+                    "description": "Make the replication synchronous. This will wait until the data is synchronized in all the replicas before other query can be run. This ensures the data availability at the expenses of speed.",
+                    "default": false
+                },
+                "syncReplicationMode": {
+                    "type": "string",
+                    "description": "This specifies the method to choose synchronous standbys from the listed servers. Valid values: empty, FIRST, ANY.",
+                    "default": ""
+                },
+                "repmgrUsername": {
+                    "type": "string",
+                    "description": "PostgreSQL Repmgr username",
+                    "default": "repmgr"
+                },
+                "repmgrPassword": {
+                    "type": "string",
+                    "description": "PostgreSQL Repmgr password",
+                    "default": ""
+                },
+                "repmgrDatabase": {
+                    "type": "string",
+                    "description": "PostgreSQL Repmgr database",
+                    "default": "repmgr"
+                },
+                "repmgrLogLevel": {
+                    "type": "string",
+                    "description": "Repmgr log level (DEBUG, INFO, NOTICE, WARNING, ERROR, ALERT, CRIT or EMERG)",
+                    "default": "NOTICE"
+                },
+                "repmgrConnectTimeout": {
+                    "type": "number",
+                    "description": "Repmgr backend connection timeout (in seconds)",
+                    "default": 5
+                },
+                "repmgrReconnectAttempts": {
+                    "type": "number",
+                    "description": "Repmgr backend reconnection attempts",
+                    "default": 2
+                },
+                "repmgrReconnectInterval": {
+                    "type": "number",
+                    "description": "Repmgr backend reconnection interval (in seconds)",
+                    "default": 3
+                },
+                "repmgrFenceOldPrimary": {
+                    "type": "boolean",
+                    "description": "Set if fencing of old primary in multiple primary situation is desired",
+                    "default": false
+                },
+                "repmgrChildNodesCheckInterval": {
+                    "type": "number",
+                    "description": "Repmgr child nodes check interval (in seconds)",
+                    "default": 5
+                },
+                "repmgrChildNodesConnectedMinCount": {
+                    "type": "number",
+                    "description": "Repmgr minimum number of connected child nodes before being considered as failed primary for fencing",
+                    "default": 1
+                },
+                "repmgrChildNodesDisconnectTimeout": {
+                    "type": "number",
+                    "description": "Repmgr time before node will be fenced when insufficient child nodes are detected (in seconds)",
+                    "default": 30
+                },
+                "usePgRewind": {
+                    "type": "boolean",
+                    "description": "Use pg_rewind for standby failover (experimental)",
+                    "default": false
+                },
+                "audit": {
+                    "type": "object",
+                    "properties": {
+                        "logHostname": {
+                            "type": "boolean",
+                            "description": "Add client hostnames to the log file",
+                            "default": true
+                        },
+                        "logConnections": {
+                            "type": "boolean",
+                            "description": "Add client log-in operations to the log file",
+                            "default": false
+                        },
+                        "logDisconnections": {
+                            "type": "boolean",
+                            "description": "Add client log-outs operations to the log file",
+                            "default": false
+                        },
+                        "pgAuditLog": {
+                            "type": "string",
+                            "description": "Add operations to log using the pgAudit extension",
+                            "default": ""
+                        },
+                        "pgAuditLogCatalog": {
+                            "type": "string",
+                            "description": "Log catalog using pgAudit",
+                            "default": "off"
+                        },
+                        "clientMinMessages": {
+                            "type": "string",
+                            "description": "Message log level to share with the user",
+                            "default": "error"
+                        },
+                        "logLinePrefix": {
+                            "type": "string",
+                            "description": "Template string for the log line prefix",
+                            "default": ""
+                        },
+                        "logTimezone": {
+                            "type": "string",
+                            "description": "Timezone for the log timestamps",
+                            "default": ""
+                        }
+                    }
+                },
+                "sharedPreloadLibraries": {
+                    "type": "string",
+                    "description": "Shared preload libraries (comma-separated list)",
+                    "default": "pgaudit, repmgr"
+                },
+                "maxConnections": {
+                    "type": "string",
+                    "description": "Maximum total connections",
+                    "default": ""
+                },
+                "postgresConnectionLimit": {
+                    "type": "string",
+                    "description": "Maximum connections for the postgres user",
+                    "default": ""
+                },
+                "dbUserConnectionLimit": {
+                    "type": "string",
+                    "description": "Maximum connections for the created user",
+                    "default": ""
+                },
+                "tcpKeepalivesInterval": {
+                    "type": "string",
+                    "description": "TCP keepalives interval",
+                    "default": ""
+                },
+                "tcpKeepalivesIdle": {
+                    "type": "string",
+                    "description": "TCP keepalives idle",
+                    "default": ""
+                },
+                "tcpKeepalivesCount": {
+                    "type": "string",
+                    "description": "TCP keepalives count",
+                    "default": ""
+                },
+                "statementTimeout": {
+                    "type": "string",
+                    "description": "Statement timeout",
+                    "default": ""
+                },
+                "pghbaRemoveFilters": {
+                    "type": "string",
+                    "description": "Comma-separated list of patterns to remove from the pg_hba.conf file",
+                    "default": ""
+                },
+                "extraInitContainers": {
+                    "type": "array",
+                    "description": "Extra init containers",
+                    "default": [],
+                    "items": {}
+                },
+                "repmgrConfiguration": {
+                    "type": "string",
+                    "description": "Repmgr configuration",
+                    "default": ""
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "PostgreSQL configuration",
+                    "default": ""
+                },
+                "pgHbaConfiguration": {
+                    "type": "string",
+                    "description": "PostgreSQL client authentication configuration",
+                    "default": ""
+                },
+                "configurationCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with configuration files",
+                    "default": ""
+                },
+                "extendedConf": {
+                    "type": "string",
+                    "description": "Extended PostgreSQL configuration (appended to main or default configuration). Implies `volumePermissions.enabled`.",
+                    "default": ""
+                },
+                "extendedConfCM": {
+                    "type": "string",
+                    "description": "ConfigMap with PostgreSQL extended configuration",
+                    "default": ""
+                },
+                "initdbScripts": {
+                    "type": "object",
+                    "description": "Dictionary of initdb scripts",
+                    "default": {}
+                },
+                "initdbScriptsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with scripts to be run at first boot",
+                    "default": ""
+                },
+                "initdbScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret with scripts to be run at first boot",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS traffic support for end-client connections",
+                            "default": false
+                        },
+                        "preferServerCiphers": {
+                            "type": "boolean",
+                            "description": "Whether to use the server's TLS cipher preferences rather than the client's",
+                            "default": true
+                        },
+                        "certificatesSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret that contains the certificates",
+                            "default": ""
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "Certificate filename",
+                            "default": ""
+                        },
+                        "certKeyFilename": {
+                            "type": "string",
+                            "description": "Certificate key filename",
+                            "default": ""
+                        }
+                    }
+                },
+                "preStopDelayAfterPgStopSeconds": {
+                    "type": "number",
+                    "description": "Minimal number of seconds preStop hook waits after postgres instance is stopped",
+                    "default": 25
+                },
+                "headlessWithNotReadyAddresses": {
+                    "type": "boolean",
+                    "description": "set postgres headless service into publishNotReadyAddresses mode",
+                    "default": false
+                }
+            }
+        },
+        "witness": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create PostgreSQL witness nodes",
+                    "default": false
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels to add to the StatefulSet. Evaluated as template",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Labels to add to the StatefulSet pods. Evaluated as template",
+                    "default": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of replicas to deploy.",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Postgresql statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "postgresql": {
+                            "type": "number",
+                            "description": "PostgreSQL witness port",
+                            "default": 5432
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for PostgreSQL witness pod",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for PostgreSQL witness pod",
+                    "default": false
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL witness pod affinity preset. Ignored if `witness.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL witness pod anti-affinity preset. Ignored if `witness.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL witness node affinity preset type. Ignored if `witness.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "PostgreSQL witness node label key to match Ignored if `witness.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "PostgreSQL witness node label values to match. Ignored if `witness.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for PostgreSQL witness pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for PostgreSQL witness pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for PostgreSQL witness pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Pod priority class",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds PostgreSQL witness pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for PostgreSQL witness with Repmgr",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the PostgreSQL witness with Repmgr filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the PostgreSQL witness with Repmgr container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the PostgreSQL witness with Repmgr container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL witness with Repmgr containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL witness with Repmgr containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL witness with Repmgr container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set PostgreSQL witness with Repmgr container's Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set PostgreSQL witness with Repmgr container's Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook to set additional configuration at startup, e.g. LDAP settings via REST API. Evaluated as a template",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the container. Normally used with `extraVolumes`.",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Extra init containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra sidecar containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether to create a Pod disruption budget for PostgreSQL witness with Repmgr",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number / percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number / percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "upgradeRepmgrExtension": {
+                    "type": "boolean",
+                    "description": "Upgrade repmgr extension in the database",
+                    "default": false
+                },
+                "pgHbaTrustAll": {
+                    "type": "boolean",
+                    "description": "Configures PostgreSQL HBA to trust every user",
+                    "default": false
+                },
+                "repmgrLogLevel": {
+                    "type": "string",
+                    "description": "Repmgr log level (DEBUG, INFO, NOTICE, WARNING, ERROR, ALERT, CRIT or EMERG)",
+                    "default": "NOTICE"
+                },
+                "repmgrConnectTimeout": {
+                    "type": "number",
+                    "description": "Repmgr backend connection timeout (in seconds)",
+                    "default": 5
+                },
+                "repmgrReconnectAttempts": {
+                    "type": "number",
+                    "description": "Repmgr backend reconnection attempts",
+                    "default": 2
+                },
+                "repmgrReconnectInterval": {
+                    "type": "number",
+                    "description": "Repmgr backend reconnection interval (in seconds)",
+                    "default": 3
+                },
+                "audit": {
+                    "type": "object",
+                    "properties": {
+                        "logHostname": {
+                            "type": "boolean",
+                            "description": "Add client hostnames to the log file",
+                            "default": true
+                        },
+                        "logConnections": {
+                            "type": "boolean",
+                            "description": "Add client log-in operations to the log file",
+                            "default": false
+                        },
+                        "logDisconnections": {
+                            "type": "boolean",
+                            "description": "Add client log-outs operations to the log file",
+                            "default": false
+                        },
+                        "pgAuditLog": {
+                            "type": "string",
+                            "description": "Add operations to log using the pgAudit extension",
+                            "default": ""
+                        },
+                        "pgAuditLogCatalog": {
+                            "type": "string",
+                            "description": "Log catalog using pgAudit",
+                            "default": "off"
+                        },
+                        "clientMinMessages": {
+                            "type": "string",
+                            "description": "Message log level to share with the user",
+                            "default": "error"
+                        },
+                        "logLinePrefix": {
+                            "type": "string",
+                            "description": "Template string for the log line prefix",
+                            "default": ""
+                        },
+                        "logTimezone": {
+                            "type": "string",
+                            "description": "Timezone for the log timestamps",
+                            "default": ""
+                        }
+                    }
+                },
+                "maxConnections": {
+                    "type": "string",
+                    "description": "Maximum total connections",
+                    "default": ""
+                },
+                "postgresConnectionLimit": {
+                    "type": "string",
+                    "description": "Maximum connections for the postgres user",
+                    "default": ""
+                },
+                "dbUserConnectionLimit": {
+                    "type": "string",
+                    "description": "Maximum connections for the created user",
+                    "default": ""
+                },
+                "tcpKeepalivesInterval": {
+                    "type": "string",
+                    "description": "TCP keepalives interval",
+                    "default": ""
+                },
+                "tcpKeepalivesIdle": {
+                    "type": "string",
+                    "description": "TCP keepalives idle",
+                    "default": ""
+                },
+                "tcpKeepalivesCount": {
+                    "type": "string",
+                    "description": "TCP keepalives count",
+                    "default": ""
+                },
+                "statementTimeout": {
+                    "type": "string",
+                    "description": "Statement timeout",
+                    "default": ""
+                },
+                "pghbaRemoveFilters": {
+                    "type": "string",
+                    "description": "Comma-separated list of patterns to remove from the pg_hba.conf file",
+                    "default": ""
+                },
+                "extraInitContainers": {
+                    "type": "array",
+                    "description": "Extra init containers",
+                    "default": [],
+                    "items": {}
+                },
+                "repmgrConfiguration": {
+                    "type": "string",
+                    "description": "Repmgr configuration",
+                    "default": ""
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "PostgreSQL configuration",
+                    "default": ""
+                },
+                "pgHbaConfiguration": {
+                    "type": "string",
+                    "description": "PostgreSQL client authentication configuration",
+                    "default": ""
+                },
+                "configurationCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with configuration files",
+                    "default": ""
+                },
+                "extendedConf": {
+                    "type": "string",
+                    "description": "Extended PostgreSQL configuration (appended to main or default configuration). Implies `volumePermissions.enabled`.",
+                    "default": ""
+                },
+                "extendedConfCM": {
+                    "type": "string",
+                    "description": "ConfigMap with PostgreSQL extended configuration",
+                    "default": ""
+                },
+                "initdbScripts": {
+                    "type": "object",
+                    "description": "Dictionary of initdb scripts",
+                    "default": {}
+                },
+                "initdbScriptsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with scripts to be run at first boot",
+                    "default": ""
+                },
+                "initdbScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret with scripts to be run at first boot",
+                    "default": ""
+                }
+            }
+        },
+        "pgpool": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Pgpool image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Pgpool image repository",
+                            "default": "bitnami/pgpool"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Pgpool image tag",
+                            "default": "4.4.4-debian-11-r13"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Pgpool image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Pgpool image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Specify if debug logs should be enabled",
+                            "default": false
+                        }
+                    }
+                },
+                "customUsers": {
+                    "type": "object",
+                    "properties": {
+                        "usernames": {
+                            "type": "string",
+                            "description": "Comma or semicolon separated list of additional users that will be performing connections to the database using pgpool.",
+                            "default": ""
+                        },
+                        "passwords": {
+                            "type": "string",
+                            "description": "Comma or semicolon separated list of the associated passwords for the users above. Must have the same number of elements as the usernames list.",
+                            "default": ""
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "customUsersSecret": {
+                    "type": "string",
+                    "description": "Name of a secret containing the usernames and passwords of accounts that will be added to pgpool_passwd",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Pgpool admin password using existing secret",
+                    "default": ""
+                },
+                "srCheckDatabase": {
+                    "type": "string",
+                    "description": "Name of the database to perform streaming replication checks",
+                    "default": "postgres"
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels to add to the Deployment. Evaluated as template",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Labels to add to the pods. Evaluated as template",
+                    "default": {}
+                },
+                "serviceLabels": {
+                    "type": "object",
+                    "description": "Labels to add to the service. Evaluated as template",
+                    "default": {}
+                },
+                "serviceAnnotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations for Pgpool service",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook to set additional configuration at startup, e.g. LDAP settings via REST API. Evaluated as a template",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the container. Normally used with `extraVolumes`",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Extra init containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra sidecar containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "The number of replicas to deploy",
+                    "default": 1
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Pod priority class",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds pgpool pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pgpool pod affinity preset. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pgpool pod anti-affinity preset. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Pgpool node affinity preset type. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Pgpool node label key to match Ignored if `pgpool.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Pgpool node label values to match. Ignored if `pgpool.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Pgpool pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Pgpool pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Pgpool pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for Pgpool",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the Pgpool filesystem",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the Pgpool container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "User ID for the Pgpool container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Pgpool containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Pgpool containers' Security Context runAsNonRoot",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Pgpool container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Pgpool container's Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Pgpool container's Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a Pod disruption budget should be created for Pgpool pods",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number / percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number / percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "description": "Strategy used to replace old Pods by new ones",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "postgresql": {
+                            "type": "number",
+                            "description": "Pgpool port",
+                            "default": 5432
+                        }
+                    }
+                },
+                "minReadySeconds": {
+                    "type": "string",
+                    "description": "How many seconds a pod needs to be ready before killing the next, during update",
+                    "default": ""
+                },
+                "adminUsername": {
+                    "type": "string",
+                    "description": "Pgpool Admin username",
+                    "default": "admin"
+                },
+                "adminPassword": {
+                    "type": "string",
+                    "description": "Pgpool Admin password",
+                    "default": ""
+                },
+                "usePasswordFile": {
+                    "type": "string",
+                    "description": "Set to `true` to mount pgpool secret as a file instead of passing environment variable",
+                    "default": ""
+                },
+                "authenticationMethod": {
+                    "type": "string",
+                    "description": "Pgpool authentication method. Use 'md5' for PSQL < 14.",
+                    "default": "scram-sha-256"
+                },
+                "logConnections": {
+                    "type": "boolean",
+                    "description": "Log all client connections (PGPOOL_ENABLE_LOG_CONNECTIONS)",
+                    "default": false
+                },
+                "logHostname": {
+                    "type": "boolean",
+                    "description": "Log the client hostname instead of IP address (PGPOOL_ENABLE_LOG_HOSTNAME)",
+                    "default": true
+                },
+                "logPerNodeStatement": {
+                    "type": "boolean",
+                    "description": "Log every SQL statement for each DB node separately (PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT)",
+                    "default": false
+                },
+                "logLinePrefix": {
+                    "type": "string",
+                    "description": "Format of the log entry lines (PGPOOL_LOG_LINE_PREFIX)",
+                    "default": ""
+                },
+                "clientMinMessages": {
+                    "type": "string",
+                    "description": "Log level for clients",
+                    "default": "error"
+                },
+                "numInitChildren": {
+                    "type": "string",
+                    "description": "The number of preforked Pgpool-II server processes. It is also the concurrent",
+                    "default": ""
+                },
+                "reservedConnections": {
+                    "type": "number",
+                    "description": "Number of reserved connections. When zero, excess connection block. When non-zero, excess connections are refused with an error message.",
+                    "default": 1
+                },
+                "maxPool": {
+                    "type": "string",
+                    "description": "The maximum number of cached connections in each child process (PGPOOL_MAX_POOL)",
+                    "default": ""
+                },
+                "childMaxConnections": {
+                    "type": "string",
+                    "description": "The maximum number of client connections in each child process (PGPOOL_CHILD_MAX_CONNECTIONS)",
+                    "default": ""
+                },
+                "childLifeTime": {
+                    "type": "string",
+                    "description": "The time in seconds to terminate a Pgpool-II child process if it remains idle (PGPOOL_CHILD_LIFE_TIME)",
+                    "default": ""
+                },
+                "clientIdleLimit": {
+                    "type": "string",
+                    "description": "The time in seconds to disconnect a client if it remains idle since the last query (PGPOOL_CLIENT_IDLE_LIMIT)",
+                    "default": ""
+                },
+                "connectionLifeTime": {
+                    "type": "string",
+                    "description": "The time in seconds to terminate the cached connections to the PostgreSQL backend (PGPOOL_CONNECTION_LIFE_TIME)",
+                    "default": ""
+                },
+                "useLoadBalancing": {
+                    "type": "boolean",
+                    "description": "Use Pgpool Load-Balancing",
+                    "default": true
+                },
+                "loadBalancingOnWrite": {
+                    "type": "string",
+                    "description": "LoadBalancer on write actions behavior",
+                    "default": "transaction"
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Pgpool configuration",
+                    "default": ""
+                },
+                "configurationCM": {
+                    "type": "string",
+                    "description": "ConfigMap with Pgpool configuration",
+                    "default": ""
+                },
+                "initdbScripts": {
+                    "type": "object",
+                    "description": "Dictionary of initdb scripts",
+                    "default": {}
+                },
+                "initdbScriptsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with scripts to be run every time Pgpool container is initialized",
+                    "default": ""
+                },
+                "initdbScriptsSecret": {
+                    "type": "string",
+                    "description": "Secret with scripts to be run every time Pgpool container is initialized",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS traffic support for end-client connections",
+                            "default": false
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                            "default": false
+                        },
+                        "preferServerCiphers": {
+                            "type": "boolean",
+                            "description": "Whether to use the server's TLS cipher preferences rather than the client's",
+                            "default": true
+                        },
+                        "certificatesSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret that contains the certificates",
+                            "default": ""
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "Certificate filename",
+                            "default": ""
+                        },
+                        "certKeyFilename": {
+                            "type": "string",
+                            "description": "Certificate key filename",
+                            "default": ""
+                        },
+                        "certCAFilename": {
+                            "type": "string",
+                            "description": "CA Certificate filename",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP support",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of existing secret to use for LDAP passwords",
+                    "default": ""
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "LDAP URL beginning in the form `ldap[s]://<hostname>:<port>`",
+                    "default": ""
+                },
+                "basedn": {
+                    "type": "string",
+                    "description": "LDAP base DN",
+                    "default": ""
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "LDAP bind DN",
+                    "default": ""
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "LDAP bind password",
+                    "default": ""
+                },
+                "bslookup": {
+                    "type": "string",
+                    "description": "LDAP base lookup",
+                    "default": ""
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "LDAP search scope",
+                    "default": ""
+                },
+                "tlsReqcert": {
+                    "type": "string",
+                    "description": "LDAP TLS check on server certificates",
+                    "default": ""
+                },
+                "nssInitgroupsIgnoreusers": {
+                    "type": "string",
+                    "description": "LDAP ignored users",
+                    "default": "root,nslcd"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create Role and RoleBinding (required for PSP to work)",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Airflow pods",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                }
+            }
+        },
+        "psp": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PostgreSQL Prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter image repository",
+                            "default": "bitnami/postgres-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter image tag",
+                            "default": "0.13.2-debian-11-r36"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Specify if debug logs should be enabled",
+                            "default": false
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for PostgreSQL Prometheus exporter",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the PostgreSQL Prometheus exporter container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the PostgreSQL Prometheus exporter container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL Prometheus exporter container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set PostgreSQL Prometheus exporter  container's Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Prometheus metrics exporter port",
+                            "default": 9187
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 10
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter metrics service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "PostgreSQL Prometheus exporter metrics service port",
+                                    "default": 9187
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "string",
+                                    "description": "PostgreSQL Prometheus exporter Node Port",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter metrics service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "PostgreSQL Prometheus exporter service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus exporter service external traffic policy",
+                            "default": "Cluster"
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9187"
+                                }
+                            }
+                        }
+                    }
+                },
+                "customMetrics": {
+                    "type": "object",
+                    "description": "Additional custom metrics",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array containing extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Optional namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "How frequently to scrape metrics (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Service monitor scrape timeout",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "kube-prometheus"
+                                }
+                            }
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "ServiceMonitor relabelings. Value is evaluated as a template",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "ServiceMonitor metricRelabelings. Value is evaluated as a template",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container to adapt volume permissions",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r54"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Init container volume-permissions User ID",
+                            "default": 0
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the init container volume-permissions container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Security Context runAsNonRoot for the init container volume-permissions container",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Security Context seccompProfile for the init container volume-permissions container",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable data persistence",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume and Claim",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "The path the volume will be mounted at, useful when using different PostgreSQL images.",
+                    "default": "/bitnami/postgresql"
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "List of access modes of data volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume Claim size",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim labels",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "postgresql": {
+                            "type": "number",
+                            "description": "PostgreSQL port",
+                            "default": 5432
+                        }
+                    }
+                },
+                "portName": {
+                    "type": "string",
+                    "description": "PostgreSQL service port name",
+                    "default": "postgresql"
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "postgresql": {
+                            "type": "string",
+                            "description": "Kubernetes service nodePort",
+                            "default": ""
+                        }
+                    }
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Load balancer IP if service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Addresses that are allowed when service is LoadBalancer",
+                    "default": [],
+                    "items": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Set the Cluster IP to use",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations both for PostgreSQL and Pgpool services",
+                    "default": {}
+                },
+                "serviceLabels": {
+                    "type": "object",
+                    "description": "Labels for PostgreSQL service",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable NetworkPolicy",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53)",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/postgresql/values.schema.json
+++ b/bitnami/postgresql/values.schema.json
@@ -1,156 +1,2537 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "architecture": {
-      "type": "string",
-      "title": "PostgreSQL architecture",
-      "form": true,
-      "description": "Allowed values: `standalone` or `replication`"
-    },
-    "auth": {
-      "type": "object",
-      "title": "Authentication configuration",
-      "form": true,
-      "properties": {
-        "enablePostgresUser": {
-          "type": "boolean",
-          "title": "Enable \"postgres\" admin user",
-          "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
-          "form": true
-        },
-        "postgresPassword": {
-          "type": "string",
-          "title": "Password for the \"postgres\" admin user",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true
-        },
-        "database": {
-          "type": "string",
-          "title": "PostgreSQL custom database",
-          "description": "Name of the custom database to be created during the 1st initialization of PostgreSQL",
-          "form": true
-        },
-        "username": {
-          "type": "string",
-          "title": "PostgreSQL custom user",
-          "description": "Name of the custom user to be created during the 1st initialization of PostgreSQL. This user only has permissions on the PostgreSQL custom database",
-          "form": true
-        },
-        "password": {
-          "type": "string",
-          "title": "Password for the custom user to create",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true
-        },
-        "replicationUsername": {
-          "type": "string",
-          "title": "PostgreSQL replication user",
-          "description": "Name of user used to manage replication.",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        },
-        "replicationPassword": {
-          "type": "string",
-          "title": "Password for PostgreSQL replication user",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        }
-      }
-    },
-    "persistence": {
-      "type": "object",
-      "properties": {
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi"
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Required Resources",
-      "description": "Configure resource requests",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "postgresql": {
+                    "type": "object",
+                    "properties": {
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "postgresPassword": {
+                                    "type": "string",
+                                    "description": "Password for the \"postgres\" admin user (overrides `auth.postgresPassword`)",
+                                    "default": ""
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "description": "Name for a custom user to create (overrides `auth.username`)",
+                                    "default": ""
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "description": "Password for the custom user to create (overrides `auth.password`)",
+                                    "default": ""
+                                },
+                                "database": {
+                                    "type": "string",
+                                    "description": "Name for a custom database to create (overrides `auth.database`)",
+                                    "default": ""
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing secret to use for PostgreSQL credentials (overrides `auth.existingSecret`).",
+                                    "default": ""
+                                },
+                                "secretKeys": {
+                                    "type": "object",
+                                    "properties": {
+                                        "adminPasswordKey": {
+                                            "type": "string",
+                                            "description": "Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.adminPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.",
+                                            "default": ""
+                                        },
+                                        "userPasswordKey": {
+                                            "type": "string",
+                                            "description": "Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.userPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.",
+                                            "default": ""
+                                        },
+                                        "replicationPasswordKey": {
+                                            "type": "string",
+                                            "description": "Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.replicationPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "postgresql": {
+                                            "type": "string",
+                                            "description": "PostgreSQL service port (overrides `service.ports.postgresql`)",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
-    },
-    "replication": {
-      "type": "object",
-      "form": true,
-      "title": "Replication Details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Replication",
-          "form": true
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "PostgreSQL image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "PostgreSQL image repository",
+                    "default": "bitnami/postgresql"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "PostgreSQL image tag (immutable tags are recommended)",
+                    "default": "15.4.0-debian-11-r10"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "PostgreSQL image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enablePostgresUser": {
+                    "type": "boolean",
+                    "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                    "default": true
+                },
+                "postgresPassword": {
+                    "type": "string",
+                    "description": "Password for the \"postgres\" admin user. Ignored if `auth.existingSecret` is provided",
+                    "default": ""
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Name for a custom user to create",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the custom user to create. Ignored if `auth.existingSecret` is provided",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name for a custom database to create",
+                    "default": ""
+                },
+                "replicationUsername": {
+                    "type": "string",
+                    "description": "Name of the replication user",
+                    "default": "repl_user"
+                },
+                "replicationPassword": {
+                    "type": "string",
+                    "description": "Password for the replication user. Ignored if `auth.existingSecret` is provided",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of existing secret to use for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.",
+                    "default": ""
+                },
+                "secretKeys": {
+                    "type": "object",
+                    "properties": {
+                        "adminPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.",
+                            "default": "postgres-password"
+                        },
+                        "userPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.",
+                            "default": "password"
+                        },
+                        "replicationPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.",
+                            "default": "replication-password"
+                        }
+                    }
+                },
+                "usePasswordFiles": {
+                    "type": "boolean",
+                    "description": "Mount credentials as a files instead of using an environment variable",
+                    "default": false
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "PostgreSQL architecture (`standalone` or `replication`)",
+            "default": "standalone"
+        },
+        "replication": {
+            "type": "object",
+            "properties": {
+                "synchronousCommit": {
+                    "type": "string",
+                    "description": "Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`",
+                    "default": "off"
+                },
+                "numSynchronousReplicas": {
+                    "type": "number",
+                    "description": "Number of replicas that will have synchronous replication. Note: Cannot be greater than `readReplicas.replicaCount`.",
+                    "default": 0
+                },
+                "applicationName": {
+                    "type": "string",
+                    "description": "Cluster application name. Useful for advanced replication settings",
+                    "default": "my_application"
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "postgresql": {
+                    "type": "number",
+                    "description": "PostgreSQL container port",
+                    "default": 5432
+                }
+            }
+        },
+        "audit": {
+            "type": "object",
+            "properties": {
+                "logHostname": {
+                    "type": "boolean",
+                    "description": "Log client hostnames",
+                    "default": false
+                },
+                "logConnections": {
+                    "type": "boolean",
+                    "description": "Add client log-in operations to the log file",
+                    "default": false
+                },
+                "logDisconnections": {
+                    "type": "boolean",
+                    "description": "Add client log-outs operations to the log file",
+                    "default": false
+                },
+                "pgAuditLog": {
+                    "type": "string",
+                    "description": "Add operations to log using the pgAudit extension",
+                    "default": ""
+                },
+                "pgAuditLogCatalog": {
+                    "type": "string",
+                    "description": "Log catalog using pgAudit",
+                    "default": "off"
+                },
+                "clientMinMessages": {
+                    "type": "string",
+                    "description": "Message log level to share with the user",
+                    "default": "error"
+                },
+                "logLinePrefix": {
+                    "type": "string",
+                    "description": "Template for log line prefix (default if not set)",
+                    "default": ""
+                },
+                "logTimezone": {
+                    "type": "string",
+                    "description": "Timezone for the log timestamps",
+                    "default": ""
+                }
+            }
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP support",
+                    "default": false
+                },
+                "server": {
+                    "type": "string",
+                    "description": "IP address or name of the LDAP server.",
+                    "default": ""
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port number on the LDAP server to connect to",
+                    "default": ""
+                },
+                "prefix": {
+                    "type": "string",
+                    "description": "String to prepend to the user name when forming the DN to bind",
+                    "default": ""
+                },
+                "suffix": {
+                    "type": "string",
+                    "description": "String to append to the user name when forming the DN to bind",
+                    "default": ""
+                },
+                "basedn": {
+                    "type": "string",
+                    "description": "Root DN to begin the search for the user in",
+                    "default": ""
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "DN of user to bind to LDAP",
+                    "default": ""
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "Password for the user to bind to LDAP",
+                    "default": ""
+                },
+                "searchAttribute": {
+                    "type": "string",
+                    "description": "Attribute to match against the user name in the search",
+                    "default": ""
+                },
+                "searchFilter": {
+                    "type": "string",
+                    "description": "The search filter to use when doing search+bind authentication",
+                    "default": ""
+                },
+                "scheme": {
+                    "type": "string",
+                    "description": "Set to `ldaps` to use LDAPS",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Se to true to enable TLS encryption",
+                            "default": false
+                        }
+                    }
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "LDAP URL beginning in the form `ldap[s]://host[:port]/basedn`. If provided, all the other LDAP parameters will be ignored.",
+                    "default": ""
+                }
+            }
+        },
+        "postgresqlDataDir": {
+            "type": "string",
+            "description": "PostgreSQL data dir folder",
+            "default": "/bitnami/postgresql/data"
+        },
+        "postgresqlSharedPreloadLibraries": {
+            "type": "string",
+            "description": "Shared preload libraries (comma-separated list)",
+            "default": "pgaudit"
+        },
+        "shmVolume": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable emptyDir volume for /dev/shm for PostgreSQL pod(s)",
+                    "default": true
+                },
+                "sizeLimit": {
+                    "type": "string",
+                    "description": "Set this to enable a size limit on the shm tmpfs",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS traffic support",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates",
+                    "default": false
+                },
+                "preferServerCiphers": {
+                    "type": "boolean",
+                    "description": "Whether to use the server's TLS cipher preferences rather than the client's",
+                    "default": true
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret that contains the certificates",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "Certificate filename",
+                    "default": ""
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "description": "Certificate key filename",
+                    "default": ""
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "description": "CA Certificate filename",
+                    "default": ""
+                },
+                "crlFilename": {
+                    "type": "string",
+                    "description": "File containing a Certificate Revocation List",
+                    "default": ""
+                }
+            }
+        },
+        "primary": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the primary database (eg primary, master, leader, ...)",
+                    "default": "primary"
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "PostgreSQL Primary main configuration to be injected as ConfigMap",
+                    "default": ""
+                },
+                "pgHbaConfiguration": {
+                    "type": "string",
+                    "description": "PostgreSQL Primary client authentication configuration",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing ConfigMap with PostgreSQL Primary configuration",
+                    "default": ""
+                },
+                "extendedConfiguration": {
+                    "type": "string",
+                    "description": "Extended PostgreSQL Primary configuration (appended to main or default configuration)",
+                    "default": ""
+                },
+                "existingExtendedConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing ConfigMap with PostgreSQL Primary extended configuration",
+                    "default": ""
+                },
+                "initdb": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "string",
+                            "description": "PostgreSQL initdb extra arguments",
+                            "default": ""
+                        },
+                        "postgresqlWalDir": {
+                            "type": "string",
+                            "description": "Specify a custom location for the PostgreSQL transaction log",
+                            "default": ""
+                        },
+                        "scripts": {
+                            "type": "object",
+                            "description": "Dictionary of initdb scripts",
+                            "default": {}
+                        },
+                        "scriptsConfigMap": {
+                            "type": "string",
+                            "description": "ConfigMap with scripts to be run at first boot",
+                            "default": ""
+                        },
+                        "scriptsSecret": {
+                            "type": "string",
+                            "description": "Secret with scripts to be run at first boot (in case it contains sensitive information)",
+                            "default": ""
+                        },
+                        "user": {
+                            "type": "string",
+                            "description": "Specify the PostgreSQL username to execute the initdb scripts",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Specify the PostgreSQL password to execute the initdb scripts",
+                            "default": ""
+                        }
+                    }
+                },
+                "standby": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to enable current cluster's primary as standby server of another cluster or not",
+                            "default": false
+                        },
+                        "primaryHost": {
+                            "type": "string",
+                            "description": "The Host of replication primary in the other cluster",
+                            "default": ""
+                        },
+                        "primaryPort": {
+                            "type": "string",
+                            "description": "The Port of replication primary in the other cluster",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to PostgreSQL Primary nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for PostgreSQL Primary nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for PostgreSQL Primary nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on PostgreSQL Primary containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on PostgreSQL Primary containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on PostgreSQL Primary containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the PostgreSQL Primary container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL Primary containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the PostgreSQL Primary containers",
+                                    "default": "256Mi"
+                                },
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested cpu for the PostgreSQL Primary containers",
+                                    "default": "250m"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set runAsNonRoot for the container",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set allowPrivilegeEscalation for the container",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set seccompProfile.type for the container",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set capabilities.drop for the container",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "PostgreSQL primary pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for PostgreSQL pod (postgresql primary)",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)",
+                    "default": false
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the statefulset (postgresql primary)",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for PostgreSQL primary pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the pods (postgresql primary)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Map of annotations to add to the pods (postgresql primary)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL primary pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL primary pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL primary node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "PostgreSQL primary node label key to match Ignored if `primary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "PostgreSQL primary node label values to match. Ignored if `primary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for PostgreSQL primary pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for PostgreSQL primary pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for PostgreSQL primary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class to use for each pod (postgresql primary)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds PostgreSQL primary pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL Primary statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "PostgreSQL Primary statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the PostgreSQL Primary container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the PostgreSQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the PostgreSQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the PostgreSQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPodSpec": {
+                    "type": "object",
+                    "description": "Optionally specify extra PodSpec for the PostgreSQL Primary pod(s)",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "string",
+                                    "description": "Node port for PostgreSQL",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for PostgreSQL primary service",
+                            "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the PostgreSQL primary service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for headless PostgreSQL primary service",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable PostgreSQL Primary data persistence using PVC",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at",
+                            "default": "/bitnami/postgresql"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for PostgreSQL Primary data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Mode for PostgreSQL volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for PostgreSQL volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Persistent volume retention policy for Primary Statefulset",
+                            "default": false
+                        },
+                        "whenScaled": {
+                            "type": "string",
+                            "description": "Volume retention behavior when the replica count of the StatefulSet is reduced",
+                            "default": "Retain"
+                        },
+                        "whenDeleted": {
+                            "type": "string",
+                            "description": "Volume retention behavior that applies when the StatefulSet is deleted",
+                            "default": "Retain"
+                        }
+                    }
+                }
+            }
         },
         "readReplicas": {
-          "type": "integer",
-          "title": "read Replicas",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the read replicas database (eg secondary, slave, ...)",
+                    "default": "read"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of PostgreSQL read only replicas",
+                    "default": 1
+                },
+                "extendedConfiguration": {
+                    "type": "string",
+                    "description": "Extended PostgreSQL read only replicas configuration (appended to main or default configuration)",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to PostgreSQL read only nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for PostgreSQL read only nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for PostgreSQL read only nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on PostgreSQL read only containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on PostgreSQL read only containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on PostgreSQL read only containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the PostgreSQL read only container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL read only containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the PostgreSQL read only containers",
+                                    "default": "256Mi"
+                                },
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested cpu for the PostgreSQL read only containers",
+                                    "default": "250m"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set runAsNonRoot for the container",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set allowPrivilegeEscalation for the container",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set seccompProfile.type for the container",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set capabilities.drop for the container",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "PostgreSQL read only pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for PostgreSQL pod (PostgreSQL read only)",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)",
+                    "default": false
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the statefulset (PostgreSQL read only)",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for PostgreSQL read only pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the pods (PostgreSQL read only)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Map of annotations to add to the pods (PostgreSQL read only)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL read only pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL read only pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL read only node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "PostgreSQL read only node label key to match Ignored if `primary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "PostgreSQL read only node label values to match. Ignored if `primary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for PostgreSQL read only pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for PostgreSQL read only pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for PostgreSQL read only pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class to use for each pod (PostgreSQL read only)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds PostgreSQL read only pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL read only statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "PostgreSQL read only statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the PostgreSQL read only container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the PostgreSQL read only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the PostgreSQL read only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the PostgreSQL read only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPodSpec": {
+                    "type": "object",
+                    "description": "Optionally specify extra PodSpec for the PostgreSQL read only pod(s)",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "string",
+                                    "description": "Node port for PostgreSQL",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for PostgreSQL read only service",
+                            "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the PostgreSQL read only service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for headless PostgreSQL read only service",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable PostgreSQL read only data persistence using PVC",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at",
+                            "default": "/bitnami/postgresql"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for PostgreSQL read only data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Mode for PostgreSQL volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for PostgreSQL volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Persistent volume retention policy for read only Statefulset",
+                            "default": false
+                        },
+                        "whenScaled": {
+                            "type": "string",
+                            "description": "Volume retention behavior when the replica count of the StatefulSet is reduced",
+                            "default": "Retain"
+                        },
+                        "whenDeleted": {
+                            "type": "string",
+                            "description": "Volume retention behavior that applies when the StatefulSet is deleted",
+                            "default": "Retain"
+                        }
+                    }
+                }
+            }
+        },
+        "backup": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the logical dump of the database \"regularly\"",
+                    "default": false
+                },
+                "cronjob": {
+                    "type": "object",
+                    "properties": {
+                        "schedule": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter schedule",
+                            "default": "@daily"
+                        },
+                        "concurrencyPolicy": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter concurrencyPolicy",
+                            "default": "Allow"
+                        },
+                        "failedJobsHistoryLimit": {
+                            "type": "number",
+                            "description": "Set the cronjob parameter failedJobsHistoryLimit",
+                            "default": 1
+                        },
+                        "successfulJobsHistoryLimit": {
+                            "type": "number",
+                            "description": "Set the cronjob parameter successfulJobsHistoryLimit",
+                            "default": 3
+                        },
+                        "startingDeadlineSeconds": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter startingDeadlineSeconds",
+                            "default": ""
+                        },
+                        "ttlSecondsAfterFinished": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter ttlSecondsAfterFinished",
+                            "default": ""
+                        },
+                        "restartPolicy": {
+                            "type": "string",
+                            "description": "Set the cronjob parameter restartPolicy",
+                            "default": "OnFailure"
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "User ID for the backup container",
+                                    "default": 1001
+                                },
+                                "runAsGroup": {
+                                    "type": "number",
+                                    "description": "Group ID for the backup container",
+                                    "default": 0
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set backup container's Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Is the container itself readonly",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Is it possible to escalate backup pod(s) privileges",
+                                    "default": false
+                                },
+                                "seccompProfile": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Set backup container's Security Context seccompProfile type",
+                                            "default": "RuntimeDefault"
+                                        }
+                                    }
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set backup container's Security Context capabilities to drop",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Set backup container's command to run",
+                            "default": [
+                                "/bin/sh",
+                                "-c",
+                                "pg_dumpall --clean --if-exists --load-via-partition-root --quote-all-identifiers --no-password --file=${PGDUMP_DIR}/pg_dumpall-$(date '+%Y-%m-%d-%H-%M').pgdump"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Set the cronjob labels",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Set the cronjob annotations",
+                            "default": {}
+                        },
+                        "storage": {
+                            "type": "object",
+                            "properties": {
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)",
+                                    "default": ""
+                                },
+                                "resourcePolicy": {
+                                    "type": "string",
+                                    "description": "Setting it to \"keep\" to avoid removing PVCs during a helm delete operation. Leaving it empty will delete PVCs after the chart deleted",
+                                    "default": ""
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class for the backup data volume",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "PV Access Mode",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "PVC Storage Request for the backup data volume",
+                                    "default": "8Gi"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "PVC annotations",
+                                    "default": {}
+                                },
+                                "mountPath": {
+                                    "type": "string",
+                                    "description": "Path to mount the volume at ",
+                                    "default": "/backup/pgdump"
+                                },
+                                "subPath": {
+                                    "type": "string",
+                                    "description": "Subdirectory of the volume to mount at",
+                                    "default": ""
+                                },
+                                "volumeClaimTemplates": {
+                                    "type": "object",
+                                    "properties": {
+                                        "selector": {
+                                            "type": "object",
+                                            "description": "A label query over volumes to consider for binding (e.g. when using local volumes)",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policies for metrics (prometheus)",
+                            "default": false
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "primaryAccessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes PostgreSQL primary node only accessible from a particular origin.",
+                                    "default": false
+                                },
+                                "customRules": {
+                                    "type": "array",
+                                    "description": "Custom network policy for the PostgreSQL primary node.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "readReplicasAccessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes PostgreSQL read-only nodes only accessible from a particular origin.",
+                                    "default": false
+                                },
+                                "customRules": {
+                                    "type": "array",
+                                    "description": "Custom network policy for the PostgreSQL read-only nodes.",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "array",
+                            "description": "Custom network policy rule",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the init container",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "runAsNonRoot for the init container",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "seccompProfile.type for the init container",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for PostgreSQL pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create Role and RoleBinding (required for PSP to work)",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "psp": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image repository",
+                            "default": "bitnami/postgres-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)",
+                            "default": "0.13.2-debian-11-r25"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "customMetrics": {
+                    "type": "object",
+                    "description": "Define additional custom metrics",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to PostgreSQL Prometheus exporter",
+                    "default": [],
+                    "items": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable PostgreSQL Prometheus exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set PostgreSQL Prometheus exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set PostgreSQL Prometheus exporter containers' Security Context runAsGroup",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL Prometheus exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL Prometheus exporter containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set PostgreSQL Prometheus exporter containers' Security Context seccompProfile.type",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set PostgreSQL Prometheus exporter containers' Security Context capabilities.drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on PostgreSQL Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on PostgreSQL Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on PostgreSQL Prometheus exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "PostgreSQL Prometheus exporter metrics container port",
+                            "default": 9187
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL Prometheus exporter container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the PostgreSQL Prometheus exporter container",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "PostgreSQL Prometheus Exporter service port",
+                                    "default": 9187
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.metrics }}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a PrometheusRule for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "PrometheusRule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
         }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Change the owner of the persist volume mountpoint to RunAsUser:fsGroup"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Configure metrics exporter",
-          "form": true
-        }
-      }
     }
-  }
 }

--- a/bitnami/prestashop/values.schema.json
+++ b/bitnami/prestashop/values.schema.json
@@ -1,0 +1,1248 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override prestashop.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override prestashop.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all PrestaShop resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all PrestaShop resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array with extra yaml to deploy with the chart. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "PrestaShop image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "PrestaShop image repository",
+                    "default": "bitnami/prestashop"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "PrestaShop image tag (immutable tags are recommended)",
+                    "default": "8.1.1-debian-11-r12"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "PrestaShop image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "PrestaShop image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of PrestaShop Pods to run (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "prestashopSkipInstall": {
+            "type": "boolean",
+            "description": "Skip PrestaShop installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "prestashopHost": {
+            "type": "string",
+            "description": "PrestaShop host to create application URLs (when ingress, it will be ignored)",
+            "default": ""
+        },
+        "prestashopUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user@example.com"
+        },
+        "prestashopPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "prestashopEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "prestashopFirstName": {
+            "type": "string",
+            "description": "First Name",
+            "default": "Bitnami"
+        },
+        "prestashopLastName": {
+            "type": "string",
+            "description": "Last Name",
+            "default": "User"
+        },
+        "prestashopCookieCheckIP": {
+            "type": "string",
+            "description": "Whether to check the cookie's IP address or not",
+            "default": "no"
+        },
+        "prestashopCountry": {
+            "type": "string",
+            "description": "Default country of the store",
+            "default": "us"
+        },
+        "prestashopLanguage": {
+            "type": "string",
+            "description": "Default language of the store (ISO code)",
+            "default": "en"
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": true
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Extra volumes to add to the deployment. Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Extra volume mounts to add to the container. Normally used with `extraVolumes`",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Extra init containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Extra sidecar containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "PrestaShop pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Use existing secret for the application password",
+            "default": ""
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP Protocol (options: ssl,tls, nil)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Sets HTTP port inside NGINX container",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "Sets HTTPS port inside NGINX container",
+                    "default": 8443
+                }
+            }
+        },
+        "sessionAffinity": {
+            "type": "string",
+            "description": "Control where client requests go, to the same pod or round-robin",
+            "default": "None"
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PrestaShop Data Persistent Volume Storage Class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for PrestaShop volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for PrestaShop volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "If defined, the prestashop-data volume will mount to the specified hostPath",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PrestaShop pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "PrestaShop pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PrestaShop containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "PrestaShop containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "PrestaShop containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod extra labels",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Control hosts connecting to \"LoadBalancer\" only",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Load balancerIP for the PrestaShop Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes HTTPS node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for PrestaShop service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Override API Version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "prestashop.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress resource*' in order to use this",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Create TLS Secret",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_prestashop"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_prestashop"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB primary persistent volume storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Database Persistent Volume Access Modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the existing database",
+                    "default": "bn_prestashop"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_prestashop"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password",
+                    "default": ""
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r21"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Apache exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container for the metrics exporter container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by PrestaShop's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes PrestaShop only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access PrestaShop. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access PrestaShop. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/prometheus/values.schema.json
+++ b/bitnami/prometheus/values.schema.json
@@ -128,7 +128,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Alertmanager image tag (immutable tags are recommended)",
-                            "default": "0.25.0-debian-11-r48"
+                            "default": "0.26.0-debian-11-r11"
                         },
                         "digest": {
                             "type": "string",
@@ -788,7 +788,7 @@
                         "tag": {
                             "type": "string",
                             "description": "Prometheus image tag (immutable tags are recommended)",
-                            "default": "2.44.0-debian-11-r0"
+                            "default": "2.47.0-debian-11-r0"
                         },
                         "digest": {
                             "type": "string",
@@ -811,7 +811,7 @@
                 "configuration": {
                     "type": "string",
                     "description": "Promethus configuration. This content will be stored in the the prometheus.yaml file and the content can be a template.",
-                    "default": "global:\n  {{- if .Values.server.scrapeInterval }}\n  scrape_interval: {{ .Values.server.scrapeInterval }}\n  {{- end }}\n  {{- if .Values.server.scrapeTimeout }}\n  scrape_timeout: {{ .Values.server.scrapeTimeout }}\n  {{- end }}\n  {{- if .Values.server.evaluationInterval }}\n  evaluation_interval: {{ .Values.server.evaluationInterval }}\n  {{- end }}\n  external_labels:\n    monitor: {{ template \"common.names.fullname\" . }}\n    {{- if .Values.server.externalLabels }}\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.externalLabels \"context\" $) | nindent 4 }}\n    {{- end }}\n{{- if .Values.server.remoteWrite }}\nremote_write: {{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.remoteWrite \"context\" $) | nindent 4 }}\n{{- end }}\nscrape_configs:\n  - job_name: prometheus\n  {{- include \"prometheus.scrape_config\" (dict \"component\" \"server\" \"context\" $) | nindent 4 }}\n{{- if .Values.alertmanager.enabled }}\n  - job_name: alertmanager\n    {{- include \"prometheus.scrape_config\" (dict \"component\" \"alertmanager\" \"context\" $) | nindent 4 }}\n{{- end }}\n{{- if .Values.server.extraScrapeConfigs}}\n{{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.extraScrapeConfigs \"context\" $) | nindent 2 }}\n{{- end }}\n{{- if or .Values.alertmanager.enabled .Values.server.alertingEndpoints}}\nalerting:\n  alertmanagers:\n    {{- if .Values.server.alertingEndpoints }}\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.alertingEndpoints \"context\" $) | nindent 4 }}\n    {{- end }}\n    - scheme: HTTP\n      static_configs:\n        - targets: [ {{ printf \"%s:%d\" (include \"prometheus.alertmanager.fullname\" .) (int .Values.alertmanager.service.ports.http) }}]\nrule_files:\n  - rules.yaml\n{{- end }}\n"
+                    "default": "global:\n  {{- if .Values.server.scrapeInterval }}\n  scrape_interval: {{ .Values.server.scrapeInterval }}\n  {{- end }}\n  {{- if .Values.server.scrapeTimeout }}\n  scrape_timeout: {{ .Values.server.scrapeTimeout }}\n  {{- end }}\n  {{- if .Values.server.evaluationInterval }}\n  evaluation_interval: {{ .Values.server.evaluationInterval }}\n  {{- end }}\n  external_labels:\n    monitor: {{ template \"common.names.fullname\" . }}\n    {{- if .Values.server.externalLabels }}\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.externalLabels \"context\" $) | nindent 4 }}\n    {{- end }}\n{{- if .Values.server.remoteWrite }}\nremote_write: {{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.remoteWrite \"context\" $) | nindent 4 }}\n{{- end }}\nscrape_configs:\n  - job_name: prometheus\n  {{- include \"prometheus.scrape_config\" (dict \"component\" \"server\" \"context\" $) | nindent 4 }}\n{{- if .Values.alertmanager.enabled }}\n  - job_name: alertmanager\n    {{- include \"prometheus.scrape_config\" (dict \"component\" \"alertmanager\" \"context\" $) | nindent 4 }}\n{{- end }}\n{{- if .Values.server.extraScrapeConfigs}}\n{{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.extraScrapeConfigs \"context\" $) | nindent 2 }}\n{{- end }}\n{{- if or .Values.alertmanager.enabled .Values.server.alertingEndpoints}}\nalerting:\n  alertmanagers:\n    {{- if .Values.server.alertingEndpoints }}\n    {{- include \"common.tplvalues.render\" (dict \"value\" .Values.server.alertingEndpoints \"context\" $) | nindent 4 }}\n    {{- end }}\n    - scheme: HTTP\n      static_configs:\n        - targets: [ \"{{ printf \"%s.%s.svc.%s:%d\" (include \"prometheus.alertmanager.fullname\" .) (include \"common.names.namespace\" .) .Values.clusterDomain (int .Values.alertmanager.service.ports.http) }}\" ]\nrule_files:\n  - rules.yaml\n{{- end }}\n"
                 },
                 "alertingRules": {
                     "type": "object",
@@ -1298,7 +1298,7 @@
                                 "tag": {
                                     "type": "string",
                                     "description": "Thanos image tag",
-                                    "default": "0.31.0-scratch-r3"
+                                    "default": "0.32.2-debian-11-r2"
                                 },
                                 "digest": {
                                     "type": "string",
@@ -1908,7 +1908,7 @@
                         "tag": {
                             "type": "string",
                             "description": "OS Shell + Utility image tag (immutable tags are recommended)",
-                            "default": "11-debian-11-r2"
+                            "default": "11-debian-11-r57"
                         },
                         "pullPolicy": {
                             "type": "string",

--- a/bitnami/pytorch/values.schema.json
+++ b/bitnami/pytorch/values.schema.json
@@ -1,0 +1,766 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "PyTorch image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "PyTorch image repository",
+                    "default": "bitnami/pytorch"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "PyTorch image tag (immutable tags are recommended)",
+                    "default": "2.0.1-debian-11-r97"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "PyTorch image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "PyTorch image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "worldSize": {
+            "type": "number",
+            "description": "Number of nodes that will run the code",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "pytorch": {
+                    "type": "number",
+                    "description": "PyTorch master port. `MASTER_PORT` will be set to this value",
+                    "default": 49875
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Pytorch pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Pytorch pods' Security Context fsGroup",
+                    "default": 1001
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Pytorch pods' Security Context runAsUser",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Pytorch containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Pytorch containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Pytorch containers' Security Context runAsNonRoot",
+                    "default": true
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "description": "Set Pytorch containers' Security Context runAsNonRoot",
+                    "default": false
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Pytorch containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the Pytorch containers",
+                    "default": {}
+                }
+            }
+        },
+        "entrypoint": {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "description": "Main entrypoint to your application",
+                    "default": ""
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args required by your entrypoint",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "Run PyTorch in standalone or distributed mode. Possible values: `standalone`, `distributed`",
+            "default": "standalone"
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Pytorch pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Pytorch pods",
+            "default": {}
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "Config map that contains the files you want to load in PyTorch",
+            "default": ""
+        },
+        "cloneFilesFromGit": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable in order to download files from git repository",
+                    "default": false
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Repository that holds the files",
+                    "default": ""
+                },
+                "revision": {
+                    "type": "string",
+                    "description": "Revision from the repository to checkout",
+                    "default": ""
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Add extra volume mounts for the Git container",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Pytorch statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+            "default": "OrderedReady"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Pytorch pods' priorityClassName",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default) for Pytorch pods",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Redmine pod needs to terminate gracefully",
+            "default": ""
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Pytorch container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to Pytorch nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for Pytorch nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for Pytorch nodes",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the Pytorch pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Pytorch container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Pytorch pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "pytorch": {
+                            "type": "number",
+                            "description": "Scheduler Service port",
+                            "default": 49875
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "pytorch": {
+                            "type": "string",
+                            "description": "Node port for Pytorch",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Pytorch service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Pytorch service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Pytorch service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Pytorch service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Pytorch service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in Pytorch service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "git": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Git image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Git image repository",
+                    "default": "bitnami/git"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Git image tag (immutable tags are recommended)",
+                    "default": "2.41.0-debian-11-r76"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Git image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Path to mount the volume at.",
+                    "default": "/bitnami/pytorch"
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Storage class of backing PVC",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/rabbitmq-cluster-operator/values.schema.json
+++ b/bitnami/rabbitmq-cluster-operator/values.schema.json
@@ -1,0 +1,1395 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled)",
+                    "default": false
+                }
+            }
+        },
+        "rabbitmqImage": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "RabbitMQ Image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "RabbitMQ Image repository",
+                    "default": "bitnami/rabbitmq"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "RabbitMQ Image tag (immutable tags are recommended)",
+                    "default": "3.11.22-debian-11-r2"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "RabbitMQ image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "RabbitMQ Image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "credentialUpdaterImage": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "RabbitMQ Default User Credential Updater image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "RabbitMQ Default User Credential Updater image repository",
+                    "default": "bitnami/rmq-default-credential-updater"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "RabbitMQ Default User Credential Updater image tag (immutable tags are recommended)",
+                    "default": "1.0.2-debian-11-r20"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "RabbitMQ Default User Credential Updater image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "RabbitMQ Default User Credential Updater image pull secrets",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "clusterOperator": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "RabbitMQ Cluster Operator image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "RabbitMQ Cluster Operator image repository",
+                            "default": "bitnami/rabbitmq-cluster-operator"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "RabbitMQ Cluster Operator image tag (immutable tags are recommended)",
+                            "default": "2.5.0-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "RabbitMQ Cluster Operator image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "RabbitMQ Cluster Operator image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "RabbitMQ Cluster Operator image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of RabbitMQ Cluster Operator replicas to deploy",
+                    "default": 1
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on RabbitMQ Cluster Operator nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on RabbitMQ Cluster Operator nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on RabbitMQ Cluster Operator nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the RabbitMQ Cluster Operator containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the RabbitMQ Cluster Operator containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled RabbitMQ Cluster Operator pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set RabbitMQ Cluster Operator pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled RabbitMQ Cluster Operator containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set RabbitMQ Cluster Operator containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force running the container as non root",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on cluster operator containers",
+                            "default": true
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "RabbitMQ Cluster Operator pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for RabbitMQ Cluster Operator pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for RabbitMQ Cluster Operator pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for RabbitMQ Cluster Operator pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for RabbitMQ Cluster Operator pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for RabbitMQ Cluster Operator pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "RabbitMQ Cluster Operator statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "RabbitMQ Cluster Operator pods' priorityClassName",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the RabbitMQ Cluster Operator container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "RabbitMQ Cluster Operator container port (used for metrics)",
+                            "default": 9782
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to RabbitMQ Cluster Operator nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for RabbitMQ Cluster Operator nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for RabbitMQ Cluster Operator nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the RabbitMQ Cluster Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the RabbitMQ Cluster Operator container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the RabbitMQ Cluster Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the RabbitMQ Cluster Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "clusterRole": {
+                            "type": "object",
+                            "properties": {
+                                "customRules": {
+                                    "type": "array",
+                                    "description": "Define custom access rules for the ClusterRole",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Add annotations",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a service for accessing the metrics endpoint",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "RabbitMQ Cluster Operator metrics service HTTP port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "RabbitMQ Cluster Operator metrics service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.clusterOperator.metrics.service.ports.http }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Specify if a servicemonitor will be deployed for prometheus-operator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "Specify the jobLabel to use for the prometheus-operator",
+                                    "default": "app.kubernetes.io/name"
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "Honor metrics labels",
+                                    "default": false
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Scrape interval. If not set, the Prometheus default scrape interval is used",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "msgTopologyOperator": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy RabbitMQ Messaging Topology Operator as part of the installation",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator image repository",
+                            "default": "bitnami/rmq-messaging-topology-operator"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator image tag (immutable tags are recommended)",
+                            "default": "1.12.0-debian-11-r20"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "RabbitMQ Messaging Topology Operator image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of RabbitMQ Messaging Topology Operator replicas to deploy",
+                    "default": 1
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternative scheduler",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "hostNetwork": {
+                    "type": "string",
+                    "description": "Boolean",
+                    "default": "false"
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Alternative DNS policy",
+                    "default": "ClusterFirst"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on RabbitMQ Messaging Topology Operator nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on RabbitMQ Messaging Topology Operator nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on RabbitMQ Messaging Topology Operator nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 30
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "existingWebhookCertSecret": {
+                    "type": "string",
+                    "description": "name of a secret containing the certificates (use it to avoid certManager creating one)",
+                    "default": ""
+                },
+                "existingWebhookCertCABundle": {
+                    "type": "string",
+                    "description": "PEM-encoded CA Bundle of the existing secret provided in existingWebhookCertSecret (only if useCertManager=false)",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the RabbitMQ Messaging Topology Operator containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the RabbitMQ Messaging Topology Operator containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled RabbitMQ Messaging Topology Operator pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set RabbitMQ Messaging Topology Operator pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled RabbitMQ Messaging Topology Operator containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set RabbitMQ Messaging Topology Operator containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force running the container as non root",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Messaging Topology Operator",
+                            "default": true
+                        }
+                    }
+                },
+                "fullnameOverride": {
+                    "type": "string",
+                    "description": "String to fully override rmqco.msgTopologyOperator.fullname template",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "RabbitMQ Messaging Topology Operator pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for RabbitMQ Messaging Topology Operator pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for RabbitMQ Messaging Topology Operator pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for RabbitMQ Messaging Topology Operator pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for RabbitMQ Messaging Topology Operator pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for RabbitMQ Messaging Topology Operator pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "RabbitMQ Messaging Topology Operator pods' priorityClassName",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the RabbitMQ Messaging Topology Operator container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "RabbitMQ Messaging Topology Operator container port (used for metrics)",
+                            "default": 8080
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to RabbitMQ Messaging Topology Operator nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for RabbitMQ Messaging Topology Operator nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for RabbitMQ Messaging Topology Operator nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the RabbitMQ Messaging Topology Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the RabbitMQ Messaging Topology Operator container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the RabbitMQ Messaging Topology Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the RabbitMQ Messaging Topology Operator pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator webhook service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "webhook": {
+                                    "type": "number",
+                                    "description": "RabbitMQ Messaging Topology Operator webhook service HTTP port",
+                                    "default": 443
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator webhook service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator webhook service Load Balancer IP",
+                            "default": ""
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "RabbitMQ Messaging Topology Operator webhook service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "RabbitMQ Messaging Topology Operator webhook service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for RabbitMQ Messaging Topology Operator webhook service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Add annotations",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount API credentials for a service account.",
+                            "default": true
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a service for accessing the metrics endpoint",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "RabbitMQ Cluster Operator metrics service HTTP port",
+                                            "default": 80
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service Cluster IP",
+                                    "default": ""
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "RabbitMQ Cluster Operator metrics service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "RabbitMQ Cluster Operator metrics service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.msgTopologyOperator.metrics.service.ports.http }}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Specify if a servicemonitor will be deployed for prometheus-operator",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace which Prometheus is running in",
+                                    "default": ""
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "Specify the jobLabel to use for the prometheus-operator",
+                                    "default": "app.kubernetes.io/name"
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "Honor metrics labels",
+                                    "default": false
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Scrape interval. If not set, the Prometheus default scrape interval is used",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "useCertManager": {
+            "type": "boolean",
+            "description": "Deploy cert-manager objects (Issuer and Certificate) for webhooks",
+            "default": false
+        }
+    }
+}

--- a/bitnami/rabbitmq/values.schema.json
+++ b/bitnami/rabbitmq/values.schema.json
@@ -1,100 +1,1605 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "auth": {
-      "type": "object",
-      "properties": {
-        "username": {
-          "type": "string",
-          "title": "RabbitMQ user",
-          "form": true
-        },
-        "password": {
-          "type": "string",
-          "title": "RabbitMQ password",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set"
-        }
-      }
-    },
-    "extraConfiguration": {
-      "type": "string",
-      "title": "Extra RabbitMQ Configuration",
-      "form": true,
-      "render": "textArea",
-      "description": "Extra configuration to be appended to RabbitMQ Configuration"
-    },
-    "replicaCount": {
-      "type": "integer",
-      "form": true,
-      "title": "Number of replicas",
-      "description": "Number of replicas to deploy"
-    },
-    "persistence": {
-      "type": "object",
-      "title": "Persistence configuration",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable persistence",
-          "description": "Enable persistence using Persistent Volume Claims"
-        },
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi",
-          "hidden": {
-            "value": false,
-            "path": "persistence/enabled"
-          }
-        }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Prometheus metrics for RabbitMQ",
-          "description": "Install Prometheus plugin in the RabbitMQ container",
-          "form": true
-        },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
             }
-          }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "RabbitMQ image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "RabbitMQ image repository",
+                    "default": "bitnami/rabbitmq"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "RabbitMQ image tag (immutable tags are recommended)",
+                    "default": "3.12.4-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "RabbitMQ image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "RabbitMQ image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Set to true if you would like to see extra information on logs",
+                    "default": false
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override rabbitmq.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override rabbitmq.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "servicenameOverride": {
+            "type": "string",
+            "description": "String to partially override headless service name",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "dnsPolicy": {
+            "type": "string",
+            "description": "DNS Policy for pod",
+            "default": ""
+        },
+        "dnsConfig": {
+            "type": "object",
+            "description": "DNS Configuration pod",
+            "default": {}
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "description": "RabbitMQ application username",
+                    "default": "user"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "RabbitMQ application password",
+                    "default": ""
+                },
+                "securePassword": {
+                    "type": "boolean",
+                    "description": "Whether to set the RabbitMQ password securely. This is incompatible with loading external RabbitMQ definitions and 'true' when not setting the auth.password parameter.",
+                    "default": true
+                },
+                "existingPasswordSecret": {
+                    "type": "string",
+                    "description": "Existing secret with RabbitMQ credentials (must contain a value for `rabbitmq-password` key)",
+                    "default": ""
+                },
+                "enableLoopbackUser": {
+                    "type": "boolean",
+                    "description": "If enabled, the user `auth.username` can only connect from localhost",
+                    "default": false
+                },
+                "erlangCookie": {
+                    "type": "string",
+                    "description": "Erlang cookie to determine whether different nodes are allowed to communicate with each other",
+                    "default": ""
+                },
+                "existingErlangSecret": {
+                    "type": "string",
+                    "description": "Existing secret with RabbitMQ Erlang cookie (must contain a value for `rabbitmq-erlang-cookie` key)",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS support on RabbitMQ",
+                            "default": false
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Generate automatically self-signed TLS certificates",
+                            "default": false
+                        },
+                        "failIfNoPeerCert": {
+                            "type": "boolean",
+                            "description": "When set to true, TLS connection will be rejected if client fails to provide a certificate",
+                            "default": true
+                        },
+                        "sslOptionsVerify": {
+                            "type": "string",
+                            "description": "Should [peer verification](https://www.rabbitmq.com/ssl.html#peer-verification) be enabled?",
+                            "default": "verify_peer"
+                        },
+                        "sslOptionsPassword": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable usage of password for private Key",
+                                    "default": false
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing Secret containing the sslOptionsPassword",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Enable Key referring to sslOptionsPassword in Secret specified in auth.tls.sslOptionsPassword.existingSecret",
+                                    "default": ""
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "description": "Use this string as Password. If set, auth.tls.sslOptionsPassword.existingSecret and auth.tls.sslOptionsPassword.key are ignored",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "caCertificate": {
+                            "type": "string",
+                            "description": "Certificate Authority (CA) bundle content",
+                            "default": ""
+                        },
+                        "serverCertificate": {
+                            "type": "string",
+                            "description": "Server certificate content",
+                            "default": ""
+                        },
+                        "serverKey": {
+                            "type": "string",
+                            "description": "Server private key content",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret with certificate content to RabbitMQ credentials",
+                            "default": ""
+                        },
+                        "existingSecretFullChain": {
+                            "type": "boolean",
+                            "description": "Whether or not the existing secret contains the full chain in the certificate (`tls.crt`). Will be used in place of `ca.cert` if `true`.",
+                            "default": false
+                        },
+                        "overrideCaCertificate": {
+                            "type": "string",
+                            "description": "Existing secret with certificate content be mounted instead of the `ca.crt` coming from caCertificate or existingSecret/existingSecretFullChain.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "logs": {
+            "type": "string",
+            "description": "Path of the RabbitMQ server's Erlang log file. Value for the `RABBITMQ_LOGS` environment variable",
+            "default": "-"
+        },
+        "ulimitNofiles": {
+            "type": "string",
+            "description": "RabbitMQ Max File Descriptors",
+            "default": "65536"
+        },
+        "maxAvailableSchedulers": {
+            "type": "string",
+            "description": "RabbitMQ maximum available scheduler threads",
+            "default": ""
+        },
+        "onlineSchedulers": {
+            "type": "string",
+            "description": "RabbitMQ online scheduler threads",
+            "default": ""
+        },
+        "memoryHighWatermark": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable configuring Memory high watermark on RabbitMQ",
+                    "default": false
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Memory high watermark type. Either `absolute` or `relative`",
+                    "default": "relative"
+                },
+                "value": {
+                    "type": "number",
+                    "description": "Memory high watermark value",
+                    "default": 0.4
+                }
+            }
+        },
+        "plugins": {
+            "type": "string",
+            "description": "List of default plugins to enable (should only be altered to remove defaults; for additional plugins use `extraPlugins`)",
+            "default": "rabbitmq_management rabbitmq_peer_discovery_k8s"
+        },
+        "communityPlugins": {
+            "type": "string",
+            "description": "List of Community plugins (URLs) to be downloaded during container initialization",
+            "default": ""
+        },
+        "extraPlugins": {
+            "type": "string",
+            "description": "Extra plugins to enable (single string containing a space-separated list)",
+            "default": "rabbitmq_auth_backend_ldap"
+        },
+        "clustering": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable RabbitMQ clustering",
+                    "default": true
+                },
+                "addressType": {
+                    "type": "string",
+                    "description": "Switch clustering mode. Either `ip` or `hostname`",
+                    "default": "hostname"
+                },
+                "rebalance": {
+                    "type": "boolean",
+                    "description": "Rebalance master for queues in cluster when new replica is created",
+                    "default": false
+                },
+                "forceBoot": {
+                    "type": "boolean",
+                    "description": "Force boot of an unexpectedly shut down cluster (in an unexpected order).",
+                    "default": false
+                },
+                "partitionHandling": {
+                    "type": "string",
+                    "description": "Switch Partition Handling Strategy. Either `autoheal` or `pause-minority` or `pause-if-all-down` or `ignore`",
+                    "default": "autoheal"
+                }
+            }
+        },
+        "loadDefinition": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable loading a RabbitMQ definitions file to configure RabbitMQ",
+                    "default": false
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Name of the definitions file",
+                    "default": "/app/load_definition.json"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret with the load definitions file",
+                    "default": ""
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "Overwrite livecycle for the RabbitMQ container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "number",
+            "description": "Default duration in seconds k8s waits for container to exit before sending kill signal.",
+            "default": 120
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to add to RabbitMQ pods",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra environment variables (in case of sensitive data)",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "amqp": {
+                    "type": "number",
+                    "description": "",
+                    "default": 5672
+                },
+                "amqpTls": {
+                    "type": "number",
+                    "description": "",
+                    "default": 5671
+                },
+                "dist": {
+                    "type": "number",
+                    "description": "",
+                    "default": 25672
+                },
+                "manager": {
+                    "type": "number",
+                    "description": "",
+                    "default": 15672
+                },
+                "epmd": {
+                    "type": "number",
+                    "description": "",
+                    "default": 4369
+                },
+                "metrics": {
+                    "type": "number",
+                    "description": "",
+                    "default": 9419
+                }
+            }
+        },
+        "initScripts": {
+            "type": "object",
+            "description": "Dictionary of init scripts. Evaluated as a template.",
+            "default": {}
+        },
+        "initScriptsCM": {
+            "type": "string",
+            "description": "ConfigMap with the init scripts. Evaluated as a template.",
+            "default": ""
+        },
+        "initScriptsSecret": {
+            "type": "string",
+            "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+            "default": ""
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Extra ports to be included in container spec, primarily informational",
+            "default": [],
+            "items": {}
+        },
+        "configuration": {
+            "type": "string",
+            "description": "RabbitMQ Configuration file content: required cluster configuration",
+            "default": "## Username and password\n##\ndefault_user = {{ .Values.auth.username }}\n{{- if and (not .Values.auth.securePassword) .Values.auth.password }}\ndefault_pass = {{ .Values.auth.password }}\n{{- end }}\n{{- if .Values.clustering.enabled }}\n## Clustering\n##\ncluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s\ncluster_formation.k8s.host = kubernetes.default\ncluster_formation.node_cleanup.interval = 10\ncluster_formation.node_cleanup.only_log_warning = true\ncluster_partition_handling = {{ .Values.clustering.partitionHandling }}\n{{- end }}\n{{ if and .Values.clustering.enabled .Values.loadDefinition.enabled }}\ncluster_formation.target_cluster_size_hint = {{ .Values.replicaCount }}\n{{ end }}\n{{- if .Values.loadDefinition.enabled }}\nload_definitions = {{ .Values.loadDefinition.file }}\n{{- end }}\n# queue master locator\nqueue_master_locator = min-masters\n# enable loopback user\n{{- if not (empty .Values.auth.username) }}\nloopback_users.{{ .Values.auth.username }} = {{ .Values.auth.enableLoopbackUser }}\n{{- else}}\nloopback_users.guest = {{ .Values.auth.enableLoopbackUser }}\n{{- end }}\n{{ template \"rabbitmq.extraConfiguration\" . }}\n{{- if .Values.auth.tls.enabled }}\nssl_options.verify = {{ .Values.auth.tls.sslOptionsVerify }}\nlisteners.ssl.default = {{ .Values.service.ports.amqpTls }}\nssl_options.fail_if_no_peer_cert = {{ .Values.auth.tls.failIfNoPeerCert }}\nssl_options.cacertfile = /opt/bitnami/rabbitmq/certs/ca_certificate.pem\nssl_options.certfile = /opt/bitnami/rabbitmq/certs/server_certificate.pem\nssl_options.keyfile = /opt/bitnami/rabbitmq/certs/server_key.pem\n{{- if .Values.auth.tls.sslOptionsPassword.enabled }}\nssl_options.password = {{ template \"rabbitmq.tlsSslOptionsPassword\" . }}\n{{- end }}\n{{- end }}\n{{- if .Values.ldap.enabled }}\nauth_backends.1.authn = ldap\nauth_backends.1.authz = {{ ternary \"ldap\" \"internal\" .Values.ldap.authorisationEnabled }}\nauth_backends.2 = internal\n{{- $host :=  list }}\n{{- $port :=  ternary 636 389 .Values.ldap.tls.enabled }}\n{{- if .Values.ldap.uri }}\n{{- $hostPort := get (urlParse .Values.ldap.uri) \"host\" }}\n{{- $host = list (index (splitList \":\" $hostPort) 0) -}}\n{{- if (contains \":\" $hostPort) }}\n{{- $port = index (splitList \":\" $hostPort) 1 -}}\n{{- end }}\n{{- end }}\n{{- range $index, $server := concat $host .Values.ldap.servers }}\nauth_ldap.servers.{{ add $index 1 }} = {{ $server }}\n{{- end }}\nauth_ldap.port = {{ coalesce .Values.ldap.port $port }}\n{{- if or .Values.ldap.user_dn_pattern .Values.ldap.userDnPattern }}\nauth_ldap.user_dn_pattern = {{ coalesce .Values.ldap.user_dn_pattern .Values.ldap.userDnPattern }}\n{{- end }}\n{{- if .Values.ldap.basedn }}\nauth_ldap.dn_lookup_base = {{ .Values.ldap.basedn }}\n{{- end }}\n{{- if .Values.ldap.uidField }}\nauth_ldap.dn_lookup_attribute = {{ .Values.ldap.uidField }}\n{{- end }}\n{{- if .Values.ldap.binddn }}\nauth_ldap.dn_lookup_bind.user_dn = {{ .Values.ldap.binddn }}\nauth_ldap.dn_lookup_bind.password = {{ required \"'ldap.bindpw' is required when 'ldap.binddn' is defined\" .Values.ldap.bindpw }}\n{{- end }}\n{{- if .Values.ldap.tls.enabled }}\nauth_ldap.use_ssl = {{ not .Values.ldap.tls.startTls }}\nauth_ldap.use_starttls = {{ .Values.ldap.tls.startTls }}\n{{- if .Values.ldap.tls.CAFilename }}\nauth_ldap.ssl_options.cacertfile = {{ .Values.ldap.tls.certificatesMountPath }}/{{ .Values.ldap.tls.CAFilename }}\n{{- end }}\n{{- if .Values.ldap.tls.certFilename }}\nauth_ldap.ssl_options.certfile = {{ .Values.ldap.tls.certificatesMountPath }}/{{ .Values.ldap.tls.certFilename }}\nauth_ldap.ssl_options.keyfile = {{ .Values.ldap.tls.certificatesMountPath }}/{{ required \"'ldap.tls.certKeyFilename' is required when 'ldap.tls.certFilename' is defined\" .Values.ldap.tls.certKeyFilename }}\n{{- end }}\n{{- if .Values.ldap.tls.skipVerify }}\nauth_ldap.ssl_options.verify = verify_none\nauth_ldap.ssl_options.fail_if_no_peer_cert = false\n{{- else if .Values.ldap.tls.verify }}\nauth_ldap.ssl_options.verify = {{ .Values.ldap.tls.verify }}\n{{- end }}\n{{- end }}\n{{- end }}\n{{- if .Values.metrics.enabled }}\n## Prometheus metrics\n##\nprometheus.tcp.port = {{ .Values.containerPorts.metrics }}\n{{- end }}\n{{- if .Values.memoryHighWatermark.enabled }}\n## Memory Threshold\n##\ntotal_memory_available_override_value = {{ include \"rabbitmq.toBytes\" .Values.resources.limits.memory }}\nvm_memory_high_watermark.{{ .Values.memoryHighWatermark.type }} = {{ .Values.memoryHighWatermark.value }}\n## TCP Listen Options\n##\ntcp_listen_options.backlog = {{ .Values.tcpListenOptions.backlog }}\ntcp_listen_options.nodelay = {{ .Values.tcpListenOptions.nodelay }}\ntcp_listen_options.linger.on      = {{ .Values.tcpListenOptions.linger.lingerOn }}\ntcp_listen_options.linger.timeout = {{ .Values.tcpListenOptions.linger.timeout }}\ntcp_listen_options.keepalive = {{ .Values.tcpListenOptions.keepalive }}\n{{- end }}"
+        },
+        "tcpListenOptions": {
+            "type": "object",
+            "properties": {
+                "backlog": {
+                    "type": "number",
+                    "description": "Maximum size of the unaccepted TCP connections queue",
+                    "default": 128
+                },
+                "nodelay": {
+                    "type": "boolean",
+                    "description": "When set to true, deactivates Nagle's algorithm. Default is true. Highly recommended for most users.",
+                    "default": true
+                },
+                "linger": {
+                    "type": "object",
+                    "properties": {
+                        "lingerOn": {
+                            "type": "boolean",
+                            "description": "Enable Server socket lingering",
+                            "default": true
+                        },
+                        "timeout": {
+                            "type": "number",
+                            "description": "Server Socket lingering timeout",
+                            "default": 0
+                        }
+                    }
+                },
+                "keepalive": {
+                    "type": "boolean",
+                    "description": "When set to true, enables TCP keepalives",
+                    "default": false
+                }
+            }
+        },
+        "configurationExistingSecret": {
+            "type": "string",
+            "description": "Existing secret with the configuration to use as rabbitmq.conf.",
+            "default": ""
+        },
+        "extraConfiguration": {
+            "type": "string",
+            "description": "Configuration file content: extra configuration to be appended to RabbitMQ configuration",
+            "default": "#default_vhost = {{ .Release.Namespace }}-vhost\n#disk_free_limit.absolute = 50MB"
+        },
+        "extraConfigurationExistingSecret": {
+            "type": "string",
+            "description": "Existing secret with the extra configuration to append to `configuration`.",
+            "default": ""
+        },
+        "advancedConfiguration": {
+            "type": "string",
+            "description": "Configuration file content: advanced configuration",
+            "default": ""
+        },
+        "advancedConfigurationExistingSecret": {
+            "type": "string",
+            "description": "Existing secret with the advanced configuration file (must contain a key `advanced.config`).",
+            "default": ""
+        },
+        "featureFlags": {
+            "type": "string",
+            "description": "that controls what features are considered to be enabled or available on all cluster nodes.",
+            "default": ""
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP support",
+                    "default": false
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "LDAP connection string.",
+                    "default": ""
+                },
+                "servers": {
+                    "type": "array",
+                    "description": "List of LDAP servers hostnames. This is valid only if ldap.uri is not set",
+                    "default": [],
+                    "items": {}
+                },
+                "port": {
+                    "type": "string",
+                    "description": "LDAP servers port. This is valid only if ldap.uri is not set",
+                    "default": ""
+                },
+                "userDnPattern": {
+                    "type": "string",
+                    "description": "Pattern used to translate the provided username into a value to be used for the LDAP bind.",
+                    "default": ""
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "DN of the account used to search in the LDAP server.",
+                    "default": ""
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "Password for binddn account.",
+                    "default": ""
+                },
+                "basedn": {
+                    "type": "string",
+                    "description": "Base DN path where binddn account will search for the users.",
+                    "default": ""
+                },
+                "uidField": {
+                    "type": "string",
+                    "description": "Field used to match with the user name (uid, samAccountName, cn, etc). It matches with 'dn_lookup_attribute' in RabbitMQ configuration",
+                    "default": ""
+                },
+                "authorisationEnabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP authorisation. Please set 'advancedConfiguration' with tag, topic, resources and vhost mappings",
+                    "default": false
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled TLS configuration.",
+                            "default": false
+                        },
+                        "startTls": {
+                            "type": "boolean",
+                            "description": "Use STARTTLS instead of LDAPS.",
+                            "default": false
+                        },
+                        "skipVerify": {
+                            "type": "boolean",
+                            "description": "Skip any SSL verification (hostanames or certificates)",
+                            "default": false
+                        },
+                        "verify": {
+                            "type": "string",
+                            "description": "Verify connection. Valid values are 'verify_peer' or 'verify_none'",
+                            "default": "verify_peer"
+                        },
+                        "certificatesMountPath": {
+                            "type": "string",
+                            "description": "Where LDAP certifcates are mounted.",
+                            "default": "/opt/bitnami/rabbitmq/ldap/certs"
+                        },
+                        "certificatesSecret": {
+                            "type": "string",
+                            "description": "Secret with LDAP certificates.",
+                            "default": ""
+                        },
+                        "CAFilename": {
+                            "type": "string",
+                            "description": "CA certificate filename. Should match with the CA entry key in the ldap.tls.certificatesSecret.",
+                            "default": ""
+                        },
+                        "certFilename": {
+                            "type": "string",
+                            "description": "Client certificate filename to authenticate against the LDAP server. Should match with certificate the entry key in the ldap.tls.certificatesSecret.",
+                            "default": ""
+                        },
+                        "certKeyFilename": {
+                            "type": "string",
+                            "description": "Client Key filename to authenticate against the LDAP server. Should match with certificate the entry key in the ldap.tls.certificatesSecret.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes .",
+            "default": [],
+            "items": {}
+        },
+        "extraSecrets": {
+            "type": "object",
+            "description": "Optionally specify extra secrets to be created by the chart.",
+            "default": {}
+        },
+        "extraSecretsPrependReleaseName": {
+            "type": "boolean",
+            "description": "Set this flag to true if extraSecrets should be created with <release-name> prepended.",
+            "default": false
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of RabbitMQ replicas to deploy",
+            "default": 1
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Use an alternate scheduler, e.g. \"stork\".",
+            "default": ""
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Pod management policy",
+            "default": "OrderedReady"
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "RabbitMQ Pod labels. Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "RabbitMQ Pod annotations. Evaluated as a template",
+            "default": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy type for RabbitMQ statefulset",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "statefulsetLabels": {
+            "type": "object",
+            "description": "RabbitMQ statefulset labels. Evaluated as a template",
+            "default": {}
+        },
+        "statefulsetAnnotations": {
+            "type": "object",
+            "description": "RabbitMQ statefulset annotations. Evaluated as a template",
+            "default": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of the priority class to be used by RabbitMQ pods, priority class needs to be created beforehand",
+            "default": ""
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable RabbitMQ pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set RabbitMQ pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled RabbitMQ containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set RabbitMQ containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set RabbitMQ container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for RabbitMQ containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for RabbitMQ containers",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 30
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 20
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 30
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 20
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 30
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 20
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Define a custom startup probe",
+            "default": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add init containers to the RabbitMQ pod",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add sidecar containers to the RabbitMQ pod",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for RabbitMQ pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created serviceAccount",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Auto-mount the service account token in the pod",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether RBAC rules should be created",
+                    "default": true
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable RabbitMQ data persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for RabbitMQ data volume",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Modes for RabbitMQ data volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Provide an existing PersistentVolumeClaims",
+                    "default": ""
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "The path the volume will be mounted at",
+                    "default": "/bitnami/rabbitmq/mnesia"
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The subdirectory of the volume to mount to",
+                    "default": ""
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for RabbitMQ data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistence annotations. Evaluated as a template",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Persistence labels. Evaluated as a template",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "portEnabled": {
+                    "type": "boolean",
+                    "description": "Amqp port. Cannot be disabled when `auth.tls.enabled` is `false`. Listener can be disabled with `listeners.tcp = none`.",
+                    "default": true
+                },
+                "distPortEnabled": {
+                    "type": "boolean",
+                    "description": "Erlang distribution server port",
+                    "default": true
+                },
+                "managerPortEnabled": {
+                    "type": "boolean",
+                    "description": "RabbitMQ Manager port",
+                    "default": true
+                },
+                "epmdPortEnabled": {
+                    "type": "boolean",
+                    "description": "RabbitMQ EPMD Discovery service port",
+                    "default": true
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "amqp": {
+                            "type": "number",
+                            "description": "Amqp service port",
+                            "default": 5672
+                        },
+                        "amqpTls": {
+                            "type": "number",
+                            "description": "Amqp TLS service port",
+                            "default": 5671
+                        },
+                        "dist": {
+                            "type": "number",
+                            "description": "Erlang distribution service port",
+                            "default": 25672
+                        },
+                        "manager": {
+                            "type": "number",
+                            "description": "RabbitMQ Manager service port",
+                            "default": 15672
+                        },
+                        "metrics": {
+                            "type": "number",
+                            "description": "RabbitMQ Prometheues metrics service port",
+                            "default": 9419
+                        },
+                        "epmd": {
+                            "type": "number",
+                            "description": "EPMD Discovery service port",
+                            "default": 4369
+                        }
+                    }
+                },
+                "portNames": {
+                    "type": "object",
+                    "properties": {
+                        "amqp": {
+                            "type": "string",
+                            "description": "Amqp service port name",
+                            "default": "amqp"
+                        },
+                        "amqpTls": {
+                            "type": "string",
+                            "description": "Amqp TLS service port name",
+                            "default": "amqp-tls"
+                        },
+                        "dist": {
+                            "type": "string",
+                            "description": "Erlang distribution service port name",
+                            "default": "dist"
+                        },
+                        "manager": {
+                            "type": "string",
+                            "description": "RabbitMQ Manager service port name",
+                            "default": "http-stats"
+                        },
+                        "metrics": {
+                            "type": "string",
+                            "description": "RabbitMQ Prometheues metrics service port name",
+                            "default": "metrics"
+                        },
+                        "epmd": {
+                            "type": "string",
+                            "description": "EPMD Discovery service port name",
+                            "default": "epmd"
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "amqp": {
+                            "type": "string",
+                            "description": "Node port for Ampq",
+                            "default": ""
+                        },
+                        "amqpTls": {
+                            "type": "string",
+                            "description": "Node port for Ampq TLS",
+                            "default": ""
+                        },
+                        "dist": {
+                            "type": "string",
+                            "description": "Node port for Erlang distribution",
+                            "default": ""
+                        },
+                        "manager": {
+                            "type": "string",
+                            "description": "Node port for RabbitMQ Manager",
+                            "default": ""
+                        },
+                        "epmd": {
+                            "type": "string",
+                            "description": "Node port for EPMD Discovery",
+                            "default": ""
+                        },
+                        "metrics": {
+                            "type": "string",
+                            "description": "Node port for RabbitMQ Prometheues metrics",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Address(es) that are allowed when service is `LoadBalancer`",
+                    "default": [],
+                    "items": {}
+                },
+                "externalIPs": {
+                    "type": "array",
+                    "description": "Set the ExternalIPs",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Set the LoadBalancerIP",
+                    "default": ""
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Kubernetes service Cluster IP",
+                    "default": ""
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Service labels. Evaluated as a template",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Service annotations. Evaluated as a template",
+                    "default": {}
+                },
+                "annotationsHeadless": {
+                    "type": "object",
+                    "description": "Headless Service annotations. Evaluated as a template",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress resource for Management console",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the default host. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "rabbitmq.local"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Set this to true in order to create a TLS secret for this ingress record",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "The list of additional rules to be added to this ingress record. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "It is you own the certificate as secret.",
+                    "default": ""
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "additionalRules": {
+                    "type": "array",
+                    "description": "Additional NetworkPolicy Ingress \"from\" rules to set. Note that all rules are OR-ed.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable exposing RabbitMQ metrics to be gathered by Prometheus",
+                    "default": false
+                },
+                "plugins": {
+                    "type": "string",
+                    "description": "Plugins to enable Prometheus metrics in RabbitMQ",
+                    "default": "rabbitmq_prometheus"
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.service.ports.metrics }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Specify the namespace in which the serviceMonitor resource will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricsRelabelConfigs to apply to samples before ingestion.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "targetLabels": {
+                            "type": "object",
+                            "description": "Used to keep given service's labels in target",
+                            "default": {}
+                        },
+                        "podTargetLabels": {
+                            "type": "object",
+                            "description": "Used to keep given pod's labels in target",
+                            "default": {}
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Define the path used by ServiceMonitor to scrap metrics",
+                            "default": ""
+                        },
+                        "params": {
+                            "type": "object",
+                            "description": "Define the HTTP URL parameters used by ServiceMonitor",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Extra annotations for the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set this to true to create prometheusRules for Prometheus operator",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRules will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "namespace where prometheusRules resource should be created",
+                            "default": ""
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "List of rules, used as template by Helm.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r45"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/redis-cluster/values.schema.json
+++ b/bitnami/redis-cluster/values.schema.json
@@ -1,0 +1,1489 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "redis": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string",
+                            "description": "Redis&reg; password (overrides `password`)",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Redis&reg; cluster image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Redis&reg; cluster image repository",
+                    "default": "bitnami/redis-cluster"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Redis&reg; cluster image tag (immutable tags are recommended)",
+                    "default": "7.2.1-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Redis&reg; cluster image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Redis&reg; cluster image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable NetworkPolicy",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "The Policy model to apply. Don't require client label for connections",
+                    "default": true
+                },
+                "ingressNSMatchLabels": {
+                    "type": "object",
+                    "description": "Allow connections from other namespacess. Just set label for namespace and set label for pods (optional).",
+                    "default": {}
+                },
+                "ingressNSPodMatchLabels": {
+                    "type": "object",
+                    "description": "For other namespaces match by pod labels and namespace labels",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to create",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Cassandra Service Account",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account.",
+                    "default": false
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": false
+                },
+                "role": {
+                    "type": "object",
+                    "properties": {
+                        "rules": {
+                            "type": "array",
+                            "description": "Rules to create. It follows the role specification",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Redis&reg; pod Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Group ID for the pods",
+                    "default": 1001
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the pods",
+                    "default": 1001
+                },
+                "sysctls": {
+                    "type": "array",
+                    "description": "Set namespaced sysctls for the pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "description": "Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions",
+            "default": {}
+        },
+        "minAvailable": {
+            "type": "string",
+            "description": "Min number of pods that must still be available after the eviction",
+            "default": ""
+        },
+        "maxUnavailable": {
+            "type": "string",
+            "description": "Max number of pods that can be unavailable after the eviction",
+            "default": ""
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the containers.",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Run container as non root",
+                    "default": true
+                }
+            }
+        },
+        "usePassword": {
+            "type": "boolean",
+            "description": "Use password authentication",
+            "default": true
+        },
+        "password": {
+            "type": "string",
+            "description": "Redis&reg; password (ignored if existingSecret set)",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret object (for password authentication)",
+            "default": ""
+        },
+        "existingSecretPasswordKey": {
+            "type": "string",
+            "description": "Name of key containing password to be retrieved from the existing secret",
+            "default": ""
+        },
+        "usePasswordFile": {
+            "type": "boolean",
+            "description": "Mount passwords as files instead of environment variables",
+            "default": false
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS support for replication traffic",
+                    "default": false
+                },
+                "authClients": {
+                    "type": "boolean",
+                    "description": "Require clients to authenticate or not",
+                    "default": true
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of the existing secret that contains the TLS certificates",
+                    "default": ""
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "DEPRECATED. Use tls.existingSecret instead",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "Certificate filename",
+                    "default": ""
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "description": "Certificate key filename",
+                    "default": ""
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "description": "CA Certificate filename",
+                    "default": ""
+                },
+                "dhParamsFilename": {
+                    "type": "string",
+                    "description": "File containing DH params (in order to support DH based ciphers)",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "redis": {
+                            "type": "number",
+                            "description": "Kubernetes Redis service port",
+                            "default": 6379
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "redis": {
+                            "type": "string",
+                            "description": "Node port for Redis",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Provide any additional annotations which may be required.",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Additional labels for redis service",
+                    "default": {}
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Service type for default redis service",
+                    "default": "ClusterIP"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Load balancer IP if `service.type` is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Service external traffic policy",
+                    "default": "Cluster"
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence on Redis&reg;",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to mount the volume at, to use other images Redis&reg; images.",
+                    "default": "/bitnami/redis/data"
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Storage class of backing PVC",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "matchLabels": {
+                    "type": "object",
+                    "description": "Persistent Volume selectors",
+                    "default": {}
+                },
+                "matchExpressions": {
+                    "type": "object",
+                    "description": "matchExpressions Persistent Volume selectors",
+                    "default": {}
+                }
+            }
+        },
+        "persistentVolumeClaimRetentionPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Controls if and how PVCs are deleted during the lifecycle of a StatefulSet",
+                    "default": false
+                },
+                "whenScaled": {
+                    "type": "string",
+                    "description": "Volume retention behavior when the replica count of the StatefulSet is reduced",
+                    "default": "Retain"
+                },
+                "whenDeleted": {
+                    "type": "string",
+                    "description": "Volume retention behavior that applies when the StatefulSet is deleted",
+                    "default": "Retain"
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the registry (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the containers.",
+                            "default": 0
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Run container as privileged",
+                            "default": false
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "description": "Redis&reg; entrypoint string. The command `redis-server` is executed if this is not provided",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Arguments for the provided command if needed",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Argo Workflows statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "partition": {
+                                    "type": "number",
+                                    "description": "Partition update strategy",
+                                    "default": 0
+                                }
+                            }
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+                    "default": "Parallel"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Host networking requested for this pod. Use the host's network namespace.",
+                    "default": false
+                },
+                "useAOFPersistence": {
+                    "type": "string",
+                    "description": "Whether to use AOF Persistence mode or not",
+                    "default": "yes"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "redis": {
+                            "type": "number",
+                            "description": "Redis&reg; port",
+                            "default": 6379
+                        },
+                        "bus": {
+                            "type": "number",
+                            "description": "The busPort should be obtained adding 10000 to the redisPort. By default: 10000 + 6379 = 16379",
+                            "default": 16379
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "LifecycleHook to set additional configuration before or after startup. Evaluated as a template",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the container",
+                    "default": [],
+                    "items": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Extra init containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra sidecar containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional labels for Redis&reg; pod",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Redis&reg; Master pod priorityClassName",
+                    "default": ""
+                },
+                "defaultConfigOverride": {
+                    "type": "string",
+                    "description": "Optional default Redis&reg; configuration for the nodes",
+                    "default": ""
+                },
+                "configmap": {
+                    "type": "string",
+                    "description": "Additional Redis&reg; configuration for the nodes",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Redis&reg; additional annotations",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Enable shared process namespace in a pod.",
+                    "default": false
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to check for startupProbe",
+                            "default": "/"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 300
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Redis&reg; pod affinity preset. Ignored if `redis.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Redis&reg; pod anti-affinity preset. Ignored if `redis.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; node affinity preset type. Ignored if `redis.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Redis&reg; node label key to match Ignored if `redis.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Redis&reg; node label values to match. Ignored if `redis.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity settings for Redis&reg; pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Redis&reg; pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Redis&reg; pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Pod topology spread constraints for Redis&reg; pod",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "updateJob": {
+            "type": "object",
+            "properties": {
+                "activeDeadlineSeconds": {
+                    "type": "number",
+                    "description": "Number of seconds the Job to create the cluster will be waiting for the Nodes to be ready.",
+                    "default": 600
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Container command (using container default if not set)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Container args (using container default if not set)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Job annotations",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Job pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Pod extra labels",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the container",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Extra init containers to add to the deployment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Update job pod affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Update job pod anti-affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update job node affinity preset type. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Update job node label key to match Ignored if `updateJob.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Update job node label values to match. Ignored if `updateJob.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for update job pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for update job pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for update job pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority class name",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "init": {
+                    "type": "boolean",
+                    "description": "Enable the initialization of the Redis&reg; Cluster",
+                    "default": true
+                },
+                "nodes": {
+                    "type": "number",
+                    "description": "The number of master nodes should always be >= 3, otherwise cluster creation will fail",
+                    "default": 6
+                },
+                "replicas": {
+                    "type": "number",
+                    "description": "Number of replicas for every master in the cluster",
+                    "default": 1
+                },
+                "externalAccess": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable access to the Redis",
+                            "default": false
+                        },
+                        "hostMode": {
+                            "type": "boolean",
+                            "description": "Set cluster preferred endpoint type as hostname",
+                            "default": false
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Type for the services used to expose every Pod",
+                                    "default": "LoadBalancer"
+                                },
+                                "port": {
+                                    "type": "number",
+                                    "description": "Port for the services used to expose every Pod",
+                                    "default": 6379
+                                },
+                                "loadBalancerIP": {
+                                    "type": "array",
+                                    "description": "Array of load balancer IPs for each Redis&reg; node. Length must be the same as cluster.nodes",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations to add to the services used to expose every Pod of the Redis&reg; Cluster",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "update": {
+                    "type": "object",
+                    "properties": {
+                        "addNodes": {
+                            "type": "boolean",
+                            "description": "Boolean to specify if you want to add nodes after the upgrade",
+                            "default": false
+                        },
+                        "currentNumberOfNodes": {
+                            "type": "number",
+                            "description": "Number of currently deployed Redis&reg; nodes",
+                            "default": 6
+                        },
+                        "currentNumberOfReplicas": {
+                            "type": "number",
+                            "description": "Number of currently deployed Redis&reg; replicas",
+                            "default": 1
+                        },
+                        "newExternalIPs": {
+                            "type": "array",
+                            "description": "External IPs obtained from the services for the new nodes to add to the cluster",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter image name",
+                            "default": "bitnami/redis-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter image tag",
+                            "default": "1.54.0-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "description": "Extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter)",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Redis&reg; exporter",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9121"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional labels for Metrics exporter pod",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Metrics Containers' Security Context",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Allow Privilege Escalation for metrics container",
+                            "default": false
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Optional namespace which Prometheus is running in",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "How frequently to scrape metrics (use by default, falling back to Prometheus' default)",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "ServiceMonitor extra labels",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "ServiceMonitor annotations",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set this to true to create prometheusRules for Prometheus operator",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRules will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "namespace where prometheusRules resource should be created",
+                            "default": ""
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Create specified [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/), check values for an example.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Metrics exporter pod priorityClassName",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type (redis metrics)",
+                            "default": "ClusterIP"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the services to monitor.",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for the metrics service",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Service Cluster IP",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "sysctlImage": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable an init container to modify Kernel settings",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "sysctlImage command to execute",
+                    "default": [],
+                    "items": {}
+                },
+                "registry": {
+                    "type": "string",
+                    "description": "sysctlImage Init container registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "sysctlImage Init container repository",
+                    "default": "bitnami/os-shell"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "sysctlImage Init container tag",
+                    "default": "11-debian-11-r60"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "sysctlImage Init container digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "sysctlImage Init container pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "mountHostSys": {
+                    "type": "boolean",
+                    "description": "Mount the host `/sys` folder to `/host-sys`",
+                    "default": false
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the containers.",
+                            "default": 0
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Run privileged as privileged",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/redis/values.schema.json
+++ b/bitnami/redis/values.schema.json
@@ -1,156 +1,2808 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "architecture": {
-      "type": "string",
-      "title": "Redis architecture",
-      "form": true,
-      "description": "Allowed values: `standalone` or `replication`",
-      "enum": ["standalone", "replication"]
-    },
-    "auth": {
-      "type": "object",
-      "title": "Authentication configuration",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use password authentication"
-        },
-        "password": {
-          "type": "string",
-          "title": "Redis password",
-          "form": true,
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "hidden": {
-            "value": false,
-            "path": "auth/enabled"
-          }
-        }
-      }
-    },
-    "master": {
-      "type": "object",
-      "title": "Master replicas settings",
-      "form": true,
-      "properties": {
-        "kind": {
-          "type": "string",
-          "title": "Workload Kind",
-          "form": true,
-          "description": "Allowed values: `Deployment` or `StatefulSet`",
-          "enum": ["Deployment", "StatefulSet"]
-        },
-        "persistence": {
-          "type": "object",
-          "title": "Persistence for master replicas",
-          "form": true,
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "form": true,
-              "title": "Enable persistence",
-              "description": "Enable persistence using Persistent Volume Claims"
-            },
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi",
-              "hidden": {
-                "value": false,
-                "path": "master/persistence/enabled"
-              }
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "redis": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string",
+                            "description": "Global Redis&reg; password (overrides `auth.password`)",
+                            "default": ""
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
-    },
-    "replica": {
-      "type": "object",
-      "title": "Redis replicas settings",
-      "form": true,
-      "hidden": {
-        "value": "standalone",
-        "path": "architecture"
-      },
-      "properties": {
-        "replicaCount": {
-          "type": "integer",
-          "form": true,
-          "title": "Number of Redis replicas"
         },
-        "persistence": {
-          "type": "object",
-          "title": "Persistence for Redis replicas",
-          "form": true,
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "form": true,
-              "title": "Enable persistence",
-              "description": "Enable persistence using Persistent Volume Claims"
-            },
-            "size": {
-              "type": "string",
-              "title": "Persistent Volume Size",
-              "form": true,
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi",
-              "hidden": {
-                "value": false,
-                "path": "replica/persistence/enabled"
-              }
-            }
-          }
-        }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
         },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "metrics/enabled"
-              }
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "secretAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to secret",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "useHostnames": {
+            "type": "boolean",
+            "description": "Use hostnames internally when announcing replication. If false, the hostname will be resolved to an IP address",
+            "default": true
+        },
+        "nameResolutionThreshold": {
+            "type": "number",
+            "description": "Failure threshold for internal hostnames resolution",
+            "default": 5
+        },
+        "nameResolutionTimeout": {
+            "type": "number",
+            "description": "Timeout seconds between probes for internal hostnames resolution",
+            "default": 5
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
-          }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Redis&reg; image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Redis&reg; image repository",
+                    "default": "bitnami/redis"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Redis&reg; image tag (immutable tags are recommended)",
+                    "default": "7.2.1-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Redis&reg; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Redis&reg; image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Redis&reg; image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "Redis&reg; architecture. Allowed values: `standalone` or `replication`",
+            "default": "replication"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable password authentication",
+                    "default": true
+                },
+                "sentinel": {
+                    "type": "boolean",
+                    "description": "Enable password authentication on sentinels too",
+                    "default": true
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Redis&reg; password",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of an existing secret with Redis&reg; credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Password key to be retrieved from existing secret",
+                    "default": ""
+                },
+                "usePasswordFiles": {
+                    "type": "boolean",
+                    "description": "Mount credentials as files instead of using an environment variable",
+                    "default": false
+                }
+            }
+        },
+        "commonConfiguration": {
+            "type": "string",
+            "description": "Common configuration to be added into the ConfigMap",
+            "default": "# Enable AOF https://redis.io/topics/persistence#append-only-file\nappendonly yes\n# Disable RDB persistence, AOF persistence already enabled.\nsave \"\""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your custom configuration for Redis&reg; nodes",
+            "default": ""
+        },
+        "master": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "number",
+                    "description": "Number of Redis&reg; master instances to deploy (experimental, requires additional configuration)",
+                    "default": 1
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Configuration for Redis&reg; master nodes",
+                    "default": ""
+                },
+                "disableCommands": {
+                    "type": "array",
+                    "description": "Array with Redis&reg; commands to disable on master nodes",
+                    "default": [
+                        "FLUSHDB",
+                        "FLUSHALL"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "enableServiceLinks": {
+                    "type": "boolean",
+                    "description": "Whether information about services should be injected into pod's environment variable",
+                    "default": true
+                },
+                "preExecCmds": {
+                    "type": "array",
+                    "description": "Additional commands to run prior to starting Redis&reg; master",
+                    "default": [],
+                    "items": {}
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Array with additional command line flags for Redis&reg; master",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Redis&reg; master nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Redis&reg; master nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Redis&reg; master nodes",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "redis": {
+                            "type": "number",
+                            "description": "Container port to open on Redis&reg; master nodes",
+                            "default": 6379
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Redis&reg; master nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Redis&reg; master nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Redis&reg; master nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Redis&reg; master containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Redis&reg; master containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redis&reg; master pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Redis&reg; master pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redis&reg; master containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Redis&reg; master containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set Redis&reg; master containers' Security Context runAsGroup",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; master containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Is it possible to escalate Redis&reg; pod(s) privileges",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Redis&reg; master containers' Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Redis&reg; master containers' Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Use either Deployment or StatefulSet (default)",
+                    "default": "StatefulSet"
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternate scheduler for Redis&reg; master pods",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; master statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "minReadySeconds": {
+                    "type": "number",
+                    "description": "How many seconds a pod needs to be ready before killing the next, during update",
+                    "default": 0
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Redis&reg; master pods' priorityClassName",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Redis&reg; master pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Redis&reg; master pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Redis&reg; master pods",
+                    "default": {}
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Share a single process namespace between all of the containers in Redis&reg; master pods",
+                    "default": false
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `master.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `master.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Redis&reg; master pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Redis&reg; master pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Redis&reg; master pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Spread Constraints for Redis&reg; master pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "DNS Policy for Redis&reg; master pod",
+                    "default": ""
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "DNS Configuration for Redis&reg; master pod",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Redis&reg; master container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Redis&reg; master pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Redis&reg; master container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Redis&reg; master pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Redis&reg; master pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on Redis&reg; master nodes using Persistent Volume Claims",
+                            "default": true
+                        },
+                        "medium": {
+                            "type": "string",
+                            "description": "Provide a medium for `emptyDir` volumes.",
+                            "default": ""
+                        },
+                        "sizeLimit": {
+                            "type": "string",
+                            "description": "Set this to enable a size limit for `emptyDir` volumes.",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at on Redis&reg; master containers",
+                            "default": "/data"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount on Redis&reg; master containers",
+                            "default": ""
+                        },
+                        "subPathExpr": {
+                            "type": "string",
+                            "description": "Used to construct the subPath subdirectory of the volume to mount on Redis&reg; master containers",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional custom labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Additional labels to match for the PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Use a existing PVC which must be created manually before bound",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; master service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "number",
+                                    "description": "Redis&reg; master service port",
+                                    "default": 6379
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "string",
+                                    "description": "Node port for Redis&reg; master",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; master service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "internalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; master service internal traffic policy (requires Kubernetes v1.22 or greater to be usable)",
+                            "default": "Cluster"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Redis&reg; master service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Redis&reg; master service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Redis&reg; master service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalIPs": {
+                            "type": "array",
+                            "description": "Redis&reg; master service External IPs",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Redis&reg; master service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "Integer setting the termination grace period for the redis-master pods",
+                    "default": 30
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Whether to auto mount the service account token",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "replica": {
+            "type": "object",
+            "properties": {
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Redis&reg; replicas to deploy",
+                    "default": 3
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Configuration for Redis&reg; replicas nodes",
+                    "default": ""
+                },
+                "disableCommands": {
+                    "type": "array",
+                    "description": "Array with Redis&reg; commands to disable on replicas nodes",
+                    "default": [
+                        "FLUSHDB",
+                        "FLUSHALL"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "enableServiceLinks": {
+                    "type": "boolean",
+                    "description": "Whether information about services should be injected into pod's environment variable",
+                    "default": true
+                },
+                "preExecCmds": {
+                    "type": "array",
+                    "description": "Additional commands to run prior to starting Redis&reg; replicas",
+                    "default": [],
+                    "items": {}
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Array with additional command line flags for Redis&reg; replicas",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Redis&reg; replicas nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Redis&reg; replicas nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Redis&reg; replicas nodes",
+                    "default": ""
+                },
+                "externalMaster": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use external master for bootstrapping",
+                            "default": false
+                        },
+                        "host": {
+                            "type": "string",
+                            "description": "External master host to bootstrap from",
+                            "default": ""
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Port for Redis service external master host",
+                            "default": 6379
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "redis": {
+                            "type": "number",
+                            "description": "Container port to open on Redis&reg; replicas nodes",
+                            "default": 6379
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Redis&reg; replicas nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 22
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Redis&reg; replicas nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Redis&reg; replicas nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Redis&reg; replicas containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Redis&reg; replicas containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redis&reg; replicas pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Redis&reg; replicas pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redis&reg; replicas containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Redis&reg; replicas containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set Redis&reg; replicas containers' Security Context runAsGroup",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; replicas containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; replicas pod's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Redis&reg; replicas containers' Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Redis&reg; replicas containers' Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Alternate scheduler for Redis&reg; replicas pods",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; replicas statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "minReadySeconds": {
+                    "type": "number",
+                    "description": "How many seconds a pod needs to be ready before killing the next, during update",
+                    "default": 0
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Redis&reg; replicas pods' priorityClassName",
+                    "default": ""
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Redis&reg; replicas pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Redis&reg; replicas pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Redis&reg; replicas pods",
+                    "default": {}
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean",
+                    "description": "Share a single process namespace between all of the containers in Redis&reg; replicas pods",
+                    "default": false
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `replica.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `replica.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Redis&reg; replicas pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Redis&reg; replicas pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Redis&reg; replicas pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Spread Constraints for Redis&reg; replicas pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "DNS Policy for Redis&reg; replica pods",
+                    "default": ""
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "DNS Configuration for Redis&reg; replica pods",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Redis&reg; replica container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Redis&reg; replicas pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Redis&reg; replicas container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Redis&reg; replicas pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Redis&reg; replicas pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on Redis&reg; replicas nodes using Persistent Volume Claims",
+                            "default": true
+                        },
+                        "medium": {
+                            "type": "string",
+                            "description": "Provide a medium for `emptyDir` volumes.",
+                            "default": ""
+                        },
+                        "sizeLimit": {
+                            "type": "string",
+                            "description": "Set this to enable a size limit for `emptyDir` volumes.",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at on Redis&reg; replicas containers",
+                            "default": "/data"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount on Redis&reg; replicas containers",
+                            "default": ""
+                        },
+                        "subPathExpr": {
+                            "type": "string",
+                            "description": "Used to construct the subPath subdirectory of the volume to mount on Redis&reg; replicas containers",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional custom labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Additional labels to match for the PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Use a existing PVC which must be created manually before bound",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; replicas service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "number",
+                                    "description": "Redis&reg; replicas service port",
+                                    "default": 6379
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "string",
+                                    "description": "Node port for Redis&reg; replicas",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; replicas service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "internalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; replicas service internal traffic policy (requires Kubernetes v1.22 or greater to be usable)",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Redis&reg; replicas service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Redis&reg; replicas service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Redis&reg; replicas service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Redis&reg; replicas service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "Integer setting the termination grace period for the redis-replicas pods",
+                    "default": 30
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable replica autoscaling settings",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "number",
+                            "description": "Minimum replicas for the pod autoscaling",
+                            "default": 1
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Maximum replicas for the pod autoscaling",
+                            "default": 11
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Percentage of CPU to consider when autoscaling",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Percentage of Memory to consider when autoscaling",
+                            "default": ""
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": false
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Whether to auto mount the service account token",
+                            "default": true
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the ServiceAccount",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "sentinel": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Use Redis&reg; Sentinel on Redis&reg; pods.",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel image repository",
+                            "default": "bitnami/redis-sentinel"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel image tag (immutable tags are recommended)",
+                            "default": "7.2.1-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Redis&reg; Sentinel image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Redis&reg; Sentinel resource",
+                    "default": {}
+                },
+                "masterSet": {
+                    "type": "string",
+                    "description": "Master set name",
+                    "default": "mymaster"
+                },
+                "quorum": {
+                    "type": "number",
+                    "description": "Sentinel Quorum",
+                    "default": 2
+                },
+                "getMasterTimeout": {
+                    "type": "number",
+                    "description": "Amount of time to allow before get_sentinel_master_info() times out.",
+                    "default": 99
+                },
+                "automateClusterRecovery": {
+                    "type": "boolean",
+                    "description": "Automate cluster recovery in cases where the last replica is not considered a good replica and Sentinel won't automatically failover to it.",
+                    "default": false
+                },
+                "redisShutdownWaitFailover": {
+                    "type": "boolean",
+                    "description": "Whether the Redis&reg; master container waits for the failover at shutdown (in addition to the Redis&reg; Sentinel container).",
+                    "default": true
+                },
+                "downAfterMilliseconds": {
+                    "type": "number",
+                    "description": "Timeout for detecting a Redis&reg; node is down",
+                    "default": 60000
+                },
+                "failoverTimeout": {
+                    "type": "number",
+                    "description": "Timeout for performing a election failover",
+                    "default": 180000
+                },
+                "parallelSyncs": {
+                    "type": "number",
+                    "description": "Number of replicas that can be reconfigured in parallel to use the new master after a failover",
+                    "default": 1
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Configuration for Redis&reg; Sentinel nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "enableServiceLinks": {
+                    "type": "boolean",
+                    "description": "Whether information about services should be injected into pod's environment variable",
+                    "default": true
+                },
+                "preExecCmds": {
+                    "type": "array",
+                    "description": "Additional commands to run prior to starting Redis&reg; Sentinel",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Redis&reg; Sentinel nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Redis&reg; Sentinel nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Redis&reg; Sentinel nodes",
+                    "default": ""
+                },
+                "externalMaster": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Use external master for bootstrapping",
+                            "default": false
+                        },
+                        "host": {
+                            "type": "string",
+                            "description": "External master host to bootstrap from",
+                            "default": ""
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Port for Redis service external master host",
+                            "default": 6379
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "sentinel": {
+                            "type": "number",
+                            "description": "Container port to open on Redis&reg; Sentinel nodes",
+                            "default": 26379
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Redis&reg; Sentinel nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 22
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Redis&reg; Sentinel nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Redis&reg; Sentinel nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on Redis&reg; sentinel nodes using Persistent Volume Claims (Experimental)",
+                            "default": false
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "100Mi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional custom labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Additional labels to match for the PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        },
+                        "medium": {
+                            "type": "string",
+                            "description": "Provide a medium for `emptyDir` volumes.",
+                            "default": ""
+                        },
+                        "sizeLimit": {
+                            "type": "string",
+                            "description": "Set this to enable a size limit for `emptyDir` volumes.",
+                            "default": ""
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Redis&reg; Sentinel containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Redis&reg; Sentinel containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redis&reg; Sentinel containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Redis&reg; Sentinel containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set Redis&reg; Sentinel containers' Security Context runAsGroup",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; Sentinel containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; Sentinel containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Redis&reg; Sentinel containers' Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Redis&reg; Sentinel containers' Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Redis&reg; sentinel container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Redis&reg; Sentinel",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Redis&reg; Sentinel container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "number",
+                                    "description": "Redis&reg; service port for Redis&reg;",
+                                    "default": 6379
+                                },
+                                "sentinel": {
+                                    "type": "number",
+                                    "description": "Redis&reg; service port for Redis&reg; Sentinel",
+                                    "default": 26379
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "redis": {
+                                    "type": "string",
+                                    "description": "Node port for Redis&reg;",
+                                    "default": ""
+                                },
+                                "sentinel": {
+                                    "type": "string",
+                                    "description": "Node port for Sentinel",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Redis&reg; Sentinel service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Redis&reg; Sentinel service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Redis&reg; Sentinel service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "Integer setting the termination grace period for the redis-node pods",
+                    "default": 30
+                }
+            }
+        },
+        "serviceBindings": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Create secret for service binding (Experimental)",
+                    "default": false
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "extraIngress": {
+                    "type": "array",
+                    "description": "Add extra ingress rules to the NetworkPolicy",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEgress": {
+                    "type": "array",
+                    "description": "Add extra egress rules to the NetworkPolicy",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressNSMatchLabels": {
+                    "type": "object",
+                    "description": "Labels to match to allow traffic from other namespaces",
+                    "default": {}
+                },
+                "ingressNSPodMatchLabels": {
+                    "type": "object",
+                    "description": "Pod labels to match to allow traffic from other namespaces",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PodSecurityPolicy's RBAC rules",
+                    "default": false
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Whether to auto mount the service account token",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a PodDisruptionBudget should be created",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Min number of pods that must still be available after the eviction",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Max number of pods that can be unavailable after the eviction",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS traffic",
+                    "default": false
+                },
+                "authClients": {
+                    "type": "boolean",
+                    "description": "Require clients to authenticate",
+                    "default": true
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Enable autogenerated certificates",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of the existing secret that contains the TLS certificates",
+                    "default": ""
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "DEPRECATED. Use existingSecret instead.",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "Certificate filename",
+                    "default": ""
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "description": "Certificate Key filename",
+                    "default": ""
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "description": "CA Certificate filename",
+                    "default": ""
+                },
+                "dhParamsFilename": {
+                    "type": "string",
+                    "description": "File containing DH params (in order to support DH based ciphers)",
+                    "default": ""
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a sidecar prometheus exporter to expose Redis&reg; metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Redis&reg; Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Redis&reg; Exporter image repository",
+                            "default": "bitnami/redis-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Redis&reg; Exporter image tag (immutable tags are recommended)",
+                            "default": "1.54.0-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Redis&reg; Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Redis&reg; Exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Redis&reg; replicas nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Redis&reg; replicas nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Redis&reg; replicas nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default metrics container init command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "redisTargetHost": {
+                    "type": "string",
+                    "description": "A way to specify an alternative Redis&reg; hostname",
+                    "default": "localhost"
+                },
+                "extraArgs": {
+                    "type": "object",
+                    "description": "Extra arguments for Redis&reg; exporter, for example:",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Redis&reg; exporter",
+                    "default": [],
+                    "items": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redis&reg; exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Redis&reg; exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set Redis&reg; exporter containers' Security Context runAsGroup",
+                            "default": 0
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Redis&reg; exporter containers' Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Redis&reg; exporter containers' Security Context seccompProfile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Redis&reg; exporter containers' Security Context capabilities to drop",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Redis&reg; metrics sidecar",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Redis&reg; metrics sidecar",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Redis&reg; exporter container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Redis&reg; exporter container",
+                            "default": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9121"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Redis&reg; exporter pods",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Redis&reg; exporter service port",
+                            "default": 9121
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Redis&reg; exporter service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Redis&reg; exporter service",
+                            "default": {}
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Redis&reg; exporter service Cluster IP",
+                            "default": ""
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the ServiceMonitor will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "The interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "The timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabellings": {
+                            "type": "array",
+                            "description": "Metrics RelabelConfigs to apply to samples before scraping.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Metrics RelabelConfigs to apply to samples before ingestion.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor resource(s) can be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "podTargetLabels": {
+                            "type": "array",
+                            "description": "Labels from the Kubernetes pod to be transferred to the created metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sampleLimit": {
+                            "type": "boolean",
+                            "description": "Limit of how many samples should be scraped from every Pod",
+                            "default": false
+                        },
+                        "targetLimit": {
+                            "type": "boolean",
+                            "description": "Limit of how many targets should be scraped",
+                            "default": false
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a custom prometheusRule Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the prometheusRule will be created",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels for the prometheusRule",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom Prometheus rules",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "sysctl": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container to modify Kernel settings",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default init-sysctl container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "mountHostSys": {
+                    "type": "boolean",
+                    "description": "Mount the host `/sys` folder to `/host-sys`",
+                    "default": false
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "useExternalDNS": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable various syntax that would enable external-dns to work.  Note this requires a working installation of `external-dns` to be usable.",
+                    "default": false
+                },
+                "additionalAnnotations": {
+                    "type": "object",
+                    "description": "Extra annotations to be utilized when `external-dns` is enabled.",
+                    "default": {}
+                },
+                "annotationKey": {
+                    "type": "string",
+                    "description": "The annotation key utilized when `external-dns` is enabled. Setting this to `false` will disable annotations.",
+                    "default": "external-dns.alpha.kubernetes.io/"
+                },
+                "suffix": {
+                    "type": "string",
+                    "description": "The DNS suffix utilized when `external-dns` is enabled.  Note that we prepend the suffix with the full name of the release.",
+                    "default": ""
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/redmine/values.schema.json
+++ b/bitnami/redmine/values.schema.json
@@ -1,174 +1,1459 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "redmineUsername": {
-      "type": "string",
-      "title": "Username",
-      "form": true
-    },
-    "redminePassword": {
-      "type": "string",
-      "title": "Password",
-      "form": true,
-      "description": "Defaults to a random 10-character alphanumeric string if not set"
-    },
-    "redmineEmail": {
-      "type": "string",
-      "title": "Admin email",
-      "form": true
-    },
-    "persistence": {
-      "type": "object",
-      "title": "Persistence for Redmine replicas",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable persistence",
-          "description": "Enable persistence using Persistent Volume Claims"
-        },
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi",
-          "hidden": {
-            "value": false,
-            "path": "persistence/enabled"
-          }
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress Configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the Redmine installation."
-        },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        },
-        "tls": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable TLS configuration",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\""
-        }
-      }
-    },
-    "databaseType": {
-      "type": "string",
-      "form": true,
-      "enum": ["mariadb", "postgresql"],
-      "title": "Database Type",
-      "description": "Allowed values: \"mariadb\" and \"postgresql\""
-    },
-    "mariadb": {
-      "type": "object",
-      "title": "MariaDB Details",
-      "form": true,
-      "hidden": {
-        "value": "postgresql",
-        "path": "databaseType"
-      },
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MariaDB database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
-        },
-        "primary": {
-          "type": "object",
-          "properties": {
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "title": "Volume Size",
-                  "form": true,
-                  "hidden": {
-                    "value": false,
-                    "path": "mariadb/enabled"
-                  },
-                  "render": "slider",
-                  "sliderMin": 1,
-                  "sliderMax": 100,
-                  "sliderUnit": "Gi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "postgresql": {
-      "type": "object",
-      "title": "PostgreSQL Details",
-      "form": true,
-      "hidden": {
-        "value": "mariadb",
-        "pathe": "databaseType"
-      },
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new PostgreSQL database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a postgresql server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Redmine image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Redmine image repository",
+                    "default": "bitnami/redmine"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Redmine image tag (immutable tags are recommended)",
+                    "default": "5.0.5-debian-11-r71"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Redmine image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Redmine image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Redmine image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "redmineUsername": {
+            "type": "string",
+            "description": "Redmine username",
+            "default": "user"
+        },
+        "redminePassword": {
+            "type": "string",
+            "description": "Redmine user password",
+            "default": ""
+        },
+        "redmineEmail": {
+            "type": "string",
+            "description": "Redmine user email",
+            "default": "user@example.com"
+        },
+        "redmineLanguage": {
+            "type": "string",
+            "description": "Redmine default data language",
+            "default": "en"
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow the container to be started with blank passwords",
+            "default": false
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP server host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP server port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP username",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP user password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing Redmine credentials",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "customPostInitScripts": {
+            "type": "object",
+            "description": "Custom post-init.d user scripts",
+            "default": {}
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the Redmine container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Redmine replicas to deploy",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Redmine HTTP container port",
+                    "default": 3000
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Redmine container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Redmine pods' Security Context",
+                    "default": false
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Redmine pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Redmine containers' Security Context",
+                    "default": false
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Redmine container's Security Context runAsUser",
+                    "default": 1001
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on Redmine containers",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for to check for livenessProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 300
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on Redmine containers",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to check for readinessProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on Redmine containers",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to check for startupProbe",
+                    "default": "/"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 300
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHooks to set additional configuration at startup",
+            "default": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Redmine pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Redmine pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Redmine pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Redmine pods' Priority Class Name",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternate scheduler",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Redmine pod needs to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Redmine statefulset strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Redmine statefulset rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Redmine pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Redmine container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Redmine pods",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Redmine pod",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Redmine service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Redmine service HTTP port",
+                            "default": 80
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "NodePort for the Redmine HTTP endpoint",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Redmine service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Redmine service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Redmine service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Redmine service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Redmine service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on Redmine service",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Redmine",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "redmine.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
         },
         "persistence": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "string",
-              "title": "Volume Size",
-              "form": true,
-              "hidden": {
-                "value": false,
-                "path": "postgresql/enabled"
-              },
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 100,
-              "sliderUnit": "Gi"
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "8Gi"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                }
             }
-          }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable init container's Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to create (name generated using common.names.fullname template otherwise)",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Auto-mount the service account token in the pod",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": ""
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for Redmine",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of Redmine replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of Redmine replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "databaseType": {
+            "type": "string",
+            "description": "Redmine database type. Allowed values: `mariadb` and `postgresql`",
+            "default": "mariadb"
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the MariaDB helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "MariaDB root password",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "MariaDB username",
+                            "default": "bn_redmine"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MariaDB password",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for MariaDB credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Name for a custom user to create",
+                            "default": "bn_redmine"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the custom user to create",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name for a custom database to create",
+                            "default": "bitnami_redmine"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for Redmine",
+                    "default": "bn_redmine"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for Redmine",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Redmine database name",
+                    "default": "bitnami_redmine"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": ""
+                }
+            }
+        },
+        "mailReceiver": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable scheduled mail-to-task CronJob",
+                    "default": false
+                },
+                "schedule": {
+                    "type": "string",
+                    "description": "Kubernetes CronJob schedule",
+                    "default": "*/5 * * * *"
+                },
+                "suspend": {
+                    "type": "boolean",
+                    "description": "Whether to create suspended CronJob",
+                    "default": true
+                },
+                "mailProtocol": {
+                    "type": "string",
+                    "description": "Mail protocol to use for reading emails. Allowed values: `IMAP` and `POP3`",
+                    "default": "IMAP"
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Server to receive emails from",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "TCP port on the `host`",
+                    "default": 993
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Login to authenticate on the `host`",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to authenticate on the `host`",
+                    "default": ""
+                },
+                "ssl": {
+                    "type": "boolean",
+                    "description": "Whether use SSL/TLS to connect to the `host`",
+                    "default": true
+                },
+                "startTLS": {
+                    "type": "boolean",
+                    "description": "Whether use StartTLS to connect to the `host`",
+                    "default": false
+                },
+                "imapFolder": {
+                    "type": "string",
+                    "description": "IMAP only. Folder to read emails from",
+                    "default": "INBOX"
+                },
+                "moveOnSuccess": {
+                    "type": "string",
+                    "description": "IMAP only. Folder to move processed emails to",
+                    "default": ""
+                },
+                "moveOnFailure": {
+                    "type": "string",
+                    "description": "IMAP only. Folder to move emails with processing errors to",
+                    "default": ""
+                },
+                "unknownUserAction": {
+                    "type": "string",
+                    "description": "Action to perform is an email received from unregistered user",
+                    "default": "ignore"
+                },
+                "noPermissionCheck": {
+                    "type": "number",
+                    "description": "Whether skip permission check during creating a new task",
+                    "default": 0
+                },
+                "noAccountNotice": {
+                    "type": "number",
+                    "description": "Whether send an email to an unregistered user created during a new task creation",
+                    "default": 1
+                },
+                "defaultGroup": {
+                    "type": "string",
+                    "description": "Defines a group list to add created user to",
+                    "default": ""
+                },
+                "project": {
+                    "type": "string",
+                    "description": "Defines identifier of the target project for a new task",
+                    "default": ""
+                },
+                "projectFromSubaddress": {
+                    "type": "string",
+                    "description": "Defines email address to select project from subaddress",
+                    "default": ""
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Defines a new task status",
+                    "default": ""
+                },
+                "tracker": {
+                    "type": "string",
+                    "description": "Defines a new task tracker",
+                    "default": ""
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Defines a new task category",
+                    "default": ""
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Defines a new task priority",
+                    "default": ""
+                },
+                "assignedTo": {
+                    "type": "string",
+                    "description": "Defines a new task assignee",
+                    "default": ""
+                },
+                "allowOverride": {
+                    "type": "string",
+                    "description": "Defines if email content is allowed to set attributes values. Values is a comma separated list of attributes or `all` to allow all attributes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on mailReceiver container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Redmine pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Redmine pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "mailReceiver Container securityContext",
+                            "default": false
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the mailReceiver container",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Whether to run the mailReceiver container as a non-root user",
+                            "default": true
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional pod annotations",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional pod labels",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `mailReceiver.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `mailReceiver.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Redmine pods' priority.",
+                    "default": ""
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the mailReceiver pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the mailReceiver pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for mailReceiver container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for mailReceiver container",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "customCA": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Redmine image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Redmine image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Redmine image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r43"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Redmine image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Redmine image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Redmine image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables (e.g. proxy)",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by Redmine's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes Redmine only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access Redmine. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access Redmine. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/bitnami/schema-registry/values.schema.json
+++ b/bitnami/schema-registry/values.schema.json
@@ -1,0 +1,922 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override airflow.fullname template with a string (will prepend the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override airflow.fullname template with a string",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Schema Registry image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Schema Registry image repository",
+                    "default": "bitnami/schema-registry"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Schema Registry image tag (immutable tags are recommended)",
+                    "default": "7.4.1-debian-11-r25"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Schema Registry image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Schema Registry image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Schema Registry image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Schema Registry pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Schema Registry pods",
+            "default": {}
+        },
+        "configuration": {
+            "type": "object",
+            "description": "Specify content for schema-registry.properties. Auto-generated based on other parameters when not specified",
+            "default": {}
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "Name of existing ConfigMap with Schema Registry configuration",
+            "default": ""
+        },
+        "log4j": {
+            "type": "object",
+            "description": "Schema Registry Log4J Configuration (optional)",
+            "default": {}
+        },
+        "existingLog4jConfigMap": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing a custom log4j.properties file.",
+            "default": ""
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration to provide to be used when a listener uses HTTPS",
+                            "default": false
+                        },
+                        "jksSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing the truststore and one keystore per Schema Registry replica",
+                            "default": ""
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access the keystore when it's password-protected",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access the truststore when it's password-protected",
+                            "default": ""
+                        },
+                        "clientAuthentication": {
+                            "type": "string",
+                            "description": "Client authentication configuration.",
+                            "default": "NONE"
+                        }
+                    }
+                },
+                "kafka": {
+                    "type": "object",
+                    "properties": {
+                        "jksSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing the truststore and one keystore per Schema Registry replica",
+                            "default": ""
+                        },
+                        "tlsEndpointIdentificationAlgorithm": {
+                            "type": "string",
+                            "description": "The endpoint identification algorithm used validate brokers hostnames",
+                            "default": "https"
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access the keystore when it's password-protected",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access the truststore when it's password-protected",
+                            "default": ""
+                        },
+                        "saslMechanism": {
+                            "type": "string",
+                            "description": "Mechanism that schema registry will use to connect to kafka. Allowed: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512",
+                            "default": "PLAIN"
+                        }
+                    }
+                }
+            }
+        },
+        "listeners": {
+            "type": "string",
+            "description": "Comma-separated list of listeners that listen for API requests over either HTTP or HTTPS",
+            "default": "http://0.0.0.0:8081"
+        },
+        "avroCompatibilityLevel": {
+            "type": "string",
+            "description": "Avro compatibility type",
+            "default": "backward"
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on Schema Registry container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Schema Registry replicas to deploy.",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Schema Registry statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join",
+            "default": "OrderedReady"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Schema Registry pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Schema Registry pod priority class name",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "object",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default) for Schema Registry pods",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds Redmine pod needs to terminate gracefully",
+            "default": ""
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the Schema Registry container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Controller pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Controller pod's Security Context fsGroup",
+                    "default": 1001
+                },
+                "sysctls": {
+                    "type": "array",
+                    "description": "sysctl settings of the Schema Registry pods",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable container security context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the container",
+                    "default": 1001
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 20
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 20
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for schema-registry pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for schema-registry container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the Schema Registry pods.",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the Schema Registry pods.",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable/disable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that must still be available after the eviction",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable after the eviction",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable autoscaling for replicas",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "string",
+                    "description": "Target CPU utilization percentage",
+                    "default": ""
+                },
+                "targetMemory": {
+                    "type": "string",
+                    "description": "Target Memory utilization percentage",
+                    "default": ""
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 8081
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Service HTTP node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Schema Registry service clusterIP IP",
+                    "default": ""
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP if service type is LoadBalancer",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Address that are allowed when service is LoadBalancer",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Schema Registry service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in Schema Registry service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Schema Registry",
+                    "default": false
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "schema-registry.local"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ingress record",
+                    "default": {}
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Schema Registry pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created ServiceAccount to use",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "kafka": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Kafka chart installation",
+                    "default": true
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Kafka controller-eligible (controller+broker) nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "listeners": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "object",
+                            "properties": {
+                                "protocol": {
+                                    "type": "string",
+                                    "description": "Authentication protocol for communications with clients. Allowed protocols: `PLAINTEXT`, `SASL_PLAINTEXT`, `SASL_SSL`, `SSL`",
+                                    "default": "PLAINTEXT"
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "client": {
+                                    "type": "number",
+                                    "description": "Kafka svc port for client connections",
+                                    "default": 9092
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraConfig": {
+                    "type": "string",
+                    "description": "Additional configuration to be appended at the end of the generated Kafka configuration file.",
+                    "default": "offsets.topic.replication.factor=1"
+                },
+                "sasl": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "object",
+                            "properties": {
+                                "users": {
+                                    "type": "array",
+                                    "description": "Comma-separated list of usernames for Kafka client listener when SASL is enabled",
+                                    "default": [
+                                        "user"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "passwords": {
+                                    "type": "string",
+                                    "description": "Comma-separated list of passwords for client listener when SASL is enabled, must match the number of client.users",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalKafka": {
+            "type": "object",
+            "properties": {
+                "brokers": {
+                    "type": "array",
+                    "description": "Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port",
+                    "default": [
+                        "PLAINTEXT://localhost:9092"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "listener": {
+                    "type": "object",
+                    "properties": {
+                        "protocol": {
+                            "type": "string",
+                            "description": "Kafka listener protocol. Allowed protocols: PLAINTEXT, SASL_PLAINTEXT, SASL_SSL and SSL",
+                            "default": "PLAINTEXT"
+                        }
+                    }
+                },
+                "sasl": {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "string",
+                            "description": "User for SASL authentication",
+                            "default": "user"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for SASL authentication",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing a password for SASL authentication (under the key named \"client-passwords\")",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/sealed-secrets/values.schema.json
+++ b/bitnami/sealed-secrets/values.schema.json
@@ -1,0 +1,716 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Sealed Secrets image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Sealed Secrets image repository",
+                    "default": "bitnami/sealed-secrets"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Sealed Secrets image tag (immutable tags are recommended)",
+                    "default": "0.23.1-debian-11-r2"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Sealed Secrets image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Sealed Secrets image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Sealed Secrets image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable Sealed Secrets image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "commandArgs": {
+            "type": "array",
+            "description": "Additional args (doesn't override the default ones)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Controller HTTP container port to open",
+                    "default": 8080
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on Sealed Secret containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on Sealed Secret containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on Sealed Secret containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Sealed Secret pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Sealed Secret pod's Security Context fsGroup",
+                    "default": 1001
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set Sealed Secret pod's Security Context seccompProfile type",
+                            "default": "RuntimeDefault"
+                        }
+                    }
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled Sealed Secret containers' Security Context",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Whether the Sealed Secret container can escalate privileges",
+                    "default": false
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "description": "Which privileges to drop in the Sealed Secret container",
+                            "default": [
+                                "ALL"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "description": "Whether the Sealed Secret container has a read-only root filesystem",
+                    "default": true
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Indicates that the Sealed Secret container must run as a non-root user",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Sealed Secret containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set Sealed Secret container's Security Context seccompProfile type",
+                            "default": "RuntimeDefault"
+                        }
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Sealed Secret pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for Sealed Secret pods assignment",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Sealed Secret statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Sealed Secret pods' priorityClassName",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default) for Sealed Secret pods",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "Seconds the pod needs to terminate gracefully",
+            "default": ""
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to Sealed Secret nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for Sealed Secret nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for Sealed Secret nodes",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the Sealed Secret pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Sealed Secret container(s)",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Sealed Secret service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Sealed Secret service HTTP port number",
+                            "default": 8080
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Sealed Secret service HTTP port name",
+                            "default": "http"
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Sealed Secret service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Sealed Secret service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Sealed Secret service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Sealed Secret service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in Sealed Secret service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Sealed Secret",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "sealed-secrets.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "PodSecurityPolicy",
+                    "default": false
+                },
+                "unsealer": {
+                    "type": "object",
+                    "properties": {
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set for unsealer ClusterRole",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "keyAdmin": {
+                    "type": "object",
+                    "properties": {
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set for key-admin role",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceProxier": {
+                    "type": "object",
+                    "properties": {
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set for service-proxier role",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether a NetworkPolicy should be created",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Specify if a ServiceMonitor will be deployed for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional ServiceMonitor annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/solr/values.schema.json
+++ b/bitnami/solr/values.schema.json
@@ -1,0 +1,1482 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Extra objects to deploy (value evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Solr image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Solr image repository",
+                    "default": "bitnami/solr"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Solr image tag (immutable tags are recommended)",
+                    "default": "9.3.0-debian-11-r34"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Solr image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Solr authentication",
+                    "default": true
+                },
+                "adminUsername": {
+                    "type": "string",
+                    "description": "Solr admin username",
+                    "default": "admin"
+                },
+                "adminPassword": {
+                    "type": "string",
+                    "description": "Solr admin password. Autogenerated if not provided.",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret with Solr password",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Password key to be retrieved from existing secret",
+                    "default": "solr-password"
+                }
+            }
+        },
+        "coreNames": {
+            "type": "array",
+            "description": "Solr core names to be created",
+            "default": [
+                "my-core"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "cloudEnabled": {
+            "type": "boolean",
+            "description": "Enable Solr cloud mode",
+            "default": true
+        },
+        "cloudBootstrap": {
+            "type": "boolean",
+            "description": "Enable cloud bootstrap. It will be performed from the node 0.",
+            "default": true
+        },
+        "collection": {
+            "type": "string",
+            "description": "Solr collection name",
+            "default": "my-collection"
+        },
+        "collectionShards": {
+            "type": "number",
+            "description": "Number of collection shards",
+            "default": 1
+        },
+        "collectionReplicas": {
+            "type": "number",
+            "description": "Number of collection replicas",
+            "default": 2
+        },
+        "serverDirectory": {
+            "type": "string",
+            "description": "Name of the created directory for the server",
+            "default": "server"
+        },
+        "javaMem": {
+            "type": "string",
+            "description": "Java memory options to pass to the Solr container",
+            "default": ""
+        },
+        "heap": {
+            "type": "string",
+            "description": "Java Heap options to pass to the Solr container",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override Solr entrypoint string",
+            "default": [
+                "/scripts/setup.sh"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "args": {
+            "type": "array",
+            "description": "Arguments for the provided command if needed",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Additional environment variables to set",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap with extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret with extra environment variables",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of solr replicas",
+            "default": 3
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "Solr HTTP container port",
+                    "default": 8983
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on Solr containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 40
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 15
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on Solr containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 60
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 15
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on Solr containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 40
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 15
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "lifecycleHooks for the Solr container to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Solr pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Solr pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Solr containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set Solr containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Solr containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Solr pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Solr pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Solr pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Solr pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Solr pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Solr node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Solr node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Solr node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity settings for Solr pod assignment. Evaluated as a template",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for Solr pods assignment. Evaluated as a template",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for Solr pods assignment. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "Management Policy for Solr StatefulSet",
+            "default": "Parallel"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Solr pods' priority.",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Kubernetes pod scheduler registry",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Solr statefulset strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "Solr statefulset rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the Solr pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Solr container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add init containers to the Solr pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add sidecars to the Solr pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Solr HTTP service port",
+                            "default": 8983
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for the HTTP service",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Solr service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Solr service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Solr service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Solr service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Solr service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the Solr service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for Apache Geode",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "solr.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Use a PVC to persist data.",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "A manually managed Persistent Volume and Claim",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Storage class of backing PVC",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume Access Modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistence annotations for Solr",
+                    "default": {}
+                },
+                "mountPath": {
+                    "type": "string",
+                    "description": "Persistence mount path for Solr",
+                    "default": "/bitnami/solr"
+                },
+                "subPath": {
+                    "type": "string",
+                    "description": "Path within the volume from which the container's",
+                    "default": ""
+                },
+                "subPathExpr": {
+                    "type": "string",
+                    "description": "Expanded path within the volume from which",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r54"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Solr pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the TLS/SSL configuration",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                    "default": false
+                },
+                "certificatesSecretName": {
+                    "type": "string",
+                    "description": "Name of the secret that contains the certificates",
+                    "default": ""
+                },
+                "passwordsSecretName": {
+                    "type": "string",
+                    "description": "Set the name of the secret that contains the passwords for the certificate files",
+                    "default": ""
+                },
+                "keystorePassword": {
+                    "type": "string",
+                    "description": "Password to access the keystore when it's password-protected",
+                    "default": ""
+                },
+                "truststorePassword": {
+                    "type": "string",
+                    "description": "Password to access the truststore when it's password-protected",
+                    "default": ""
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the TLS init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the TLS init container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a Solr Prometheus exporter deployment to expose metrics",
+                    "default": false
+                },
+                "configFile": {
+                    "type": "string",
+                    "description": "Config file with metrics to export by the Solr prometheus metrics. To change it mount a different file using `extraConfigMaps`",
+                    "default": "/opt/bitnami/solr/prometheus-exporter/conf/solr-exporter-config.xml"
+                },
+                "threads": {
+                    "type": "number",
+                    "description": "Number of Solr exporter threads",
+                    "default": 7
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override Solr entrypoint string.",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Arguments for the provided command if needed",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Additional environment variables to set",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Solr Prometheus exporter HTTP container port",
+                            "default": 9231
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Solr Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Solr Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 15
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 15
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Solr Prometheus exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Solr Prometheus exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the containers.",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Enable Solr Prometheus exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Solr Prometheus exporter pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pods.",
+                            "default": 1001
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Additional labels for Solr Prometheus exporter pod(s)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Additional annotations for Solr Prometheus exporter pod(s)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Solr Prometheus exporter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Solr Prometheus exporter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Solr Prometheus exporter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Solr Prometheus exporter node label key to match Ignored if `affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Solr Prometheus exporter node label values to match. Ignored if `affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity settings for Solr Prometheus exporter pod assignment. Evaluated as a template",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Solr Prometheus exporter pods assignment. Evaluated as a template",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Solr Prometheus exporter pods assignment. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Solr Prometheus exporter pods' priority.",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Kubernetes pod scheduler registry",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Solr Prometheus exporter pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Solr Prometheus exporter deployment strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "Solr Prometheus exporter deployment rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Solr Prometheus exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Solr Prometheus exporter container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the Solr Prometheus exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the Solr Prometheus exporter pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Solr Prometheus exporter HTTP service port",
+                                    "default": 9231
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Solr Prometheus exporter service Cluster IP",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "annotations for Solr Prometheus exporter service",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels for Solr Prometheus exporter service",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a custom prometheusRule Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "The namespace in which the prometheusRule will be created",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels for the prometheusRule",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom Prometheus rules",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "zookeeper": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ZooKeeper deployment. Needed for Solr cloud",
+                    "default": true
+                },
+                "fourlwCommandsWhitelist": {
+                    "type": "string",
+                    "description": "A list of comma separated Four Letter Words commands that can be executed",
+                    "default": "srvr,mntr,conf,ruok"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "number",
+                            "description": "ZooKeeper client container port",
+                            "default": 2181
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of ZooKeeper nodes",
+                    "default": 3
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence on ZooKeeper using PVC(s)",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "8Gi"
+                        }
+                    }
+                }
+            }
+        },
+        "externalZookeeper": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "description": "List of external zookeeper servers to use",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/sonarqube/values.schema.json
+++ b/bitnami/sonarqube/values.schema.json
@@ -1,0 +1,1562 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "SonarQube&trade; image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "SonarQube&trade; image repository",
+                    "default": "bitnami/sonarqube"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "SonarQube&trade; image tag (immutable tags are recommended)",
+                    "default": "10.2.0-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "SonarQube&trade; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "SonarQube&trade; image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "SonarQube&trade; image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable SonarQube&trade; image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "sonarqubeUsername": {
+            "type": "string",
+            "description": "SonarQube&trade; username",
+            "default": "user"
+        },
+        "sonarqubePassword": {
+            "type": "string",
+            "description": "SonarQube&trade; user password",
+            "default": ""
+        },
+        "provisioningFolder": {
+            "type": "string",
+            "description": "Directory to use for provisioning content to Sonarqube",
+            "default": "/bitnami/sonarqube-provisioning"
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing SonarQube&trade; credentials",
+            "default": ""
+        },
+        "sonarqubeEmail": {
+            "type": "string",
+            "description": "SonarQube&trade; user email",
+            "default": "user@example.com"
+        },
+        "minHeapSize": {
+            "type": "string",
+            "description": "Minimum heap size for SonarQube&trade;",
+            "default": "1024m"
+        },
+        "maxHeapSize": {
+            "type": "string",
+            "description": "Maximum heap size for SonarQube&trade;",
+            "default": "2048m"
+        },
+        "jvmOpts": {
+            "type": "string",
+            "description": "Values to add to SONARQUBE_WEB_JAVA_ADD_OPTS",
+            "default": ""
+        },
+        "jvmCeOpts": {
+            "type": "string",
+            "description": "Values to add to SONAR_CE_JAVAADDITIONALOPTS",
+            "default": ""
+        },
+        "startTimeout": {
+            "type": "number",
+            "description": "Timeout for the application to start in seconds",
+            "default": 150
+        },
+        "extraProperties": {
+            "type": "array",
+            "description": "List of extra properties to be set in the sonar.properties file (key=value format)",
+            "default": [],
+            "items": {}
+        },
+        "sonarqubeSkipInstall": {
+            "type": "boolean",
+            "description": "Skip wizard installation",
+            "default": false
+        },
+        "sonarSecurityRealm": {
+            "type": "string",
+            "description": "Set this to LDAP authenticate first against the external sytem. If the external system is not",
+            "default": ""
+        },
+        "sonarAuthenticatorDowncase": {
+            "type": "string",
+            "description": "Set to true when connecting to a LDAP server using a case-insensitive setup.",
+            "default": ""
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "URL of the LDAP server. If you are using ldaps, you should install the server certificate into the Java truststore",
+                    "default": ""
+                },
+                "bindDn": {
+                    "type": "string",
+                    "description": "The username of an LDAP user to connect (or bind) with. Leave this blank for anonymous access to the LDAP directory.",
+                    "default": ""
+                },
+                "bindPassword": {
+                    "type": "string",
+                    "description": "The password of the user to connect with. Leave this blank for anonymous access to the LDAP directory.",
+                    "default": ""
+                },
+                "authentication": {
+                    "type": "string",
+                    "description": "Possible values: simple, CRAM-MD5, DIGEST-MD5, GSSAPI. See the tutorial on authentication mechanisms (<http://java.sun.com/products/jndi/tutorial/ldap/security/auth.html>)",
+                    "default": "simple"
+                },
+                "realm": {
+                    "type": "string",
+                    "description": "See Digest-MD5 Authentication, CRAM-MD5 Authentication (<http://java.sun.com/products/jndi/tutorial/ldap/security/digest.html>)",
+                    "default": ""
+                },
+                "contextFactoryClass": {
+                    "type": "string",
+                    "description": "Context factory class.",
+                    "default": "com.sun.jndi.ldap.LdapCtxFactory"
+                },
+                "StartTLS": {
+                    "type": "boolean",
+                    "description": "Enable use of StartTLS",
+                    "default": false
+                },
+                "followReferrals": {
+                    "type": "boolean",
+                    "description": "Follow referrals or not",
+                    "default": true
+                },
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "baseDn": {
+                            "type": "string",
+                            "description": "Distinguished Name (DN) of the root node in LDAP from which to search for users.",
+                            "default": ""
+                        },
+                        "request": {
+                            "type": "string",
+                            "description": "LDAP user request.",
+                            "default": "(&(objectClass=inetOrgPerson)(uid={login}))"
+                        },
+                        "realNameAttribute": {
+                            "type": "string",
+                            "description": "in LDAP defining the user’s real name.",
+                            "default": "cn"
+                        },
+                        "emailAttribute": {
+                            "type": "string",
+                            "description": "Attribute in LDAP defining the user’s email.",
+                            "default": "mail"
+                        }
+                    }
+                },
+                "group": {
+                    "type": "object",
+                    "properties": {
+                        "baseDn": {
+                            "type": "string",
+                            "description": "Distinguished Name (DN) of the root node in LDAP from which to search for groups.",
+                            "default": ""
+                        },
+                        "request": {
+                            "type": "string",
+                            "description": "LDAP group request.",
+                            "default": "(&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))"
+                        },
+                        "idAttribute": {
+                            "type": "string",
+                            "description": "Attribute in LDAP defining the group’s real name.",
+                            "default": "cn"
+                        }
+                    }
+                }
+            }
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP server host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP server port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP username",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP user password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to SonarQube&trade; nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for SonarQube&trade; nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for SonarQube&trade; nodes",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of SonarQube&trade; replicas to deploy",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "SonarQube&trade; HTTP container port",
+                    "default": 9000
+                },
+                "elastic": {
+                    "type": "number",
+                    "description": "SonarQube&trade; Elasticsearch container port",
+                    "default": 9001
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on SonarQube&trade; containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 100
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on SonarQube&trade; containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 100
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on SonarQube&trade; containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the SonarQube&trade; containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "100m"
+                        },
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "2048Mi"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled SonarQube&trade; pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set SonarQube&trade; pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled SonarQube&trade; containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set SonarQube&trade; containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set SonarQube&trade; containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "SonarQube&trade; pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for SonarQube&trade; pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for SonarQube&trade; pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for SonarQube&trade; pods assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for SonarQube&trade; pods assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for SonarQube&trade; pods assignment",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "SonarQube&trade; statefulset strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "SonarQube&trade; pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default) for SonarQube&trade; pods",
+            "default": ""
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the SonarQube&trade; container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the SonarQube&trade; pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the SonarQube&trade; container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the SonarQube&trade; pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the SonarQube&trade; pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "SonarQube&trade; service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "SonarQube&trade; service HTTP port",
+                            "default": 80
+                        },
+                        "elastic": {
+                            "type": "number",
+                            "description": "SonarQube&trade; service ElasticSearch port",
+                            "default": 9001
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "elastic": {
+                            "type": "string",
+                            "description": "Node port for ElasticSearch",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "SonarQube&trade; service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "SonarQube&trade; service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "SonarQube&trade; service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "SonarQube&trade; service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for SonarQube&trade; service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in SonarQube&trade; service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for SonarQube&trade;",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "sonarqube.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Additional labels for the Ingress resource.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "caCerts": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the use of caCerts",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "secret": {
+                    "type": "string",
+                    "description": "Name of the secret containing the certificates",
+                    "default": "ca-certs-secret"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "plugins": {
+            "type": "object",
+            "properties": {
+                "install": {
+                    "type": "array",
+                    "description": "List of plugin URLS to download and install",
+                    "default": [],
+                    "items": {}
+                },
+                "netrcCreds": {
+                    "type": "string",
+                    "description": ".netrc secret file with a key \"netrc\" to use basic auth while downloading plugins",
+                    "default": ""
+                },
+                "noCheckCertificate": {
+                    "type": "boolean",
+                    "description": "Set to true to not validate the server's certificate to download plugin",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": false
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "10Gi"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "sysctl": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable kernel settings modifier image",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": false
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for SonarQube&trade;",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of SonarQube&trade; replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of SonarQube&trade; replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "jmx": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to expose JMX metrics to Prometheus",
+                            "default": false
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "JMX exporter image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "JMX exporter image repository",
+                                    "default": "bitnami/jmx-exporter"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "JMX exporter image tag (immutable tags are recommended)",
+                                    "default": "0.19.0-debian-11-r63"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "JMX exporter image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Specify docker-registry secret names as an array",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "JMX Exporter metrics container port",
+                                    "default": 10445
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the init container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the init container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled JMX Exporter containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set JMX Exporter containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set JMX Exporter containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "whitelistObjectNames": {
+                            "type": "array",
+                            "description": "Allows setting which JMX objects you want to expose to via JMX stats to JMX Exporter",
+                            "default": [
+                                "java.lang:*",
+                                "SonarQube:*",
+                                "Tomcat:*"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "configuration": {
+                            "type": "string",
+                            "description": "Configuration file for JMX exporter",
+                            "default": "jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:10443/jmxrmi\nlowercaseOutputName: true\nlowercaseOutputLabelNames: true\nssl: false\n{{- if .Values.metrics.jmx.whitelistObjectNames }}\nwhitelistObjectNames: [\"{{ join \"\\\",\\\"\" .Values.metrics.jmx.whitelistObjectNames }}\"]\n{{- end }}\nrules:\n- pattern: java.lang<type=(.+), name=(.+)><(.+)>(\\w+)\n  name: java_lang_$1_$4_$3_$2\n- pattern: java.lang<type=(.+), name=(.+)><>(\\w+)\n  name: java_lang_$1_$3_$2\n- pattern: java.lang<type=(.*)>\n- pattern: SonarQube<name=(.+)><>(\\w+)\n  name: sonarqube_$1_$2\n- pattern: Tomcat<type=(.+), name=(.+)><>(\\w+)\n  name: tomcat_$1_$3_$2"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "number",
+                                            "description": "JMX Exporter Prometheus port",
+                                            "default": 10443
+                                        }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prometheus": {
+                                            "type": "object",
+                                            "properties": {
+                                                "io/scrape": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "true"
+                                                },
+                                                "io/port": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "{{ .Values.metrics.jmx.service.ports.metrics }}"
+                                                },
+                                                "io/path": {
+                                                    "type": "string",
+                                                    "description": "",
+                                                    "default": "/"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.jmx.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "How frequently to scrape metrics",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy PostgreSQL subchart",
+                    "default": true
+                },
+                "nameOverride": {
+                    "type": "string",
+                    "description": "Override name of the PostgreSQL chart",
+                    "default": ""
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Existing secret containing the password of the PostgreSQL chart",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the postgres user of the PostgreSQL chart (auto-generated if not set)",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Username to create when deploying the PostgreSQL chart",
+                            "default": "bn_sonarqube"
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database to create when deploying the PostgreSQL chart",
+                            "default": "bitnami_sonarqube"
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "postgresql": {
+                                            "type": "number",
+                                            "description": "PostgreSQL service port",
+                                            "default": 5432
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable PostgreSQL Primary data persistence using PVC",
+                                    "default": true
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing PVC to use",
+                                    "default": ""
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "PVC Storage Class for PostgreSQL Primary data volume",
+                                    "default": ""
+                                },
+                                "accessMode": {
+                                    "type": "string",
+                                    "description": "PVC Access Mode for PostgreSQL volume",
+                                    "default": "ReadWriteOnce"
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "PVC Storage Request for PostgreSQL volume",
+                                    "default": "8Gi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of an external PostgreSQL instance to connect (only if postgresql.enabled=false)",
+                    "default": ""
+                },
+                "user": {
+                    "type": "string",
+                    "description": "User of an external PostgreSQL instance to connect (only if postgresql.enabled=false)",
+                    "default": "postgres"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password of an external PostgreSQL instance to connect (only if postgresql.enabled=false)",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Secret containing the password of an external PostgreSQL instance to connect (only if postgresql.enabled=false)",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Database inside an external PostgreSQL to connect (only if postgresql.enabled=false)",
+                    "default": "sonarqube"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of an external PostgreSQL to connect (only if postgresql.enabled=false)",
+                    "default": 5432
+                }
+            }
+        }
+    }
+}

--- a/bitnami/spark/values.schema.json
+++ b/bitnami/spark/values.schema.json
@@ -1,0 +1,1424 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "initScripts": {
+            "type": "object",
+            "description": "Dictionary of init scripts. Evaluated as a template.",
+            "default": {}
+        },
+        "initScriptsCM": {
+            "type": "string",
+            "description": "ConfigMap with the init scripts. Evaluated as a template.",
+            "default": ""
+        },
+        "initScriptsSecret": {
+            "type": "string",
+            "description": "Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.",
+            "default": ""
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Spark image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Spark image repository",
+                    "default": "bitnami/spark"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Spark image tag (immutable tags are recommended)",
+                    "default": "3.4.1-debian-11-r48"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Spark image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Spark image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "description": "Enable HOST Network",
+            "default": false
+        },
+        "master": {
+            "type": "object",
+            "properties": {
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with your custom configuration for master",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Specify the port where the web interface will listen on the master over HTTP",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Specify the port where the web interface will listen on the master over HTTPS",
+                            "default": 8480
+                        },
+                        "cluster": {
+                            "type": "number",
+                            "description": "Specify the port where the master listens to communicate with workers",
+                            "default": 7077
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "extraContainerPorts": {
+                    "type": "array",
+                    "description": "Specify the port where the running jobs inside the masters listens",
+                    "default": [],
+                    "items": {}
+                },
+                "daemonMemoryLimit": {
+                    "type": "string",
+                    "description": "Set the memory limit for the master daemon",
+                    "default": ""
+                },
+                "configOptions": {
+                    "type": "string",
+                    "description": "Use a string to set the config options for in the form \"-Dx=y\"",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to pass to the master container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for master nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for master nodes",
+                    "default": ""
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set master pod's Security Context Group ID",
+                            "default": 1001
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set master pod's Security Context User ID",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Set master pod's Security Context Group ID",
+                            "default": 0
+                        },
+                        "seLinuxOptions": {
+                            "type": "object",
+                            "description": "Set master pod's Security Context SELinux options",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled master containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set master containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set master containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set master containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for pods in StatefulSet",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for pods in StatefulSet",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Spark master pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Spark master pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Spark master node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Spark master node label key to match Ignored if `master.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Spark master node label values to match. Ignored if `master.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Spark master affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Spark master node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Spark master tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Master statefulset strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "master pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for master pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the master container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the master pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the master container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeClaimTemplates": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of volumesClaimTemplates for the master statefulset",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the master pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add initContainers to the master pods.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "worker": {
+            "type": "object",
+            "properties": {
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with your custom configuration for workers",
+                    "default": ""
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Specify the port where the web interface will listen on the worker over HTTP",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Specify the port where the web interface will listen on the worker over HTTPS",
+                            "default": 8480
+                        },
+                        "cluster": {
+                            "type": "string",
+                            "description": "Specify the port where the worker listens to communicate with workers",
+                            "default": ""
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Add deployment host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "extraContainerPorts": {
+                    "type": "array",
+                    "description": "Specify the port where the running jobs inside the workers listens",
+                    "default": [],
+                    "items": {}
+                },
+                "daemonMemoryLimit": {
+                    "type": "string",
+                    "description": "Set the memory limit for the worker daemon",
+                    "default": ""
+                },
+                "memoryLimit": {
+                    "type": "string",
+                    "description": "Set the maximum memory the worker is allowed to use",
+                    "default": ""
+                },
+                "coreLimit": {
+                    "type": "string",
+                    "description": "Se the maximum number of cores that the worker can use",
+                    "default": ""
+                },
+                "dir": {
+                    "type": "string",
+                    "description": "Set a custom working directory for the application",
+                    "default": ""
+                },
+                "javaOptions": {
+                    "type": "string",
+                    "description": "Set options for the JVM in the form `-Dx=y`",
+                    "default": ""
+                },
+                "configOptions": {
+                    "type": "string",
+                    "description": "Set extra options to configure the worker in the form `-Dx=y`",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "An array to add extra env vars",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for worker nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for worker nodes",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of spark workers (will be the minimum number when autoscaling is enabled)",
+                    "default": 2
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 1001
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        },
+                        "runAsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the container",
+                            "default": 0
+                        },
+                        "seLinuxOptions": {
+                            "type": "object",
+                            "description": "SELinux options for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled worker containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set worker containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set worker containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set worker containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for pods in StatefulSet",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for pods in StatefulSet",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Spark worker pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Spark worker pod anti-affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Spark worker node affinity preset type. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Spark worker node label key to match Ignored if `worker.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Spark worker node label values to match. Ignored if `worker.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Spark worker affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Spark worker node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Spark worker tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Worker statefulset strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod Management Policy Type",
+                    "default": "OrderedReady"
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "worker pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for worker pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the worker container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the master container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeClaimTemplates": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of volumesClaimTemplates for the worker statefulset",
+                    "default": [],
+                    "items": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 180
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the worker pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add initContainers to the worker pods.",
+                    "default": [],
+                    "items": {}
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable replica autoscaling depending on CPU",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of worker replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "number",
+                            "description": "Maximum number of worker replicas",
+                            "default": 5
+                        },
+                        "targetCPU": {
+                            "type": "number",
+                            "description": "Target CPU utilization percentage",
+                            "default": 50
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "security": {
+            "type": "object",
+            "properties": {
+                "passwordsSecretName": {
+                    "type": "string",
+                    "description": "Name of the secret that contains all the passwords",
+                    "default": ""
+                },
+                "rpc": {
+                    "type": "object",
+                    "properties": {
+                        "authenticationEnabled": {
+                            "type": "boolean",
+                            "description": "Enable the RPC authentication",
+                            "default": false
+                        },
+                        "encryptionEnabled": {
+                            "type": "boolean",
+                            "description": "Enable the encryption for RPC",
+                            "default": false
+                        }
+                    }
+                },
+                "storageEncryptionEnabled": {
+                    "type": "boolean",
+                    "description": "Enables local storage encryption",
+                    "default": false
+                },
+                "certificatesSecretName": {
+                    "type": "string",
+                    "description": "Name of the secret that contains the certificates.",
+                    "default": ""
+                },
+                "ssl": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the SSL configuration",
+                            "default": false
+                        },
+                        "needClientAuth": {
+                            "type": "boolean",
+                            "description": "Enable the client authentication",
+                            "default": false
+                        },
+                        "protocol": {
+                            "type": "string",
+                            "description": "Set the SSL protocol",
+                            "default": "TLSv1.2"
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates",
+                            "default": ""
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                            "default": false
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Set the password of the JKS Keystore",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Truststore password.",
+                            "default": ""
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the container",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Spark client port for HTTP",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Spark client port for HTTPS",
+                            "default": 443
+                        },
+                        "cluster": {
+                            "type": "number",
+                            "description": "Spark cluster port",
+                            "default": 7077
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes web node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes web node port for HTTPS",
+                            "default": ""
+                        },
+                        "cluster": {
+                            "type": "string",
+                            "description": "Kubernetes cluster node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Spark service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Load balancer IP if spark service type is `LoadBalancer`",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Spark service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Spark service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Spark service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in Spark service (normally used with the `sidecars` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "spark.local"
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The Path to Spark. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Spark pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Spark Service Account",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount API credentials for a service account.",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "masterAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/path": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "/metrics/"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.master.containerPorts.http }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "workerAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/path": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "/metrics/"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.worker.containerPorts.http }}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If the operator is installed in your cluster, set to true to create a PodMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "extraMetricsEndpoints": {
+                            "type": "array",
+                            "description": "Add metrics endpoints for monitoring the jobs running in the worker nodes",
+                            "default": [],
+                            "items": {}
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Specify the namespace in which the podMonitor resource will be created",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PodMonitors will be discovered by Prometheus",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set this to true to create prometheusRules for Prometheus",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace where the prometheusRules resource should be created",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRules will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom Prometheus [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/spring-cloud-dataflow/values.schema.json
+++ b/bitnami/spring-cloud-dataflow/values.schema.json
@@ -1,344 +1,2224 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "server": {
-      "type": "object",
-      "form": true,
-      "title": "Spring Cloud Dataflow Server configuration",
-      "properties": {
-        "configuration": {
-          "type": "object",
-          "title": "Spring Cloud Dataflow Server configuration",
-          "properties": {
-            "streamingEnabled": {
-              "type": "boolean",
-              "title": "Enable deploying streaming data",
-              "form": true,
-              "description": "Enable support for Stream processing using using RabbitMQ or Kafka"
-            },
-            "batchEnabled": {
-              "type": "boolean",
-              "title": "Enable deploying Batch data",
-              "form": true,
-              "description": "Enable support for Task and Schedules processing"
-            }
-          }
-        },
-        "replicaCount": {
-          "type": "integer",
-          "form": true,
-          "title": "Dataflow server replicas"
-        },
-        "resources": {
-          "type": "object",
-          "title": "Required Resources",
-          "description": "Configure resource requests",
-          "form": true,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "properties": {
-                "memory": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "Memory Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2048,
-                  "sliderUnit": "Mi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
                 },
-                "cpu": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "CPU Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2000,
-                  "sliderUnit": "m"
-                }
-              }
-            }
-          }
-        },
-        "ingress": {
-          "type": "object",
-          "form": true,
-          "title": "Ingress configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "form": true,
-              "title": "Use a custom hostname",
-              "description": "Enable the ingress resource that allows you to access the Dataflow Server dashboard."
-            },
-            "hostname": {
-              "type": "string",
-              "form": true,
-              "title": "Hostname",
-              "hidden": {
-                "condition": false,
-                "value": "server/ingress/enabled"
-              }
-            },
-            "tls": {
-              "type": "boolean",
-              "form": true,
-              "title": "Create a TLS secret",
-              "hidden": {
-                "condition": false,
-                "value": "server/ingress/enabled"
-              }
-            }
-          }
-        },
-        "service": {
-          "type": "object",
-          "form": true,
-          "title": "Service Configuration",
-          "properties": {
-            "type": {
-              "type": "string",
-              "form": true,
-              "title": "Service Type",
-              "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\"" 
-            }
-          }
-        }
-      }
-    },
-    "skipper": {
-      "type": "object",
-      "form": true,
-      "title": "Spring Cloud Skipper Server configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Skipper",
-          "description": "Enable Spring Cloud Skipper component"
-        },
-        "replicaCount": {
-          "type": "integer",
-          "form": true,
-          "title": "Skipper server replicas",
-          "hidden": {
-            "condition": false,
-            "value": "skipper/enabled"
-          }
-        },
-        "resources": {
-          "type": "object",
-          "title": "Required Resources",
-          "description": "Configure resource requests",
-          "form": true,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "properties": {
-                "memory": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "Memory Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2048,
-                  "sliderUnit": "Mi"
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
                 },
-                "cpu": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "CPU Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2000,
-                  "sliderUnit": "m"
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          },
-          "hidden": {
-            "condition": false,
-            "value": "skipper/enabled"
-          }
-        }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "title": "ServiceAccount configuration",
-      "form": true,
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create a ServiceAcccount",
-          "description": "Specify whether a ServiceAcccount for Spring Cloud pods should be created"
         },
-        "name": {
-          "type": "string",
-          "form": true,
-          "title": "ServiceAcccount name",
-          "description": "ServiceAcccount name to use. Auto-generated if not specified",
-          "hidden": {
-            "condition": false,
-            "value": "serviceAccount/create"
-          }
-        }
-      }
-    },
-    "rbac": {
-      "type": "object",
-      "title": "RBAC rules configuration",
-      "form": true,
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create RBAC rules",
-          "description": "Specify whether RBAC resources should be created and used"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override scdf.fullname template (will maintain the release name).",
+            "default": ""
         },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "condition": false,
-                "value": "metrics/enabled"
-              }
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override scdf.fullname template.",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image repository",
+                            "default": "bitnami/spring-cloud-dataflow"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image tag (immutable tags are recommended)",
+                            "default": "2.10.3-debian-11-r86"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "composedTaskRunner": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image repository",
+                                    "default": "bitnami/spring-cloud-dataflow-composed-task-runner"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image tag (immutable tags are recommended)",
+                                    "default": "2.10.3-debian-11-r94"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "object",
+                    "properties": {
+                        "streamingEnabled": {
+                            "type": "boolean",
+                            "description": "Enables or disables streaming data processing",
+                            "default": true
+                        },
+                        "batchEnabled": {
+                            "type": "boolean",
+                            "description": "Enables or disables batch data (tasks and schedules) processing",
+                            "default": true
+                        },
+                        "accountName": {
+                            "type": "string",
+                            "description": "The name of the account to configure for the Kubernetes platform",
+                            "default": "default"
+                        },
+                        "trustK8sCerts": {
+                            "type": "boolean",
+                            "description": "Trust K8s certificates when querying the Kubernetes API",
+                            "default": false
+                        },
+                        "containerRegistries": {
+                            "type": "object",
+                            "description": "Container registries configuration",
+                            "default": {}
+                        },
+                        "grafanaInfo": {
+                            "type": "string",
+                            "description": "Endpoint to the grafana instance (Deprecated: use the metricsDashboard instead)",
+                            "default": ""
+                        },
+                        "metricsDashboard": {
+                            "type": "string",
+                            "description": "Endpoint to the metricsDashboard instance",
+                            "default": ""
+                        },
+                        "defaultSpringApplicationJSON": {
+                            "type": "boolean",
+                            "description": "Injects default values for environment variable SPRING_APPLICATION_JSON",
+                            "default": true
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "ConfigMap with Spring Cloud Dataflow Server Configuration",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Dataflow server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on Dataflow server container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Dataflow server replicas to deploy",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Dataflow server pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Dataflow server pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Dataflow server port",
+                    "default": 8080
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Dataflow server node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Dataflow server node label key to match Ignored if `server.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Dataflow server node label values to match. Ignored if `server.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Dataflow server affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Dataflow server node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Dataflow server tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Dataflow server pods",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Deployment strategy type for Dataflow server pods.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Dataflow Server pods",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Dataflow Server pods' priority",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dataflow Server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the volumes of the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dataflow Server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Dataflow Server container's Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Dataflow server container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Dataflow server container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 8080
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Dataflow server service cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required. Evaluated as a template.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The Path to WordPress. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                            "default": "/"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "dataflow.local"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                            "default": false
+                        },
+                        "certManager": {
+                            "type": "boolean",
+                            "description": "Add the corresponding annotations for cert-manager integration",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the Dataflow Server pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the Dataflow Server pods",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Dataflow server",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Dataflow server replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Dataflow server replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra Volumes to be set on the Dataflow Server Pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra VolumeMounts to be set on the Dataflow Container",
+                    "default": [],
+                    "items": {}
+                },
+                "jdwp": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set to true to enable Java debugger",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Specify port for remote debugging",
+                            "default": 5005
+                        }
+                    }
+                },
+                "proxy": {
+                    "type": "object",
+                    "description": "Add proxy configuration for SCDF server",
+                    "default": {}
+                },
+                "applicationProperties": {
+                    "type": "object",
+                    "description": "Specify common application properties added by SCDF server to streams and/or tasks",
+                    "default": {}
+                }
             }
-          }
-        }
-      }
-    },
-    "mariadb": {
-      "type": "object",
-      "title": "MariaDB Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MariaDB database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a MariaDB server to satisfy the Spring Cloud database requirements. To use an external database switch this off and configure the external database details"
-        }
-      }
-    },
-    "flyway": {
-      "type": "object",
-      "title": "Flyway Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Run or skip Database creation scripts on startup",
-          "form": true,
-          "description": "Whether to run or skip running Database creation scripts on startup. This feature can be used in scenario of Database schema and tables already present, when using Mariadb or external database"
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MariaDB is disabled. Use this section to specify the external database details",
-      "form": true,
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host",
-          "hidden": "mariadb/enabled"
-        },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port",
-          "hidden": "mariadb/enabled"
-        },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password",
-          "hidden": "mariadb/enabled"
-        },
-        "dataflow": {
-          "type": "object",
-          "properties": {
-            "user": {
-              "type": "string",
-              "form": true,
-              "title": "Database Username for Dataflow server",
-              "hidden": "mariadb/enabled"
-            },
-            "database": {
-              "type": "string",
-              "form": true,
-              "title": "Database Name for Dataflow server",
-              "hidden": "mariadb/enabled"
-            }
-          }
         },
         "skipper": {
-          "type": "object",
-          "properties": {
-            "user": {
-              "type": "string",
-              "form": true,
-              "title": "Database Username for Skipper server",
-              "hidden": "mariadb/enabled"
-            },
-            "database": {
-              "type": "string",
-              "form": true,
-              "title": "Database Name for Skipper server",
-              "hidden": "mariadb/enabled"
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Spring Cloud Skipper component",
+                    "default": true
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image repository",
+                            "default": "bitnami/spring-cloud-skipper"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image tag (immutable tags are recommended)",
+                            "default": "2.9.3-debian-11-r98"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "object",
+                    "properties": {
+                        "accountName": {
+                            "type": "string",
+                            "description": "The name of the account to configure for the Kubernetes platform",
+                            "default": "default"
+                        },
+                        "trustK8sCerts": {
+                            "type": "boolean",
+                            "description": "Trust K8s certificates when querying the Kubernetes API",
+                            "default": false
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Skipper server configuration",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Skipper container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on Skipper server container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra environment variables",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Skipper server replicas to deploy",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Skipper pod affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Skipper pod anti-affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Skipper node affinity preset type. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Skipper node label key to match Ignored if `skipper.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Skipper node label values to match. Ignored if `skipper.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Skipper affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Skipper node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Skipper tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Skipper server pods",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Deployment strategy type for Skipper server pods.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Skipper pods",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Controller priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Skipper pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the volumes of the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Datafkiw Skipper containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Dataflow Skipper container's Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Skipper server container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Skipper server container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Service HTTP node port",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Skipper server service cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Skipper server service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the Dataflow Skipper pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the Skipper pods",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Skipper server",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Skipper server replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Skipper server replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra Volumes to be set on the Skipper Pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra VolumeMounts to be set on the Skipper Container",
+                    "default": [],
+                    "items": {}
+                },
+                "jdwp": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Java Debug Wire Protocol (JDWP)",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "JDWP TCP port for remote debugging",
+                            "default": 5005
+                        }
+                    }
+                }
             }
-          }
+        },
+        "externalSkipper": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a external Skipper Server",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Skipper Server port number",
+                    "default": 7577
+                }
+            }
+        },
+        "deployer": {
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "500m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "1024Mi"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Streaming applications resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 120
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 90
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "string",
+                    "description": "The node selectors to apply to the streaming applications deployments in \"key:value\" format",
+                    "default": ""
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Streaming applications tolerations",
+                    "default": [],
+                    "items": {}
+                },
+                "volumeMounts": {
+                    "type": "array",
+                    "description": "Streaming applications extra volume mounts",
+                    "default": [],
+                    "items": {}
+                },
+                "volumes": {
+                    "type": "array",
+                    "description": "Streaming applications extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "environmentVariables": {
+                    "type": "array",
+                    "description": "Streaming applications environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled pods' Security Context of the deployed pods batch or stream pods",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Dataflow Streams container's Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Streaming applications imagePullSecrets",
+                    "default": [],
+                    "items": {}
+                },
+                "secretRefs": {
+                    "type": "array",
+                    "description": "Streaming applications secretRefs",
+                    "default": [],
+                    "items": {}
+                },
+                "entryPointStyle": {
+                    "type": "string",
+                    "description": "An entry point style affects how application properties are passed to the container to be deployed. Allowed values: exec (default), shell, boot",
+                    "default": "exec"
+                },
+                "imagePullPolicy": {
+                    "type": "string",
+                    "description": "An image pull policy defines when a Docker image should be pulled to the local registry. Allowed values: IfNotPresent (default), Always, Never",
+                    "default": "IfNotPresent"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created serviceAccount. If not set and create is true, a name is generated using the scdf.fullname template",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image repository",
+                            "default": "bitnami/prometheus-rsocket-proxy"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image tag (immutable tags are recommended)",
+                            "default": "1.5.2-debian-11-r40"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Prometheus Rsocket Proxy container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Prometheus Rsocket Proxy container",
+                            "default": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Prometheus Rsocket Proxy replicas to deploy",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Rsocket Proxy pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Rsocket Proxy pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy node label key to match Ignored if `metrics.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Prometheus Rsocket Proxy node label values to match. Ignored if `metrics.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Prometheus Rsocket Proxy affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Prometheus Rsocket Proxy node labels for pod assignment",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Prometheus Proxy pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Prometheus Rsocket Proxy tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Prometheus Rsocket Proxy pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Prometheus Proxy pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Prometheus Proxy pods' Security Context",
+                            "default": false
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Prometheus Proxy pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Prometheus Proxy containers' Security Context",
+                            "default": false
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Prometheus Proxy containers' Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Prometheus Proxy container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Prometheus Proxy nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Prometheus Proxy nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Prometheus Proxy nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Prometheus Proxy pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Prometheus Proxy container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Prometheus Proxy HTTP container port",
+                            "default": 8080
+                        },
+                        "rsocket": {
+                            "type": "number",
+                            "description": "Prometheus Proxy Rsocket container port",
+                            "default": 7001
+                        }
+                    }
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Prometheus Proxy pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Prometheus Proxy pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Proxy deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Prometheus Rsocket Proxy pods' priority.",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Proxy service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Prometheus Rsocket Proxy HTTP port",
+                                    "default": 8080
+                                },
+                                "rsocket": {
+                                    "type": "number",
+                                    "description": "Prometheus Rsocket Proxy Rsocket port",
+                                    "default": 7001
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "rsocket": {
+                                    "type": "string",
+                                    "description": "Node port for Rsocket",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Prometheys Proxy service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Prometheys Proxy service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Prometheys Proxy service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Prometheys Proxy service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.ports.http }}"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics/proxy"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which ServiceMonitor is created if different from release",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Prometheus Rsocket Proxy",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Prometheus Rsocket Proxy replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Prometheus Rsocket Proxy replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "waitForBackends": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image name",
+                            "default": "bitnami/kubectl"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image tag",
+                            "default": "1.25.12-debian-11-r30"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container wait-for-backend resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container wait-for-backend resource requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable MariaDB chart installation",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MariaDB image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MariaDB image repository",
+                            "default": "bitnami/mariadb"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "MariaDB image tag (immutable tags are recommended)",
+                            "default": "10.11.5-debian-11-r4"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Username of new user to create",
+                            "default": "dataflow"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the new user",
+                            "default": "change-me"
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "dataflow"
+                        },
+                        "forcePassword": {
+                            "type": "boolean",
+                            "description": "Force users to specify required passwords in the database",
+                            "default": false
+                        },
+                        "usePasswordFiles": {
+                            "type": "boolean",
+                            "description": "Mount credentials as a file instead of using an environment variable",
+                            "default": false
+                        }
+                    }
+                },
+                "initdbScripts": {
+                    "type": "object",
+                    "properties": {
+                        "create_databases": {
+                            "type": "object",
+                            "properties": {
+                                "sql": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "CREATE OR REPLACE USER 'skipper'@'%' identified by 'change-me';\nCREATE DATABASE IF NOT EXISTS `skipper`;\nGRANT ALL ON skipper.* to 'skipper'@'%';\nFLUSH PRIVILEGES;\n"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "flyway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable flyway running Dataflow and Skipper Database creation scripts on startup",
+                    "default": true
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external database",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External database port number",
+                    "default": 3306
+                },
+                "driver": {
+                    "type": "string",
+                    "description": "The fully qualified name of the JDBC Driver class",
+                    "default": ""
+                },
+                "scheme": {
+                    "type": "string",
+                    "description": "The scheme is a vendor-specific or shared protocol string that follows the \"jdbc:\" of the URL",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "existingPasswordSecret": {
+                    "type": "string",
+                    "description": "Existing secret with database password",
+                    "default": ""
+                },
+                "existingPasswordKey": {
+                    "type": "string",
+                    "description": "Key of the existing secret with database password, defaults to `datasource-password`",
+                    "default": ""
+                },
+                "dataflow": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters.",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name of the existing database to be used by Dataflow server",
+                            "default": "dataflow"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Existing username in the external db to be used by Dataflow server",
+                            "default": "dataflow"
+                        }
+                    }
+                },
+                "skipper": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "JDBC URL for skipper. Overrides external scheme, host, port, database, and jdbc parameters.",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name of the existing database to be used by Skipper server",
+                            "default": "skipper"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Existing username in the external db to be used by Skipper server",
+                            "default": "skipper"
+                        }
+                    }
+                },
+                "hibernateDialect": {
+                    "type": "string",
+                    "description": "Hibernate Dialect used by Dataflow/Skipper servers",
+                    "default": ""
+                }
+            }
+        },
+        "rabbitmq": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable RabbitMQ chart installation",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "RabbitMQ username",
+                            "default": "user"
+                        }
+                    }
+                }
+            }
+        },
+        "externalRabbitmq": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable external RabbitMQ",
+                    "default": false
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external RabbitMQ",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External RabbitMQ port number",
+                    "default": 5672
+                },
+                "username": {
+                    "type": "string",
+                    "description": "External RabbitMQ username",
+                    "default": "guest"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External RabbitMQ password. It will be saved in a kubernetes secret",
+                    "default": "guest"
+                },
+                "vhost": {
+                    "type": "string",
+                    "description": "External RabbitMQ virtual host. It will be saved in a kubernetes secret",
+                    "default": ""
+                },
+                "existingPasswordSecret": {
+                    "type": "string",
+                    "description": "Existing secret with RabbitMQ password. It will be saved in a kubernetes secret",
+                    "default": ""
+                }
+            }
+        },
+        "kafka": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Kafka chart installation",
+                    "default": false
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Kafka controller+brokers nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "extraConfig": {
+                    "type": "string",
+                    "description": "Kafka extra configuration to be appended to dynamic settings",
+                    "default": "offsets.topic.replication.factor=1"
+                }
+            }
+        },
+        "externalKafka": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable external Kafka",
+                    "default": false
+                },
+                "brokers": {
+                    "type": "string",
+                    "description": "External Kafka brokers",
+                    "default": "localhost:9092"
+                },
+                "zkNodes": {
+                    "type": "string",
+                    "description": "External Zookeeper nodes",
+                    "default": "localhost:2181"
+                }
+            }
         }
-      }
-    },
-    "rabbitmq": {
-      "type": "object",
-      "title": "RabbitMQ Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new RabbitMQ server hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a RabbitMQ server to satisfy the Spring Cloud Skipper messaging middleware requirements."
-        }
-      }
-    },
-    "kafka": {
-      "type": "object",
-      "title": "Kafka Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new Kafka server hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a Kafka server to satisfy the Spring Cloud Skipper messaging middleware requirements."
-        }
-      }
     }
-  }
 }

--- a/bitnami/suitecrm/values.schema.json
+++ b/bitnami/suitecrm/values.schema.json
@@ -1,0 +1,1279 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override suitecrm.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override suitecrm.fullname template",
+            "default": ""
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array with extra yaml to deploy with the chart. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all SuiteCRM resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all SuiteCRM resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "SuiteCRM image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "SuiteCRM image repository",
+                    "default": "bitnami/suitecrm"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "SuiteCRM image tag (immutable tags are recommended)",
+                    "default": "7.13.4-debian-11-r15"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "SuiteCRM image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "SuiteCRM image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas (requires ReadWriteMany PVC support)",
+            "default": 1
+        },
+        "suitecrmSkipInstall": {
+            "type": "boolean",
+            "description": "Skip SuiteCRM installation wizard. Useful for migrations and restoring from SQL dump",
+            "default": false
+        },
+        "suitecrmValidateUserIP": {
+            "type": "boolean",
+            "description": "Whether to validate the user IP address or not",
+            "default": false
+        },
+        "suitecrmHost": {
+            "type": "string",
+            "description": "SuiteCRM host to create application URLs",
+            "default": ""
+        },
+        "suitecrmUsername": {
+            "type": "string",
+            "description": "User of the application",
+            "default": "user"
+        },
+        "suitecrmPassword": {
+            "type": "string",
+            "description": "Application password",
+            "default": ""
+        },
+        "suitecrmEmail": {
+            "type": "string",
+            "description": "Admin email",
+            "default": "user@example.com"
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow DB blank passwords",
+            "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "An array to add extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra environment variables",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Extra volumes to add to the deployment. Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Extra volume mounts to add to the container. Requires setting `extraVolumeMounts",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Extra init containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Extra sidecar containers to add to the deployment",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "SuiteCRM pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of a secret with the application password",
+            "default": ""
+        },
+        "suitecrmSmtpHost": {
+            "type": "string",
+            "description": "SMTP host",
+            "default": ""
+        },
+        "suitecrmSmtpPort": {
+            "type": "string",
+            "description": "SMTP port",
+            "default": ""
+        },
+        "suitecrmSmtpUser": {
+            "type": "string",
+            "description": "SMTP user",
+            "default": ""
+        },
+        "suitecrmSmtpPassword": {
+            "type": "string",
+            "description": "SMTP password",
+            "default": ""
+        },
+        "suitecrmSmtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol [`ssl`, `tls`]",
+            "default": ""
+        },
+        "suitecrmNotifyAddress": {
+            "type": "string",
+            "description": "SuiteCRM notify address",
+            "default": ""
+        },
+        "suitecrmNotifyName": {
+            "type": "string",
+            "description": "SuiteCRM notify name",
+            "default": ""
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "",
+                    "default": 8443
+                }
+            }
+        },
+        "sessionAffinity": {
+            "type": "string",
+            "description": "Control where client requests go, to the same pod or round-robin",
+            "default": "None"
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable SuiteCRM pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "SuiteCRM pods' group ID",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable SuiteCRM containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "SuiteCRM containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "SuiteCRM containers' Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for livenessProbe",
+                    "default": "/index.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 600
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for readinessProbe",
+                    "default": "/index.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Request path for startupProbe",
+                    "default": "/index.php"
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 0
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 60
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "lifecycleHooks for the container to automate configuration before or after startup",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod extra labels",
+            "default": {}
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to deploy a mariadb server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "bitnami_suitecrm"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Database user to create",
+                            "default": "bn_suitecrm"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the database",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable database persistence using PVC",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "MariaDB data Persistent Volume Storage Class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Database Persistent Volume Access Modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Database Persistent Volume Size",
+                                    "default": "8Gi"
+                                },
+                                "hostPath": {
+                                    "type": "string",
+                                    "description": "Set path in case you want to use local host path volumes (not recommended in production)",
+                                    "default": ""
+                                },
+                                "existingClaim": {
+                                    "type": "string",
+                                    "description": "Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the existing database",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Port of the existing database",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Existing username in the external database",
+                    "default": "bn_suitecrm"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name of the existing database",
+                    "default": "bitnami_suitecrm"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the DB password",
+                    "default": ""
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using PVC",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for SuiteCRM volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Mode for SuiteCRM volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for SuiteCRM volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name for SuiteCRM volume",
+                    "default": ""
+                },
+                "hostPath": {
+                    "type": "string",
+                    "description": "Host mount path for SuiteCRM volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r25"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 8080
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "Service HTTPS port",
+                            "default": 8443
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Static clusterIP or None for headless services",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "loadBalancerIP for the SuiteCRM Service (optional, cloud specific)",
+                    "default": ""
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes HTTP node port",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Kubernetes HTTPS node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for SuiteCRM service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "suitecrm.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a side-car prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r2"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "9117"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Metrics exporter resource requests and limits",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type for Prometheus metrics",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Prometheus metrics service port",
+                            "default": 9117
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "SuiteCRM service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "SuiteCRM service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "SuiteCRM service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "SuiteCRM service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "customCertificate": {
+                    "type": "object",
+                    "properties": {
+                        "certificateSecret": {
+                            "type": "string",
+                            "description": "Secret containing the certificate and key to add",
+                            "default": ""
+                        },
+                        "chainSecret": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the secret containing the certificate chain",
+                                    "default": ""
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Key of the certificate chain file inside the secret",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "certificateLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate",
+                            "default": "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+                        },
+                        "keyLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the private key",
+                            "default": "/etc/ssl/private/ssl-cert-snakeoil.key"
+                        },
+                        "chainLocation": {
+                            "type": "string",
+                            "description": "Location in the container to store the certificate chain",
+                            "default": "/etc/ssl/certs/mychain.pem"
+                        }
+                    }
+                },
+                "customCAs": {
+                    "type": "array",
+                    "description": "Defines a list of secrets to import into the container trust store",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Container sidecar extra environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap containing extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret containing extra environment variables (in case of sensitive data)",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Container sidecar registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Container sidecar image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Container sidecar image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r25"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Container sidecar image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Container sidecar image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        },
+                        "namespaceSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "type": "object",
+                            "description": "Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by SuiteCRM's pods.",
+                            "default": false
+                        },
+                        "customBackendSelector": {
+                            "type": "object",
+                            "description": "Backend selector labels. These labels will be used to identify the backend pods.",
+                            "default": {}
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes SuiteCRM only accessible from a particular origin",
+                                    "default": false
+                                },
+                                "namespaceSelector": {
+                                    "type": "object",
+                                    "description": "Namespace selector label that is allowed to access SuiteCRM. This label will be used to identified the allowed namespace(s).",
+                                    "default": {}
+                                },
+                                "podSelector": {
+                                    "type": "object",
+                                    "description": "Pods selector label that is allowed to access SuiteCRM. This label will be used to identified the allowed pod(s).",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy ingress rule",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        },
+                        "customRules": {
+                            "type": "object",
+                            "description": "Custom network policy rule",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/supabase/values.schema.json
+++ b/bitnami/supabase/values.schema.json
@@ -1,0 +1,3846 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "jwt": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "The name of the existing secret containing the JWT secret",
+                            "default": ""
+                        },
+                        "existingSecretKey": {
+                            "type": "string",
+                            "description": "The key in the existing secret containing the JWT secret",
+                            "default": "secret"
+                        },
+                        "existingSecretAnonKey": {
+                            "type": "string",
+                            "description": "The key in the existing secret containing the JWT anon key",
+                            "default": "anon-key"
+                        },
+                        "existingSecretServiceKey": {
+                            "type": "string",
+                            "description": "The key in the existing secret containing the JWT service key",
+                            "default": "service-key"
+                        }
+                    }
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "jwt": {
+            "type": "object",
+            "properties": {
+                "secret": {
+                    "type": "string",
+                    "description": "The secret string used to sign JWT tokens",
+                    "default": ""
+                },
+                "anonKey": {
+                    "type": "string",
+                    "description": "JWT string for annonymous users",
+                    "default": ""
+                },
+                "serviceKey": {
+                    "type": "string",
+                    "description": "JWT string for service users",
+                    "default": ""
+                },
+                "autoGenerate": {
+                    "type": "object",
+                    "properties": {
+                        "forceRun": {
+                            "type": "boolean",
+                            "description": "Force the run of the JWT generation job",
+                            "default": false
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "JWT CLI image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "JWT CLI image repository",
+                                    "default": "bitnami/jwt-cli"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "JWT CLI image tag (immutable tags are recommended)",
+                                    "default": "5.0.3-debian-11-r183"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "JWT CLI image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "JWT CLI image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "JWT CLI image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "kubectlImage": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Kubectl image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Kubectl image repository",
+                                    "default": "bitnami/kubectl"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Kubectl image tag (immutable tags are recommended)",
+                                    "default": "1.26.8-debian-11-r14"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Kubectl image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "Kubectl image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Kubectl image pull secrets",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "backoffLimit": {
+                            "type": "number",
+                            "description": "set backoff limit of the job",
+                            "default": 10
+                        },
+                        "extraVolumes": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumes for the jwt init job",
+                            "default": [],
+                            "items": {}
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled jwt init job containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set jwt init job containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set jwt init job containers' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set jwt init job containers' Security Context runAsNonRoot",
+                                    "default": false
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Set container's privilege escalation",
+                                    "default": false
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set container's Security Context runAsNonRoot",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled jwt init job pods' Security Context",
+                                    "default": true
+                                },
+                                "fsGroup": {
+                                    "type": "number",
+                                    "description": "Set jwt init job pod's Security Context fsGroup",
+                                    "default": 1001
+                                },
+                                "seccompProfile": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Set container's Security Context seccomp profile",
+                                            "default": "RuntimeDefault"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array containing extra env vars to configure the jwt init job",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "ConfigMap containing extra env vars to configure the jwt init job",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Secret containing extra env vars to configure the jwt init job (in case of sensitive data)",
+                            "default": ""
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Array of extra volume mounts to be added to the jwt Container (evaluated as template). Normally used with `extraVolumes`.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "hostAliases": {
+                            "type": "array",
+                            "description": "Add deployment host aliases",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "helm": {
+                                    "type": "object",
+                                    "properties": {
+                                        "sh/hook": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "post-install"
+                                        },
+                                        "sh/hook-delete-policy": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "before-hook-creation,hook-succeeded"
+                                        },
+                                        "sh/hook-weight": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "10"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "podLabels": {
+                            "type": "object",
+                            "description": "Additional pod labels",
+                            "default": {}
+                        },
+                        "podAnnotations": {
+                            "type": "object",
+                            "description": "Additional pod annotations",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "publicURL": {
+            "type": "string",
+            "description": "Supabase API public URL",
+            "default": ""
+        },
+        "dbSSL": {
+            "type": "string",
+            "description": "Supabase API database connection mode for SSL. Applied to all components. Allowed values: verify-ca, verify-full, disable, allow, prefer, require",
+            "default": "disable"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Supabase auth",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supabase auth replicas to deploy",
+                    "default": 1
+                },
+                "defaultConfig": {
+                    "type": "string",
+                    "description": "Supabase auth default configuration",
+                    "default": "GOTRUE_API_HOST: \"0.0.0.0\"\nGOTRUE_API_PORT: {{ .Values.auth.containerPorts.http | quote }}\nGOTRUE_SITE_URL: {{ include \"supabase.studio.publicURL\" . | quote }}\nGOTRUE_URI_ALLOW_LIST: \"*\"\nGOTRUE_DISABLE_SIGNUP: \"false\"\nGOTRUE_DB_DRIVER: \"postgres\"\nGOTRUE_JWT_DEFAULT_GROUP_NAME: \"authenticated\"\nGOTRUE_JWT_ADMIN_ROLES: \"service_role\"\nGOTRUE_JWT_AUD: \"authenticated\"\nGOTRUE_JWT_EXP: \"3600\"\nGOTRUE_EXTERNAL_EMAIL_ENABLED: \"true\"\nGOTRUE_MAILER_AUTOCONFIRM: \"true\"\nGOTRUE_SMTP_ADMIN_EMAIL: \"your-mail@example.com\"\nGOTRUE_SMTP_HOST: \"smtp.example.com\"\nGOTRUE_SMTP_PORT: \"587\"\nGOTRUE_SMTP_SENDER_NAME: \"your-mail@example.com\"\nGOTRUE_EXTERNAL_PHONE_ENABLED: \"false\"\nGOTRUE_SMS_AUTOCONFIRM: \"false\"\nGOTRUE_MAILER_URLPATHS_INVITE: \"{{ include \"supabase.studio.publicURL\" . }}/auth/v1/verify\"\nGOTRUE_MAILER_URLPATHS_CONFIRMATION: \"{{ include \"supabase.studio.publicURL\" . }}/auth/v1/verify\"\nGOTRUE_MAILER_URLPATHS_RECOVERY: \"{{ include \"supabase.studio.publicURL\" . }}/auth/v1/verify\"\nGOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: \"{{ include \"supabase.studio.publicURL\" . }}/auth/v1/verify\"\n"
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Supabase auth extra configuration",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with the default configuration",
+                    "default": ""
+                },
+                "extraConfigExistingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with extra configuration",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Gotrue image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Gotrue image repository",
+                            "default": "bitnami/gotrue"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Gotrue image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r186"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Gotrue image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Gotrue image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Gotrue image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Supabase auth HTTP container port",
+                            "default": 9999
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supabase auth containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supabase auth containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supabase auth containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supabase auth containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supabase auth containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase auth pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supabase auth pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase auth containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supabase auth containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supabase auth containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Supabase auth containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supabase auth pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supabase auth pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supabase auth pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `auth.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `auth.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `auth.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `auth.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `auth.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supabase auth pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supabase auth pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supabase auth pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase auth statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supabase auth pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supabase auth pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supabase auth container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supabase auth nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supabase auth nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supabase auth nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supabase auth pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supabase auth container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supabase auth pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supabase auth pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase auth service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Supabase auth service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Supabase auth service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Supabase auth service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Supabase auth service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Supabase auth service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Supabase auth service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Supabase auth service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where auth requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "meta": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Supabase Postgres Meta",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supabase Postgres Meta replicas to deploy",
+                    "default": 1
+                },
+                "defaultConfig": {
+                    "type": "string",
+                    "description": "Default Supabase Postgres Meta configuration",
+                    "default": "PG_META_DB_USER: {{ include \"supabase.database.user\" . | quote }}\nPG_META_DB_HOST: {{ include \"supabase.database.host\" . | quote }}\nPG_META_DB_PORT: {{ include \"supabase.database.port\" . | quote }}\nPG_META_DB_NAME: {{ include \"supabase.database.name\" . | quote }}\nPG_META_DB_SSL_MODE: {{ .Values.dbSSL | quote }}\nPG_META_PORT: {{ .Values.meta.containerPorts.http | quote }}\n"
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Extra Supabase Postgres Meta configuration",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with the default configuration",
+                    "default": ""
+                },
+                "extraConfigExistingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with extra configuration",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta image repository",
+                            "default": "bitnami/supabase-postgres-meta"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta image tag (immutable tags are recommended)",
+                            "default": "0.69.0-debian-11-r16"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Supabase Postgres Meta image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Supabase Postgres Meta HTTP container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supabase Postgres Meta containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supabase Postgres Meta containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supabase Postgres Meta containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supabase Postgres Meta containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supabase Postgres Meta containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase Postgres Meta pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supabase Postgres Meta pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase Postgres Meta containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supabase Postgres Meta containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supabase Postgres Meta containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Supabase Postgres Meta containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supabase Postgres Meta pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supabase Postgres Meta pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supabase Postgres Meta pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `meta.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `meta.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `meta.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `meta.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `meta.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supabase Postgres Meta pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supabase Postgres Meta pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supabase Postgres Meta pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supabase Postgres Meta pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supabase Postgres Meta pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supabase Postgres Meta container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supabase Postgres Meta nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supabase Postgres Meta nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supabase Postgres Meta nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supabase Postgres Meta pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supabase Postgres Meta container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supabase Postgres Meta pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supabase Postgres Meta pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Supabase Postgres Meta service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Supabase Postgres Meta service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Supabase Postgres Meta service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Supabase Postgres Meta service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Supabase Postgres Meta service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where meta requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "realtime": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Supabase realtime",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supabase realtime replicas to deploy",
+                    "default": 1
+                },
+                "keyBase": {
+                    "type": "string",
+                    "description": "key base for Supabase realtime",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret containing the key base for Supabase realtime",
+                    "default": ""
+                },
+                "existingSecretKey": {
+                    "type": "string",
+                    "description": "Key in the existing secret containing the key base for Supabase realtime",
+                    "default": "key-base"
+                },
+                "defaultConfig": {
+                    "type": "string",
+                    "description": "Default configuration for Supabase realtime",
+                    "default": "DB_HOST: {{ include \"supabase.database.host\" . | quote }}\nDB_PORT: {{ include \"supabase.database.port\" . | quote }}\nDB_NAME: {{ include \"supabase.database.name\" . | quote }}\nDB_SSL: {{ .Values.dbSSL | quote }}\nPORT: {{ .Values.realtime.containerPorts.http | quote }}\nFLY_ALLOC_ID: \"realtime\"\nFLY_APP_NAME: \"realtime\"\nERL_AFLAGS: \"-proto_dist inet_tcp\"\nREPLICATION_MODE: \"RLS\"\nREPLICATION_POLL_INTERVAL: \"100\"\nSECURE_CHANNELS: \"true\"\nSLOT_NAME: \"supabase_realtime_rls\"\nTEMPORARY_SLOT: \"true\"\n"
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Extra configuration for Supabase realtime",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with the default configuration",
+                    "default": ""
+                },
+                "extraConfigExistingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with extra configuration",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Realtime image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Realtime image repository",
+                            "default": "bitnami/supabase-realtime"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Realtime image tag (immutable tags are recommended)",
+                            "default": "2.22.7-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Realtime image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Realtime image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Realtime image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Supabase realtime HTTP container port",
+                            "default": 9999
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supabase realtime containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supabase realtime containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supabase realtime containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supabase realtime containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supabase realtime containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase realtime pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supabase realtime pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase realtime containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supabase realtime containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supabase realtime containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Supabase realtime containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supabase realtime pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supabase realtime pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supabase realtime pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `realtime.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `realtime.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `realtime.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `realtime.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `realtime.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supabase realtime pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supabase realtime pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supabase realtime pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase realtime statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supabase realtime pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supabase realtime pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supabase realtime container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supabase realtime nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supabase realtime nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supabase realtime nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supabase realtime pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supabase realtime container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supabase realtime pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supabase realtime pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase realtime service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Supabase realtime service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Supabase realtime service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Supabase realtime service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Supabase realtime service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Supabase realtime service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Supabase realtime service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Supabase realtime service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where realtime requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "rest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Supabase rest",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supabase rest replicas to deploy",
+                    "default": 1
+                },
+                "defaultConfig": {
+                    "type": "string",
+                    "description": "Default configuration for the Supabase rest service",
+                    "default": "PGRST_DB_SCHEMA: \"public,storage\"\nPGRST_DB_ANON_ROLE: \"anon\"\nPGRST_DB_USE_LEGACY_GUCS: \"false\"\nPGRST_SERVER_PORT: {{ .Values.rest.containerPorts.http | quote }}\n"
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Extra configuration for the Supabase rest service",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with the default configuration",
+                    "default": ""
+                },
+                "extraConfigExistingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with extra configuration",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgREST image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgREST image repository",
+                            "default": "bitnami/postgrest"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgREST image tag (immutable tags are recommended)",
+                            "default": "11.2.0-debian-11-r25"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgREST image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "PostgREST image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "PostgREST image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Supabase rest HTTP container port",
+                            "default": 3000
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supabase rest containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supabase rest containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supabase rest containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supabase rest containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supabase rest containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase rest pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supabase rest pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase rest containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supabase rest containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supabase rest containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Supabase rest containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supabase rest pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supabase rest pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supabase rest pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `rest.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `rest.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `rest.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `rest.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `rest.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supabase rest pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supabase rest pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supabase rest pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase rest statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supabase rest pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supabase rest pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supabase rest container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supabase rest nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supabase rest nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supabase rest nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supabase rest pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supabase rest container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supabase rest pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supabase rest pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase rest service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Supabase rest service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Supabase rest service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Supabase rest service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Supabase rest service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Supabase rest service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Supabase rest service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Supabase rest service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where rest requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "storage": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Supabase storage",
+                    "default": true
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supabase storage replicas to deploy",
+                    "default": 1
+                },
+                "defaultConfig": {
+                    "type": "string",
+                    "description": "Default configuration for Supabase storage",
+                    "default": "POSTGREST_URL: \"http://{{ include \"supabase.rest.fullname\" . }}:{{ .Values.rest.service.ports.http }}\"\nPGOPTIONS: \"-c search_path=storage,public\"\nFILE_SIZE_LIMIT: \"52428800\"\nSTORAGE_BACKEND: \"file\"\nFILE_STORAGE_BACKEND_PATH: {{ .Values.storage.persistence.mountPath | quote }}\nTENANT_ID: \"stub\"\nREGION: \"stub\"\nGLOBAL_S3_BUCKET: \"stub\"\nPORT: {{ .Values.storage.containerPorts.http | quote }}\n"
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Extra configuration for Supabase storage",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with the default configuration",
+                    "default": ""
+                },
+                "extraConfigExistingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with extra configuration",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Storage image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Storage image repository",
+                            "default": "bitnami/supabase-storage"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Storage image tag (immutable tags are recommended)",
+                            "default": "0.41.6-debian-11-r5"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Storage image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Storage image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Storage image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Supabase storage HTTP container port",
+                            "default": 5000
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supabase storage containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supabase storage containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supabase storage containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supabase storage containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supabase storage containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase storage pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supabase storage pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase storage containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supabase storage containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supabase storage containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Supabase storage containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supabase storage pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supabase storage pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supabase storage pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `storage.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `storage.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `storage.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `storage.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `storage.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supabase storage pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supabase storage pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supabase storage pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase storage statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supabase storage pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supabase storage pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supabase storage container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supabase storage nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supabase storage nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supabase storage nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supabase storage pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supabase storage container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supabase storage pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supabase storage pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase storage service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Supabase storage service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Supabase storage service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Supabase storage service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Supabase storage service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Supabase storage service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Supabase storage service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Supabase storage service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where storage requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using Persistent Volume Claims",
+                            "default": true
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Path to mount the volume at.",
+                            "default": "/bitnami/supabase-storage"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Storage class of backing PVC",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Persistent Volume Claim annotations",
+                            "default": {}
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume Access Modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Size of data volume",
+                            "default": "8Gi"
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "The name of an existing PVC to use for persistence",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "studio": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Supabase studio",
+                    "default": true
+                },
+                "publicURL": {
+                    "type": "string",
+                    "description": "Supabase studio public URL",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Supabase studio replicas to deploy",
+                    "default": 1
+                },
+                "defaultConfig": {
+                    "type": "string",
+                    "description": "Supabase studio default configuration",
+                    "default": "SUPABASE_URL: \"http://{{ include \"supabase.kong.fullname\" . }}.{{ include \"common.names.namespace\" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.kong.service.ports.proxyHttp }}\"\nSTUDIO_PG_META_URL: \"http://{{ include \"supabase.kong.fullname\" . }}.{{ include \"common.names.namespace\" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.kong.service.ports.proxyHttp }}/pg\"\nSUPABASE_PUBLIC_URL: {{ include \"supabase.api.publicURL\" . | quote }}\nPORT: {{ .Values.studio.containerPorts.http | quote }}\n"
+                },
+                "extraConfig": {
+                    "type": "object",
+                    "description": "Supabase studio extra configuration",
+                    "default": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with the default configuration",
+                    "default": ""
+                },
+                "extraConfigExistingConfigmap": {
+                    "type": "string",
+                    "description": "The name of an existing ConfigMap with extra configuration",
+                    "default": ""
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Studio image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Studio image repository",
+                            "default": "bitnami/supabase-studio"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Studio image tag (immutable tags are recommended)",
+                            "default": "0.23.8-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Studio image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Studio image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Studio image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Supabase studio HTTP container port",
+                            "default": 3000
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Supabase studio containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Supabase studio containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Supabase studio containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Supabase studio containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Supabase studio containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase studio pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Supabase studio pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Supabase studio containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Supabase studio containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Supabase studio containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Supabase studio containers' Security Context runAsNonRoot",
+                            "default": false
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Supabase studio pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Supabase studio pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Supabase studio pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `studio.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `studio.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `studio.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `studio.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `studio.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Supabase studio pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Supabase studio pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Supabase studio pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase studio statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Supabase studio pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Supabase studio pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Supabase studio container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Supabase studio nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Supabase studio nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Supabase studio nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Supabase studio pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Supabase studio container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Supabase studio pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Supabase studio pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Supabase studio service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Supabase studio service HTTP port",
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Supabase studio service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Supabase studio service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Supabase studio service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Supabase studio service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Supabase studio service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Supabase studio service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where studio requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Supabase",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "supabase-studio.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `studio.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r60"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "psqlImage": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "PostgreSQL client image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "PostgreSQL client image repository",
+                    "default": "bitnami/supabase-postgres"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "PostgreSQL client image digest (overrides image tag)",
+                    "default": ""
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "PostgreSQL client image tag (immutable tags are recommended)",
+                    "default": "15.1.0-debian-11-r148"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "PostgreSQL client image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "PostgreSQL client image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable PostgreSQL client image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional Service Account annotations (evaluated as a template)",
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                }
+            }
+        },
+        "kong": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Kong",
+                    "default": true
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Database to use",
+                    "default": "off"
+                },
+                "initContainers": {
+                    "type": "string",
+                    "description": "Add additional init containers to the Kong pods",
+                    "default": "- name: render-kong-declarative-conf\n  image: '{{ include \"kong.image\" . }}'\n  command:\n    - /bin/bash\n  args:\n    - -ec\n    - |\n      #!/bin/bash\n\n      . /opt/bitnami/scripts/liblog.sh\n\n      # We need to generate it in the tmp folder to ensure that we have write permissions\n      info \"Rendering Supabase declarative config template\"\n      render-template /bitnami/kong/declarative-template/kong.yml.tpl > \"/bitnami/kong/declarative-conf/kong.yml\"\n  volumeMounts:\n    - name: declarative-conf-template\n      mountPath: /bitnami/kong/declarative-template/\n    - name: rendered-declarative-conf\n      mountPath: /bitnami/kong/declarative-conf/\n  env:\n    - name: SUPABASE_ANON_KEY\n      valueFrom:\n        secretKeyRef:\n          name: '{{ include \"supabase.jwt.secretName\" . }}'\n          key: '{{ include \"supabase.jwt.anonSecretKey\" . }}'\n    - name: SUPABASE_SERVICE_KEY\n      valueFrom:\n        secretKeyRef:\n          name: '{{ include \"supabase.jwt.secretName\" . }}'\n          key: '{{ include \"supabase.jwt.serviceSecretKey\" . }}'\n"
+                },
+                "ingressController": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Kong Ingress Controller",
+                            "default": false
+                        }
+                    }
+                },
+                "kong": {
+                    "type": "object",
+                    "properties": {
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "mountPath": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": ""
+                            },
+                            "configMap": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            },
+                            "emptyDir": {
+                                "type": "object",
+                                "description": ""
+                            }
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Ingress rule",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Kong Ingress hostname",
+                            "default": "supabase.local"
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS for Kong Ingress",
+                            "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Kubernetes service LoadBalancer IP",
+                            "default": ""
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "LoadBalancer"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "proxyHttp": {
+                                    "type": "number",
+                                    "description": "Kong service port",
+                                    "default": 80
+                                }
+                            }
+                        }
+                    }
+                },
+                "postgresql": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Switch to enable or disable the PostgreSQL helm chart inside the Kong subchart",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Switch to enable or disable the PostgreSQL helm chart",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of existing secret to use for PostgreSQL credentials",
+                            "default": ""
+                        },
+                        "postgresPassword": {
+                            "type": "string",
+                            "description": "PostgreSQL admin password",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "PostgreSQL architecture (`standalone` or `replication`)",
+                    "default": "standalone"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL image repository",
+                            "default": "bitnami/supabase-postgres"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL image tag (immutable tags are recommended)",
+                            "default": "15.1.0-debian-11-r148"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "PostgreSQL image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Specify if debug values should be set",
+                            "default": false
+                        }
+                    }
+                },
+                "postgresqlSharedPreloadLibraries": {
+                    "type": "string",
+                    "description": "Set the shared_preload_libraries parameter in postgresql.conf",
+                    "default": "pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain"
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Database host",
+                    "default": ""
+                },
+                "port": {
+                    "type": "number",
+                    "description": "Database port number",
+                    "default": 5432
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Non-root username for PostgreSQL",
+                    "default": "supabase_admin"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the non-root username for PostgreSQL",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "PostgreSQL database name",
+                    "default": "postgres"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret resource containing the database credentials",
+                    "default": ""
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "description": "Name of an existing secret key containing the database credentials",
+                    "default": "db-password"
+                }
+            }
+        }
+    }
+}

--- a/bitnami/tensorflow-resnet/values.schema.json
+++ b/bitnami/tensorflow-resnet/values.schema.json
@@ -1,0 +1,618 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "TensorFlow Serving image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "TensorFlow Serving image repository",
+                            "default": "bitnami/tensorflow-serving"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "TensorFlow Serving Image tag (immutable tags are recommended)",
+                            "default": "2.13.0-debian-11-r22"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "TensorFlow Serving image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "TensorFlow Serving image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "client": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "TensorFlow ResNet image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "TensorFlow ResNet image repository",
+                            "default": "bitnami/tensorflow-resnet"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "TensorFlow ResNet image tag (immutable tags are recommended)",
+                            "default": "2.13.0-debian-11-r24"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "TensorFlow ResNet image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "TensorFlow ResNet image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "number",
+                    "description": "Tensorflow server port",
+                    "default": 8500
+                },
+                "restApi": {
+                    "type": "number",
+                    "description": "TensorFlow Serving Rest API Port",
+                    "default": 8501
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas",
+            "default": 1
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Pod labels",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled pod Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set pod Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled container Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set container Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set container Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the container to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables for the Tensorflow Serving container(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env variables for the Tensorflow Serving container(s)",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env variables for the Tensorflow Serving container(s)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the Tensorflow Serving container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Deployment strategy type.",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Pod's priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "description": "The requested resources for the container",
+                    "default": {}
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 15
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom liveness probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readiness probe",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "number",
+                            "description": "TensorFlow Serving server port",
+                            "default": 8500
+                        },
+                        "restApi": {
+                            "type": "number",
+                            "description": "TensorFlow Serving Rest API port",
+                            "default": 8501
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "string",
+                            "description": "Kubernetes server node port",
+                            "default": ""
+                        },
+                        "restApi": {
+                            "type": "string",
+                            "description": "Kubernetes Rest API node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for Service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus exporter to expose Tensorflow server metrics",
+                    "default": false
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "io/scrape": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "true"
+                                },
+                                "io/path": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "/monitoring/prometheus/metrics"
+                                },
+                                "io/port": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "{{ .Values.containerPorts.restApi }}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/thanos/values.schema.json
+++ b/bitnami/thanos/values.schema.json
@@ -1,0 +1,6043 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Thanos image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Thanos image repository",
+                    "default": "bitnami/thanos"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Thanos image tag (immutable tags are recommended)",
+                    "default": "0.32.2-debian-11-r2"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Thanos image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Thanos image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "objstoreConfig": {
+            "type": "string",
+            "description": "The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)",
+            "default": ""
+        },
+        "indexCacheConfig": {
+            "type": "string",
+            "description": "The [index cache configuration](https://thanos.io/tip/components/store.md/)",
+            "default": ""
+        },
+        "bucketCacheConfig": {
+            "type": "string",
+            "description": "The [bucket cache configuration](https://thanos.io/tip/components/store.md/)",
+            "default": ""
+        },
+        "existingObjstoreSecret": {
+            "type": "string",
+            "description": "Secret with Objstore Configuration",
+            "default": ""
+        },
+        "existingObjstoreSecretItems": {
+            "type": "array",
+            "description": "Optional item list for specifying a custom Secret key. If so, path should be objstore.yml",
+            "default": [],
+            "items": {}
+        },
+        "httpConfig": {
+            "type": "string",
+            "description": "The [https and basic auth configuration](https://thanos.io/tip/operating/https.md/)",
+            "default": ""
+        },
+        "existingHttpConfigSecret": {
+            "type": "string",
+            "description": "Secret containing the HTTPS and Basic auth configuration",
+            "default": ""
+        },
+        "https": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable HTTPS. Requires a secret containing the certificate and key.",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Create self-signed TLS certificates.",
+                    "default": false
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Existing secret containing your own server key and certificate",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "",
+                    "default": "tls.crt"
+                },
+                "keyFilename": {
+                    "type": "string",
+                    "description": "",
+                    "default": "tls.key"
+                },
+                "caFilename": {
+                    "type": "string",
+                    "description": "",
+                    "default": "ca.crt"
+                },
+                "key": {
+                    "type": "string",
+                    "description": "TLS Key for Thanos HTTPS - ignored if existingSecret is provided",
+                    "default": ""
+                },
+                "cert": {
+                    "type": "string",
+                    "description": "TLS Certificate for Thanos HTTPS - ignored if existingSecret is provided",
+                    "default": ""
+                },
+                "ca": {
+                    "type": "string",
+                    "description": "(Optional, used for client) CA Certificate for Thanos HTTPS - ignored if existingSecret is provided",
+                    "default": ""
+                },
+                "clientAuthType": {
+                    "type": "string",
+                    "description": "Server policy for client authentication using certificates. Maps to ClientAuth Policies.",
+                    "default": ""
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "basicAuthUsers": {
+                    "type": "object",
+                    "description": "Object containing <user>:<passwords> key-value pairs for each user that will have access via basic authentication",
+                    "default": {}
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a ServiceAccount should be created",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "query": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable Thanos Query component",
+                    "default": true
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Query log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Query log format",
+                    "default": "logfmt"
+                },
+                "replicaLabel": {
+                    "type": "array",
+                    "description": "Replica indicator(s) along which data is de-duplicated",
+                    "default": [
+                        "replica"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "dnsDiscovery": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable store APIs discovery via DNS",
+                            "default": true
+                        },
+                        "sidecarsService": {
+                            "type": "string",
+                            "description": "Sidecars service name to discover them using DNS discovery",
+                            "default": ""
+                        },
+                        "sidecarsNamespace": {
+                            "type": "string",
+                            "description": "Sidecars namespace to discover them using DNS discovery",
+                            "default": ""
+                        }
+                    }
+                },
+                "stores": {
+                    "type": "array",
+                    "description": "Statically configure store APIs to connect with Thanos Query",
+                    "default": [],
+                    "items": {}
+                },
+                "sdConfig": {
+                    "type": "string",
+                    "description": "Query Service Discovery Configuration",
+                    "default": ""
+                },
+                "existingSDConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Ruler configuration",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Query container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Query nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Query nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Query",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Query replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Query replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Query pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Query pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Query containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Query containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Query containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Query containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Query containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Query container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Query container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Query containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Query containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Query containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Query pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Query pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Query",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the query container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Query pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Query pod anti-affinity preset. Ignored if `query.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "podAntiAffinityPresetTopologyKey": {
+                    "type": "string",
+                    "description": "Thanos Query pod anti-affinity topologyKey. Ignored if `query.affinity` is set.",
+                    "default": ""
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Query node affinity preset type. Ignored if `query.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Query node label key to match Ignored if `query.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Query node label values to match. Ignored if `query.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Query affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Query node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Query tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Query pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Query pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Query container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Query priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Query pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Query pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "grpc": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enable TLS encryption in the GRPC server",
+                                            "default": false
+                                        },
+                                        "autoGenerated": {
+                                            "type": "boolean",
+                                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                                            "default": false
+                                        },
+                                        "cert": {
+                                            "type": "string",
+                                            "description": "TLS Certificate for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "TLS Key for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "ca": {
+                                            "type": "string",
+                                            "description": "TLS CA to verify clients against - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "existingSecret": {
+                                            "type": "object",
+                                            "description": "Existing secret containing your own TLS certificates",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "client": {
+                            "type": "object",
+                            "properties": {
+                                "serverName": {
+                                    "type": "string",
+                                    "description": "Server name to verify the hostname on the returned GRPC certificates",
+                                    "default": ""
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enable TLS encryption in the GRPC server",
+                                            "default": false
+                                        },
+                                        "autoGenerated": {
+                                            "type": "boolean",
+                                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                                            "default": false
+                                        },
+                                        "cert": {
+                                            "type": "string",
+                                            "description": "TLS Certificate for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "TLS Key for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "ca": {
+                                            "type": "string",
+                                            "description": "TLS CA to verify clients against - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "existingSecret": {
+                                            "type": "object",
+                                            "description": "Existing secret containing your own TLS certificates",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Query service HTTP port",
+                                    "default": 9090
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Query HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Query service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Query service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for Thanos Query service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Query service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Query service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        },
+                        "additionalHeadless": {
+                            "type": "boolean",
+                            "description": "Additional Headless service",
+                            "default": false
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceGrpc": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Thanos Query service GRPC port",
+                                    "default": 10901
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Query GRPC nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Query service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Query service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Query service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Query service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        },
+                        "additionalHeadless": {
+                            "type": "boolean",
+                            "description": "Additional Headless service",
+                            "default": false
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the deployment",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Query Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a ClusterRole and ClusterRoleBinding for the Thanos Query Service Account",
+                            "default": false
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy for Thanos Query",
+                    "default": false
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Query",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Query replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Query replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Query",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "thanos.local"
+                        },
+                        "secretName": {
+                            "type": "string",
+                            "description": "Custom secretName for the ingress resource",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at `query.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress controller resource (GRPC)",
+                                    "default": false
+                                },
+                                "hostname": {
+                                    "type": "string",
+                                    "description": "Default host for the ingress resource (GRPC)",
+                                    "default": "thanos-grpc.local"
+                                },
+                                "secretName": {
+                                    "type": "string",
+                                    "description": "Custom secretName for the ingress resource (GRPC)",
+                                    "default": ""
+                                },
+                                "ingressClassName": {
+                                    "type": "string",
+                                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional annotations for the Ingress resource (GRPC). To enable certificate autogeneration, place here your cert-manager annotations.",
+                                    "default": {}
+                                },
+                                "extraHosts": {
+                                    "type": "array",
+                                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraTls": {
+                                    "type": "array",
+                                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "secrets": {
+                                    "type": "array",
+                                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraRules": {
+                                    "type": "array",
+                                    "description": "Additional rules to be covered with this ingress record",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "tls": {
+                                    "type": "boolean",
+                                    "description": "Enable TLS configuration for the hostname defined at `query.ingress.grpc.hostname` parameter",
+                                    "default": false
+                                },
+                                "selfSigned": {
+                                    "type": "boolean",
+                                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                                    "default": false
+                                },
+                                "apiVersion": {
+                                    "type": "string",
+                                    "description": "Override API Version (automatically detected if not set)",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Ingress Path",
+                                    "default": "/"
+                                },
+                                "pathType": {
+                                    "type": "string",
+                                    "description": "Ingress Path type",
+                                    "default": "ImplementationSpecific"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "queryFrontend": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Query Frontend component",
+                    "default": true
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Query Frontend log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Query Frontend log format",
+                    "default": "logfmt"
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Thanos Query Frontend configuration",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Thanos Query Frontend configuration",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Query Frontend container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Query Frontend nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Query Frontend nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Query Frontend",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Query Frontend replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Query Frontend replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Query Frontend pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Query Frontend pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Query Frontend containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Query Frontend containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Query Frontend containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Query Frontend containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Query Frontend containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Query Frontend container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Query Frontend container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Query Frontend containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Query Frontend containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Query Frontend containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Query Frontend pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Query Frontend pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Query Frontend",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the query-frontend container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Query Frontend pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Query Frontend pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Query Frontend node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Query Frontend node label key to match. Ignored if `queryFrontend.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Query Frontend node label values to match. Ignored if `queryFrontend.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Query Frontend affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Query Frontend node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Query Frontend tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Query Frontend pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Query Frontend pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Query Frontend container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Query Frontend priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Query Frontend pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Query Frontend pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Query Frontend service HTTP port",
+                                    "default": 9090
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Query Frontend HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Query Frontend service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Query Frontend service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Query Frontend service",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for Thanos Query Frontend service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Query Frontend service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the deployment",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Query Frontend Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Create a ClusterRole and ClusterRoleBinding for the Thanos Query Frontend Service Account",
+                            "default": false
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy for Thanos Query Frontend",
+                    "default": false
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Query Frontend",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Query Frontend replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Query Frontend replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Query Frontend",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "thanos.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at `queryFrontend.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        }
+                    }
+                }
+            }
+        },
+        "bucketweb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Bucket Web component",
+                    "default": false
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Bucket Web log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Bucket Web log format",
+                    "default": "logfmt"
+                },
+                "refresh": {
+                    "type": "string",
+                    "description": "Refresh interval to download metadata from remote storage",
+                    "default": "30m"
+                },
+                "timeout": {
+                    "type": "string",
+                    "description": "Timeout to download metadata from remote storage",
+                    "default": "5m"
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Bucket Web container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Bucket Web nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Bucket Web nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Bucket Web",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Bucket Web replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Bucket Web replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Bucket Web pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Bucket Web pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Bucket Web containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Bucket Web containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Bucket Web containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Bucket Web containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Bucket Web containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Bucket Web container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Bucket Web container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Bucket Web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Bucket Web containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Bucket Web containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Bucket Web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Bucket Web pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Bucket Web",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the bucketweb container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Bucket Web pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Bucket Web pod anti-affinity preset. Ignored if `bucketweb.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Bucket Web node affinity preset type. Ignored if `bucketweb.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Bucket Web node label key to match. Ignored if `bucketweb.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Bucket Web node label values to match. Ignored if `bucketweb.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Bucket Web affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Bucket Web node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Bucket Web tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Bucket Web pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Bucket Web pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Bucket Web container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Bucket Web priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Bucket Web pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Bucket Web pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Bucket Web service HTTP port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Bucket Web HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Bucket Web service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Bucket Web service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for Thanos Bucket Web service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Bucket Web service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Bucket Web service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the deployment",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Bucket Web Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Bucket Web",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Bucket Web replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Bucket Web replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Bucket Web",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "thanos-bucketweb.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at `bucketweb.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        }
+                    }
+                }
+            }
+        },
+        "compactor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Compactor component",
+                    "default": false
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Compactor log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Compactor log format",
+                    "default": "logfmt"
+                },
+                "retentionResolutionRaw": {
+                    "type": "string",
+                    "description": "Resolution and Retention flag",
+                    "default": "30d"
+                },
+                "retentionResolution5m": {
+                    "type": "string",
+                    "description": "Resolution and Retention flag",
+                    "default": "30d"
+                },
+                "retentionResolution1h": {
+                    "type": "string",
+                    "description": "Resolution and Retention flag",
+                    "default": "10y"
+                },
+                "consistencyDelay": {
+                    "type": "string",
+                    "description": "Minimum age of fresh (non-compacted) blocks before they are being processed",
+                    "default": "30m"
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Compactor container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Compactor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Compactor nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Compactor",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "cronJob": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Run compactor as a CronJob rather than a Deployment",
+                            "default": false
+                        },
+                        "schedule": {
+                            "type": "string",
+                            "description": "The schedule in Cron format, see <https://en.wikipedia.org/wiki/Cron>",
+                            "default": "0 */6 * * *"
+                        },
+                        "timeZone": {
+                            "type": "string",
+                            "description": "The time zone name for the given schedule, see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>",
+                            "default": ""
+                        },
+                        "concurrencyPolicy": {
+                            "type": "string",
+                            "description": "Specifies how to treat concurrent executions of a Job",
+                            "default": "Forbid"
+                        },
+                        "startingDeadlineSeconds": {
+                            "type": "string",
+                            "description": "Optional deadline in seconds for starting the job if it misses scheduled time for any reason",
+                            "default": ""
+                        },
+                        "suspend": {
+                            "type": "string",
+                            "description": "This flag tells the controller to suspend subsequent executions",
+                            "default": ""
+                        },
+                        "successfulJobsHistoryLimit": {
+                            "type": "string",
+                            "description": "The number of successful finished jobs to retain",
+                            "default": ""
+                        },
+                        "failedJobsHistoryLimit": {
+                            "type": "string",
+                            "description": "The number of failed finished jobs to retain",
+                            "default": ""
+                        },
+                        "backoffLimit": {
+                            "type": "string",
+                            "description": "Specifies the number of retries before marking this job failed",
+                            "default": ""
+                        }
+                    }
+                },
+                "restartPolicy": {
+                    "type": "string",
+                    "description": "Compactor container restart policy.",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Compactor replicas",
+                            "default": "Recreate"
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Compactor pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Compactor pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Compactor containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Compactor containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Compactor containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Compactor containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Compactor containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Compactor container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Compactor container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Compactor containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Compactor containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Compactor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Compactor pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Compactor pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Compactor",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the compactor container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Compactor pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Compactor pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Compactor node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Compactor node label key to match. Ignored if `compactor.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Compactor node label values to match. Ignored if `compactor.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Compactor affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Compactor node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Compactor tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Compactor pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Compactor pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Compactor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Compactor priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Compactor pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Compactor pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Compactor service HTTP port",
+                                    "default": 9090
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Compactor HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Compactor service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Compactor service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for Thanos Compactor service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Compactor service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Compactor service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the deployment",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Compactor Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "thanos-compactor.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at `compactor.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable data persistence using PVC(s) on Thanos Compactor pods",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Specify the `storageClass` used to provision the volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Modes for data volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for data volume",
+                            "default": "8Gi"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "storegateway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Store Gateway component",
+                    "default": false
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Store Gateway log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Store Gateway log format",
+                    "default": "logfmt"
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Thanos Store Gateway configuration",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Thanos Store Gateway configuration",
+                    "default": ""
+                },
+                "grpc": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enable TLS encryption in the GRPC server",
+                                            "default": false
+                                        },
+                                        "autoGenerated": {
+                                            "type": "boolean",
+                                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                                            "default": false
+                                        },
+                                        "cert": {
+                                            "type": "string",
+                                            "description": "TLS Certificate for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "TLS Key for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "ca": {
+                                            "type": "string",
+                                            "description": "TLS CA to verify clients against - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "existingSecret": {
+                                            "type": "object",
+                                            "description": "Existing secret containing your own TLS certificates",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Store Gateway container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Store Gateway nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Store Gateway nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Store Gateway",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Store Gateway replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Store Gateway replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy: OrderedReady (default) or Parallel",
+                    "default": "OrderedReady"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Store Gateway pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Store Gateway pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Store Gateway containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Store Gateway containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Store Gateway containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Store Gateway containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Store Gateway containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Store Gateway container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Store Gateway container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Store Gateway containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Store Gateway containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Store Gateway containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Store Gateway pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Store Gateway pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Store Gateway",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the storegateway container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Store Gateway pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Store Gateway pod anti-affinity preset. Ignored if `storegateway.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Store Gateway node affinity preset type. Ignored if `storegateway.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Store Gateway node label key to match. Ignored if `storegateway.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Store Gateway node label values to match. Ignored if `storegateway.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Store Gateway affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Store Gateway node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Store Gateway tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Store Gateway pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Store Gateway pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Store Gateway container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Store Gateway priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Store Gateway pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Store Gateway pods",
+                    "default": ""
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Store Gateway service HTTP port",
+                                    "default": 9090
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Thanos Store Gateway service GRPC port",
+                                    "default": 10901
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Store Gateway HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Store Gateway GRPC nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Store Gateway service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Store Gateway service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for Thanos Store Gateway service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Store Gateway service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Store Gateway service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        },
+                        "additionalHeadless": {
+                            "type": "boolean",
+                            "description": "Additional Headless service",
+                            "default": false
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable data persistence using PVC(s) on Thanos Store Gateway pods",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Specify the `storageClass` used to provision the volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Modes for data volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for data volume",
+                            "default": "8Gi"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the sts",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Store Gateway Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Store Gateway",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Store Gateway replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Store Gateway replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Store Gateway",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "thanos-storegateway.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at `storegateway.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress controller resource (GRPC)",
+                                    "default": false
+                                },
+                                "hostname": {
+                                    "type": "string",
+                                    "description": "Default host for the ingress resource (GRPC)",
+                                    "default": "thanos-grpc.local"
+                                },
+                                "ingressClassName": {
+                                    "type": "string",
+                                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional annotations for the Ingress resource (GRPC). To enable certificate autogeneration, place here your cert-manager annotations.",
+                                    "default": {}
+                                },
+                                "extraHosts": {
+                                    "type": "array",
+                                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraTls": {
+                                    "type": "array",
+                                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "secrets": {
+                                    "type": "array",
+                                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "extraRules": {
+                                    "type": "array",
+                                    "description": "Additional rules to be covered with this ingress record",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "tls": {
+                                    "type": "boolean",
+                                    "description": "Enable TLS configuration for the hostname defined at `storegateway.ingress.grpc.hostname` parameter",
+                                    "default": false
+                                },
+                                "selfSigned": {
+                                    "type": "boolean",
+                                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                                    "default": false
+                                },
+                                "apiVersion": {
+                                    "type": "string",
+                                    "description": "Override API Version (automatically detected if not set)",
+                                    "default": ""
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "Ingress Path",
+                                    "default": "/"
+                                },
+                                "pathType": {
+                                    "type": "string",
+                                    "description": "Ingress Path type",
+                                    "default": "ImplementationSpecific"
+                                }
+                            }
+                        }
+                    }
+                },
+                "sharded": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable sharding for Thanos Store Gateway",
+                            "default": false
+                        },
+                        "hashPartitioning": {
+                            "type": "object",
+                            "properties": {
+                                "shards": {
+                                    "type": "string",
+                                    "description": "Setting hashPartitioning will create multiple store statefulsets based on the number of shards specified using the hashmod of the blocks",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "timePartitioning": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "min": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "max": {
+                                        "type": "string",
+                                        "description": ""
+                                    }
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "clusterIPs": {
+                                    "type": "array",
+                                    "description": "Array of cluster IPs for each Store Gateway service. Length must be the same as the number of shards",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "loadBalancerIPs": {
+                                    "type": "array",
+                                    "description": "Array of load balancer IPs for each Store Gateway service. Length must be the same as the number of shards",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "http": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nodePorts": {
+                                            "type": "array",
+                                            "description": "Array of http node ports used for Store Gateway service. Length must be the same as the number of shards",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                },
+                                "grpc": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nodePorts": {
+                                            "type": "array",
+                                            "description": "Array of grpc node ports used for Store Gateway service. Length must be the same as the number of shards",
+                                            "default": [],
+                                            "items": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ruler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Ruler component",
+                    "default": false
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Ruler log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Ruler log format",
+                    "default": "logfmt"
+                },
+                "replicaLabel": {
+                    "type": "string",
+                    "description": "Label to treat as a replica indicator along which data is de-duplicated",
+                    "default": "replica"
+                },
+                "dnsDiscovery": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Dynamically configure Query APIs using DNS discovery",
+                            "default": true
+                        }
+                    }
+                },
+                "queryURL": {
+                    "type": "string",
+                    "description": "Thanos query/query-frontend URL to link in Ruler UI.",
+                    "default": ""
+                },
+                "alertmanagers": {
+                    "type": "array",
+                    "description": "Alert managers URLs array",
+                    "default": [],
+                    "items": {}
+                },
+                "alertmanagersConfig": {
+                    "type": "string",
+                    "description": "Alert managers configuration",
+                    "default": ""
+                },
+                "evalInterval": {
+                    "type": "string",
+                    "description": "The default evaluation interval to use",
+                    "default": "1m"
+                },
+                "clusterName": {
+                    "type": "string",
+                    "description": "Used to set the 'ruler_cluster' label",
+                    "default": ""
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Ruler configuration",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Ruler configuration",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Ruler container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Ruler nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Ruler nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Ruler",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Ruler replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Ruler replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod Management Policy Type",
+                    "default": "OrderedReady"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Ruler pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Ruler pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Ruler containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Ruler containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Ruler containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Ruler containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Ruler containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Ruler container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Ruler container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Ruler containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Ruler containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Ruler containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Ruler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Ruler pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Ruler",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the ruler container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Ruler pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Ruler pod anti-affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Ruler node affinity preset type. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Ruler node label key to match. Ignored if `ruler.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Ruler node label values to match. Ignored if `ruler.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Ruler affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Ruler node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Ruler tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Ruler pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Ruler pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Ruler container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Ruler priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Ruler pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Ruler pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Ruler service HTTP port",
+                                    "default": 9090
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Thanos Ruler service GRPC port",
+                                    "default": 10901
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Ruler HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Ruler GRPC nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Ruler service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Ruler service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for Thanos Ruler service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Ruler service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Ruler service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos Query service",
+                            "default": {}
+                        },
+                        "additionalHeadless": {
+                            "type": "boolean",
+                            "description": "Additional Headless service",
+                            "default": false
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable data persistence using PVC(s) on Thanos Ruler pods",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Specify the `storageClass` used to provision the volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Modes for data volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the sts",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Ruler Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Ruler",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Ruler replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Ruler replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Ruler",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "thanos-ruler.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        }
+                    }
+                }
+            }
+        },
+        "receive": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Receive component",
+                    "default": false
+                },
+                "mode": {
+                    "type": "string",
+                    "description": "Mode to run receiver in. Valid options are \"standalone\" or \"dual-mode\"",
+                    "default": "standalone"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Receive log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Receive log format",
+                    "default": "logfmt"
+                },
+                "tsdbRetention": {
+                    "type": "string",
+                    "description": "Thanos Receive TSDB retention period",
+                    "default": "15d"
+                },
+                "replicationFactor": {
+                    "type": "number",
+                    "description": "Thanos Receive replication-factor",
+                    "default": 1
+                },
+                "config": {
+                    "type": "array",
+                    "description": "Receive Hashring configuration",
+                    "default": [],
+                    "items": {}
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Thanos Receive Hashring configuration",
+                    "default": ""
+                },
+                "replicaLabel": {
+                    "type": "string",
+                    "description": "Label to treat as a replica indicator along which data is de-duplicated",
+                    "default": "replica"
+                },
+                "grpc": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enable TLS encryption in the GRPC server",
+                                            "default": false
+                                        },
+                                        "autoGenerated": {
+                                            "type": "boolean",
+                                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates",
+                                            "default": false
+                                        },
+                                        "cert": {
+                                            "type": "string",
+                                            "description": "TLS Certificate for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "TLS Key for GRPC server - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "ca": {
+                                            "type": "string",
+                                            "description": "TLS CA to verify clients against - ignored if existingSecret is provided",
+                                            "default": ""
+                                        },
+                                        "existingSecret": {
+                                            "type": "object",
+                                            "description": "Existing secret containing your own TLS certificates",
+                                            "default": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Receive container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Receive nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Receive nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Receive",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Receive replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Receive replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Statefulset Pod management policy: OrderedReady (default) or Parallel",
+                    "default": "OrderedReady"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Receive pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Receive pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Receive containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Receive containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Receive containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Receive containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Receive containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Receive container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Receive container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Receive containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Receive containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Receive containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Receive pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Receive pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Receive",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the receive container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Receive pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Receive pod anti-affinity preset. Ignored if `ruler.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Receive node affinity preset type. Ignored if `receive.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Receive node label key to match. Ignored if `receive.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Receive node label values to match. Ignored if `receive.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Receive affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Receive node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Receive tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "statefulsetLabels": {
+                    "type": "object",
+                    "description": "Thanos Receive statefulset labels",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Receive pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Receive pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Receive container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Receive priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Receive pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Receive pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Thanos Ruler service HTTP port",
+                                    "default": 10902
+                                },
+                                "grpc": {
+                                    "type": "number",
+                                    "description": "Thanos Ruler service GRPC port",
+                                    "default": 10901
+                                },
+                                "remote": {
+                                    "type": "number",
+                                    "description": "Thanos Ruler service remote port",
+                                    "default": 19291
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Ruler HTTP nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                },
+                                "grpc": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Ruler GRPC nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                },
+                                "remote": {
+                                    "type": "string",
+                                    "description": "Specify the Thanos Ruler remote nodePort value for the LoadBalancer and NodePort service types",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Thanos Ruler service clusterIP IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Thanos Ruler service externalTrafficPolicy",
+                            "default": "Cluster"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for Thanos Receive service",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Receive service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the Thanos Receive service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "labelSelectorsOverride": {
+                            "type": "object",
+                            "description": "Selector for Thanos receive service",
+                            "default": {}
+                        },
+                        "additionalHeadless": {
+                            "type": "boolean",
+                            "description": "Additional Headless service",
+                            "default": false
+                        },
+                        "headless": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Annotations for the headless service.",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the sts",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Receive Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Receive",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Receive replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Receive replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Receive",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable data persistence using PVC(s) on Thanos Receive pods",
+                            "default": true
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Specify the `storageClass` used to provision the volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Modes for data volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for data volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set to true to enable ingress record generation",
+                            "default": false
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "When the ingress is enabled, a host pointing to this will be created",
+                            "default": "thanos-receive.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at `receive.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Override API Version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Ingress Path",
+                            "default": "/"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress Path type",
+                            "default": "ImplementationSpecific"
+                        }
+                    }
+                }
+            }
+        },
+        "receiveDistributor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Thanos Receive Distributor component",
+                    "default": false
+                },
+                "logLevel": {
+                    "type": "string",
+                    "description": "Thanos Receive Distributor log level",
+                    "default": "info"
+                },
+                "logFormat": {
+                    "type": "string",
+                    "description": "Thanos Receive Distributor log format",
+                    "default": "logfmt"
+                },
+                "replicaLabel": {
+                    "type": "string",
+                    "description": "Label to treat as a replica indicator along which data is de-duplicated",
+                    "default": "replica"
+                },
+                "replicationFactor": {
+                    "type": "number",
+                    "description": "Thanos Receive Distributor replication-factor",
+                    "default": 1
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables for Thanos Receive Distributor container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Thanos Receive Distributor nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Thanos Receive Distributor nodes",
+                    "default": ""
+                },
+                "extraFlags": {
+                    "type": "array",
+                    "description": "Extra Flags to passed to Thanos Receive Distributor",
+                    "default": [],
+                    "items": {}
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Thanos Receive Distributor replicas to deploy",
+                    "default": 1
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Update strategy type for Thanos Receive Distributor replicas",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context for the Thanos Receive Distributor pods",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the filesystem used by Thanos Receive Distributor pods",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context for the Thanos Receive Distributor containers",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the service user running the Thanos Receive Distributor containers",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Force the Thanos Receive Distributor containers to run as a non root user",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Switch privilegeEscalation possibility on or off for Thanos Receive Distributor containers",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "mount / (root) as a readonly filesystem on Thanos Receive Distributor containers",
+                            "default": true
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Thanos Receive container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Thanos Receive container",
+                            "default": {}
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Thanos Receive Distributor containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Thanos Receive Distributor containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 30
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Thanos Receive Distributor containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 5
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Thanos Receive Distributor pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Extra containers running as sidecars to Thanos Receive Distributor pods",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra volumes to add to Thanos Receive Distributor",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra volume mounts to add to the receive distributor container",
+                    "default": [],
+                    "items": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Receive pod affinity preset",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Thanos Receive pod anti-affinity preset. Ignored if `receiveDistributor.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Thanos Receive node affinity preset type. Ignored if `receiveDistributor.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Thanos Receive node label key to match. Ignored if `receiveDistributor.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Thanos Receive node label values to match. Ignored if `receiveDistributor.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Thanos Receive Distributor affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Thanos Receive Distributor node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Thanos Receive Distributor tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Thanos Receive Distributor pod labels",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Thanos Receive Distributor pods",
+                    "default": {}
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "description": "Deployment pod DNS config",
+                    "default": {}
+                },
+                "dnsPolicy": {
+                    "type": "string",
+                    "description": "Deployment pod DNS policy",
+                    "default": ""
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Thanos Receive Distributor container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Thanos Receive Distributor priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Thanos Receive Distributor pods",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for Thanos Receive Distributor pods assignment spread across your cluster among failure-domains",
+                    "default": [],
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Enable/disable auto mounting of the service account token only for the deployment",
+                    "default": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Thanos Receive Distributor Service Account",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Enable/disable auto mounting of the service account token",
+                            "default": true
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Thanos Receive Distributor",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Thanos Receive Distributor replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Thanos Receive Distributor replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation for Thanos Receive Distributor",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable the export of Prometheus metrics",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Specify if a ServiceMonitor will be deployed for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in Prometheus",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "How frequently to scrape metrics",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "Specify additional relabeling of metrics",
+                            "default": [],
+                            "items": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Specify general relabeling",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "extraParameters": {
+                            "type": "object",
+                            "description": "Any extra parameter to be added to the endpoint configured in the ServiceMonitor",
+                            "default": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "default": {
+                            "type": "object",
+                            "properties": {
+                                "sidecarJobRegex": {
+                                    "type": "string",
+                                    "description": "Allows the customization of the thanos-sidecar job name to use in the sidecar prometheus alerts",
+                                    "default": ".*thanos-sidecar.*"
+                                },
+                                "create": {
+                                    "type": "boolean",
+                                    "description": "would create all default prometheus alerts",
+                                    "default": false
+                                },
+                                "disabled": {
+                                    "type": "object",
+                                    "description": "disable one specific prometheus alert rule",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which the PrometheusRule CRD is created",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels for the prometheusRule",
+                            "default": {}
+                        },
+                        "groups": {
+                            "type": "array",
+                            "description": "Prometheus Rule Groups for Thanos components",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "minio": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable MinIO&reg; chart installation",
+                    "default": false
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootUser": {
+                            "type": "string",
+                            "description": "MinIO&reg; root username",
+                            "default": "admin"
+                        },
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for MinIO&reg; root user",
+                            "default": ""
+                        }
+                    }
+                },
+                "defaultBuckets": {
+                    "type": "string",
+                    "description": "Comma, semi-colon or space separated list of MinIO&reg; buckets to create",
+                    "default": "thanos"
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "explicitNamespacesSelector": {
+                    "type": "object",
+                    "description": "A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/tomcat/values.schema.json
+++ b/bitnami/tomcat/values.schema.json
@@ -1,0 +1,954 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Tomcat image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Tomcat image repository",
+                    "default": "bitnami/tomcat"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Tomcat image tag (immutable tags are recommended)",
+                    "default": "10.1.13-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Tomcat image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Deployment pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "tomcatUsername": {
+            "type": "string",
+            "description": "Tomcat admin user",
+            "default": "user"
+        },
+        "tomcatPassword": {
+            "type": "string",
+            "description": "Tomcat admin password",
+            "default": ""
+        },
+        "tomcatAllowRemoteManagement": {
+            "type": "number",
+            "description": "Enable remote access to management interface",
+            "default": 0
+        },
+        "catalinaOpts": {
+            "type": "string",
+            "description": "Java runtime option used by tomcat JVM",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables to be set on Tomcat container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra environment variables",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra environment variables",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Specify number of Tomcat replicas",
+            "default": 1
+        },
+        "deployment": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Use Deployment or StatefulSet",
+                    "default": "deployment"
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "StrategyType",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "HTTP port to expose at container level",
+                    "default": 8080
+                }
+            }
+        },
+        "containerExtraPorts": {
+            "type": "array",
+            "description": "Extra ports to expose at container level",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Tomcat pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set Tomcat pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Tomcat containers' SecurityContext",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "User ID for the Tomcat container",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Force user to be root in Tomcat container",
+                    "default": true
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the Tomcat container",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        },
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        }
+                    }
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for Tomcat pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for Tomcat pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternative scheduler",
+            "default": ""
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "podManagementPolicy to manage scaling operation of pods (only in StatefulSet mode)",
+            "default": ""
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment. Evaluated as a template.",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "extraPodSpec": {
+            "type": "object",
+            "description": "Optionally specify extra PodSpec",
+            "default": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for Tomcat pods in Deployment",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeClaimTemplates": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for Tomcat container(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add init containers to the Tomcat pods.",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add sidecars to the Tomcat pods.",
+            "default": [],
+            "items": {}
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for Tomcat volume",
+                    "default": ""
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access Modes for Tomcat volume",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for Tomcat volume",
+                    "default": "8Gi"
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "An Existing PVC name for Tomcat volume",
+                    "default": ""
+                },
+                "selectorLabels": {
+                    "type": "object",
+                    "description": "Selector labels to use in volume claim template in statefulset",
+                    "default": {}
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                },
+                "explicitNamespacesSelector": {
+                    "type": "object",
+                    "description": "A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed",
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Kubernetes http node port",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "Port Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank",
+                    "default": ""
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "Service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "Service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "Enable client source IP preservation",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for Tomcat service",
+                    "default": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the headless service.",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress controller resource",
+                    "default": false
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress resource",
+                    "default": "tomcat.local"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "Any additional arbitrary paths that may need to be added to the ingress under the main host.",
+                    "default": [],
+                    "items": {}
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Ingress path",
+                    "default": "/"
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes volume permissions in the data directory",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag",
+                            "default": "11-debian-11-r48"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource  limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource  requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "jmx": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether or not to expose JMX metrics to Prometheus",
+                            "default": false
+                        },
+                        "catalinaOpts": {
+                            "type": "string",
+                            "description": "custom option used to enabled JMX on tomcat jvm evaluated as template",
+                            "default": "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "JMX exporter image registry",
+                                    "default": "docker.io"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "JMX exporter image repository",
+                                    "default": "bitnami/jmx-exporter"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "JMX exporter image tag (immutable tags are recommended)",
+                                    "default": "0.19.0-debian-11-r54"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "description": "JMX exporter image pull policy",
+                                    "default": "IfNotPresent"
+                                },
+                                "pullSecrets": {
+                                    "type": "array",
+                                    "description": "Specify docker-registry secret names as an array",
+                                    "default": [],
+                                    "items": {}
+                                }
+                            }
+                        },
+                        "config": {
+                            "type": "string",
+                            "description": "Configuration file for JMX exporter",
+                            "default": "jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi\nstartDelaySecs: 120\nssl: false\nlowercaseOutputName: true\nlowercaseOutputLabelNames: true\nattrNameSnakeCase: true\n"
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable Prometheus JMX exporter containers' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set Prometheus JMX exporter containers' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set Prometheus JMX exporter containers' Security Context runAsNonRoot",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "JMX Exporter container resource limits",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "JMX Exporter container resource requests",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "JMX Exporter container metrics ports",
+                                    "default": 5556
+                                }
+                            }
+                        },
+                        "existingConfigmap": {
+                            "type": "string",
+                            "description": "Name of existing ConfigMap with JMX exporter configuration",
+                            "default": ""
+                        }
+                    }
+                },
+                "podMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "podTargetLabels": {
+                            "type": "array",
+                            "description": "Used to keep given pod's labels in target",
+                            "default": [],
+                            "items": {}
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create PodMonitor Resource for scraping metrics using PrometheusOperator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Optional namespace in which Prometheus is running",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Specify the interval at which metrics should be scraped",
+                            "default": "30s"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Specify the timeout after which the scrape is ended",
+                            "default": "30s"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "Scheme to use for scraping",
+                            "default": "http"
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "Prometheus relabeling rules",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set this to true to create prometheusRules for Prometheus operator",
+                            "default": false
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so prometheusRules will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "namespace where prometheusRules resource should be created",
+                            "default": ""
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Create specified [Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/vault/values.schema.json
+++ b/bitnami/vault/values.schema.json
@@ -1,0 +1,2364 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.name",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Vault Server",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Vault Server image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Vault Server image repository",
+                            "default": "bitnami/vault"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Vault Server image tag (immutable tags are recommended)",
+                            "default": "1.14.2-debian-11-r0"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Vault Server image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Vault Server image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Vault Server image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Vault Server image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Vault Server replicas to deploy",
+                    "default": 1
+                },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "description": "Pod management policy",
+                    "default": "Parallel"
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Vault Server http container port",
+                            "default": 8200
+                        },
+                        "internal": {
+                            "type": "number",
+                            "description": "Vault Server internal (HTTPS) container port",
+                            "default": 8201
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Vault Server containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Vault Server containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Vault Server containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Vault Server containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Vault Server containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Vault Server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Vault Server pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Vault Server container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Vault Server containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Vault Server containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Vault Server containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Vault Server containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Vault Server container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Vault Server container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Vault Server pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Vault server configuration (evaluated as a template)",
+                    "default": "disable_mlock = true\nui = true\nlistener \"tcp\" {\n  tls_disable = 1\n  address = \"[::]:{{ .Values.server.containerPorts.http }}\"\n  cluster_address = \"[::]:{{ .Values.server.containerPorts.internal }}\"\n  {{- if .Values.server.metrics.enabled }}\n  # Enable unauthenticated metrics access (necessary for Prometheus Operator)\n  telemetry {\n    unauthenticated_metrics_access = \"true\"\n  }\n  {{- end }}\n}\nstorage \"raft\" {\n  path = \"{{ .Values.server.persistence.mountPath }}\"\n}\n\nservice_registration \"kubernetes\" {}\n"
+                },
+                "existingConfigMap": {
+                    "type": "string",
+                    "description": "name of a ConfigMap with existing configuration for the server",
+                    "default": ""
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Vault Server pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Vault Server pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `server.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `server.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Vault Server pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Vault Server pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Vault Server pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Vault Server statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Vault Server pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Vault Server pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Vault Server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Vault Server nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Vault Server nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Vault Server nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Vault Server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Vault Server container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Vault Server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Vault Server pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "general": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Vault Server service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Vault Server service HTTP port",
+                                            "default": 8200
+                                        },
+                                        "internal": {
+                                            "type": "number",
+                                            "description": "Vault Server internal port",
+                                            "default": 8201
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        },
+                                        "internal": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Vault Server service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Vault Server service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Vault Server service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Vault Server service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Vault Server service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Vault Server service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where web requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "active": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Vault Server service type",
+                                    "default": "ClusterIP"
+                                },
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "number",
+                                            "description": "Vault Server service HTTP port",
+                                            "default": 8200
+                                        },
+                                        "internal": {
+                                            "type": "number",
+                                            "description": "Vault Server internal port",
+                                            "default": 8201
+                                        }
+                                    }
+                                },
+                                "nodePorts": {
+                                    "type": "object",
+                                    "properties": {
+                                        "http": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        },
+                                        "internal": {
+                                            "type": "string",
+                                            "description": "Node port for HTTP",
+                                            "default": ""
+                                        }
+                                    }
+                                },
+                                "clusterIP": {
+                                    "type": "string",
+                                    "description": "Vault Server service Cluster IP",
+                                    "default": ""
+                                },
+                                "loadBalancerIP": {
+                                    "type": "string",
+                                    "description": "Vault Server service Load Balancer IP",
+                                    "default": ""
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array",
+                                    "description": "Vault Server service Load Balancer sources",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string",
+                                    "description": "Vault Server service external traffic policy",
+                                    "default": "Cluster"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for Vault Server service",
+                                    "default": {}
+                                },
+                                "extraPorts": {
+                                    "type": "array",
+                                    "description": "Extra ports to expose in Vault Server service (normally used with the `sidecars` value)",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "sessionAffinity": {
+                                    "type": "string",
+                                    "description": "Control where web requests go, to the same pod or round-robin",
+                                    "default": "None"
+                                },
+                                "sessionAffinityConfig": {
+                                    "type": "object",
+                                    "description": "Additional settings for the sessionAffinity",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress record generation for Vault",
+                            "default": false
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress record",
+                            "default": "vault.local"
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Default path for the ingress record",
+                            "default": "/"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the host defined at `client.ingress.hostname` parameter",
+                            "default": false
+                        },
+                        "selfSigned": {
+                            "type": "boolean",
+                            "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "An array with additional hostname(s) to be covered with the ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "Custom TLS certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable persistence using Persistent Volume Claims",
+                            "default": true
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "Persistent Volume mount root path",
+                            "default": "/bitnami/vault/data"
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "Persistent Volume access modes",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "default": "10Gi"
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "The name of an existing PVC to use for persistence",
+                            "default": ""
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable the export of Prometheus metrics",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.server.service.general.ports.http }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                                    "default": false
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Namespace in which Prometheus is running",
+                                    "default": ""
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "Additional custom annotations for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "description": "Extra labels for the ServiceMonitor",
+                                    "default": {}
+                                },
+                                "jobLabel": {
+                                    "type": "string",
+                                    "description": "The name of the label on the target service to use as the job name in Prometheus",
+                                    "default": ""
+                                },
+                                "honorLabels": {
+                                    "type": "boolean",
+                                    "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                                    "default": false
+                                },
+                                "interval": {
+                                    "type": "string",
+                                    "description": "Interval at which metrics should be scraped.",
+                                    "default": ""
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string",
+                                    "description": "Timeout after which the scrape is ended",
+                                    "default": ""
+                                },
+                                "metricRelabelings": {
+                                    "type": "array",
+                                    "description": "Specify additional relabeling of metrics",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "relabelings": {
+                                    "type": "array",
+                                    "description": "Specify general relabeling",
+                                    "default": [],
+                                    "items": {}
+                                },
+                                "selector": {
+                                    "type": "object",
+                                    "description": "Prometheus instance selector labels",
+                                    "default": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "csiProvider": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Vault CSI Provider",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Vault CSI Provider image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Vault CSI Provider image repository",
+                            "default": "bitnami/vault-csi-provider"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Vault CSI Provider image tag (immutable tags are recommended)",
+                            "default": "1.4.0-debian-11-r105"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Vault CSI Provider image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Vault CSI Provider image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Vault CSI Provider image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Vault CSI Provider image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "config": {
+                    "type": "string",
+                    "description": "Vault CSI Provider configuration (evaluated as a template)",
+                    "default": "vault {\n    \"address\" = \"http://{{ include \"vault.server.fullname\" . }}:{{ .Values.server.service.general.ports.http }}\n}\n\ncache {}\n\nlistener \"unix\" {\n    address = \"/var/run/vault/agent.sock\"\n    tls_disable = true\n}\n"
+                },
+                "existingConfigMap": {
+                    "type": "string",
+                    "description": "name of a ConfigMap with existing configuration for the CSI Provider",
+                    "default": ""
+                },
+                "secretStoreHostPath": {
+                    "type": "string",
+                    "description": "Path to the host CSI Provider folder",
+                    "default": "/etc/kubernetes/secrets-store-csi-providers"
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Vault CSI Provider pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Vault CSI Provider pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Vault CSI Provider pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `csiProvider.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `csiProvider.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `csiProvider.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `csiProvider.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `csiProvider.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Vault CSI Provider pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Vault CSI Provider pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Vault CSI Provider pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Vault CSI Provider statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Vault CSI Provider pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Vault CSI Provider pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Vault CSI Provider pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Vault CSI Provider pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Vault CSI Provider pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled CSI Provider pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set CSI Provider pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set CSI Provider pod's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "provider": {
+                    "type": "object",
+                    "properties": {
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "health": {
+                                    "type": "number",
+                                    "description": "CSI Provider health container port",
+                                    "default": 8080
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on CSI Provider container",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 5
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on CSI Provider container",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 5
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on CSI Provider container",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 5
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the CSI Provider container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the CSI Provider container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled CSI Provider container' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set CSI Provider container' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set CSI Provider container' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set CSI Provider container' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Set CSI Provider container's privilege escalation",
+                                    "default": false
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set CSI Provider container's Security Context runAsNonRoot",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "for the CSI Provider container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add to CSI Provider nodes",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "Name of existing ConfigMap containing extra env vars for CSI Provider nodes",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Name of existing Secret containing extra env vars for CSI Provider nodes",
+                            "default": ""
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the Vault CSI Provider container",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "agent": {
+                    "type": "object",
+                    "properties": {
+                        "containerPorts": {
+                            "type": "object",
+                            "properties": {
+                                "tcp": {
+                                    "type": "number",
+                                    "description": "CSI Provider Agent metrics container port",
+                                    "default": 8200
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable livenessProbe on CSI Provider Agent container",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for livenessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for livenessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for livenessProbe",
+                                    "default": 5
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for livenessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable readinessProbe on CSI Provider Agent container",
+                                    "default": true
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for readinessProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for readinessProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for readinessProbe",
+                                    "default": 5
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for readinessProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable startupProbe on CSI Provider Agent container",
+                                    "default": false
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "number",
+                                    "description": "Initial delay seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "periodSeconds": {
+                                    "type": "number",
+                                    "description": "Period seconds for startupProbe",
+                                    "default": 10
+                                },
+                                "timeoutSeconds": {
+                                    "type": "number",
+                                    "description": "Timeout seconds for startupProbe",
+                                    "default": 5
+                                },
+                                "failureThreshold": {
+                                    "type": "number",
+                                    "description": "Failure threshold for startupProbe",
+                                    "default": 5
+                                },
+                                "successThreshold": {
+                                    "type": "number",
+                                    "description": "Success threshold for startupProbe",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "customLivenessProbe": {
+                            "type": "object",
+                            "description": "Custom livenessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customReadinessProbe": {
+                            "type": "object",
+                            "description": "Custom readinessProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "customStartupProbe": {
+                            "type": "object",
+                            "description": "Custom startupProbe that overrides the default one",
+                            "default": {}
+                        },
+                        "containerSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enabled CSI Agent container' Security Context",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "number",
+                                    "description": "Set CSI Agent container' Security Context runAsUser",
+                                    "default": 1001
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "description": "Set CSI Agent container' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean",
+                                    "description": "Set CSI Agent container' Security Context runAsNonRoot",
+                                    "default": true
+                                },
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean",
+                                    "description": "Set CSI Agent container's privilege escalation",
+                                    "default": false
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "description": "Set CSI Agent container's Security Context runAsNonRoot",
+                                            "default": [
+                                                "ALL"
+                                            ],
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "description": "The resources limits for the CSI Provider Agent container",
+                                    "default": {}
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "description": "The requested resources for the CSI Provider Agent container",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "command": {
+                            "type": "array",
+                            "description": "Override default container command (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "args": {
+                            "type": "array",
+                            "description": "Override default container args (useful when using custom images)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "lifecycleHooks": {
+                            "type": "object",
+                            "description": "for the CSI Provider Agent container(s) to automate configuration before or after startup",
+                            "default": {}
+                        },
+                        "extraEnvVars": {
+                            "type": "array",
+                            "description": "Array with extra environment variables to add to CSI Provider Agent nodes",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraEnvVarsCM": {
+                            "type": "string",
+                            "description": "Name of existing ConfigMap containing extra env vars for CSI Provider Agent nodes",
+                            "default": ""
+                        },
+                        "extraEnvVarsSecret": {
+                            "type": "string",
+                            "description": "Name of existing Secret containing extra env vars for CSI Provider Agent nodes",
+                            "default": ""
+                        },
+                        "extraVolumeMounts": {
+                            "type": "array",
+                            "description": "Optionally specify extra list of additional volumeMounts for the CSI Provider container(s)",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "injector": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Vault Kubernetes Injector",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector image repository",
+                            "default": "bitnami/vault-k8s"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector image tag (immutable tags are recommended)",
+                            "default": "1.2.1-debian-11-r96"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Vault Kubernetes Injector image pull secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable Vault Kubernetes Injector image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Vault Kubernetes Injector replicas to deploy",
+                    "default": 1
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "https": {
+                            "type": "number",
+                            "description": "Vault Kubernetes Injector metrics container port",
+                            "default": 8080
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Vault Kubernetes Injector containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Vault Kubernetes Injector containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Vault Kubernetes Injector containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 5
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Vault Kubernetes Injector containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Vault Kubernetes Injector containers",
+                            "default": {}
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Vault Kubernetes Injector pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Vault Kubernetes Injector pod's Security Context fsGroup",
+                            "default": 1001
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set Vault Kubernetes Injector container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Vault Kubernetes Injector containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Vault Kubernetes Injector containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set Vault Kubernetes Injector containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set Vault Kubernetes Injector containers' Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set Vault Kubernetes Injector container's privilege escalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "Set Vault Kubernetes Injector container's Security Context runAsNonRoot",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Vault Kubernetes Injector pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Vault Kubernetes Injector pods",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Vault Kubernetes Injector pods",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod affinity preset. Ignored if `injector.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Pod anti-affinity preset. Ignored if `injector.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for injector",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of injector replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of injector replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node affinity preset type. Ignored if `injector.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Node label key to match. Ignored if `injector.affinity` is set",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Node label values to match. Ignored if `injector.affinity` is set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for Vault Kubernetes Injector pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for Vault Kubernetes Injector pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for Vault Kubernetes Injector pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector statefulset strategy type",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Vault Kubernetes Injector pods' priorityClassName",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default) for Vault Kubernetes Injector pods",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds Redmine pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Vault Kubernetes Injector container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Vault Kubernetes Injector nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Vault Kubernetes Injector nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Vault Kubernetes Injector nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Vault Kubernetes Injector pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Vault Kubernetes Injector container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Vault Kubernetes Injector pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Vault Kubernetes Injector pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "https": {
+                                    "type": "number",
+                                    "description": "Vault Kubernetes Injector service HTTPS port",
+                                    "default": 443
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "https": {
+                                    "type": "string",
+                                    "description": "Node port for HTTPS",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Vault Kubernetes Injector service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Vault Kubernetes Injector service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional custom annotations for Vault Kubernetes Injector service",
+                            "default": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in Vault Kubernetes Injector service (normally used with the `sidecars` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where web requests go, to the same pod or round-robin",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether RBAC resources should be created",
+                            "default": true
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom RBAC rules to set",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Specifies whether a ServiceAccount should be created",
+                            "default": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the ServiceAccount to use.",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional Service Account annotations (evaluated as a template)",
+                            "default": {}
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean",
+                            "description": "Automount service account token for the server service account",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r51"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable init container's Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/whereabouts/values.schema.json
+++ b/bitnami/whereabouts/values.schema.json
@@ -1,0 +1,500 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override whereabouts.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override whereabouts.fullname template",
+            "default": ""
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.namespace",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Common annotations to add to all Whereabouts resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Common labels to add to all Whereabouts resources (sub-charts are not considered). Evaluated as a template",
+            "default": {}
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template).",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "Whereabouts image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Whereabouts Image name",
+                    "default": "bitnami/whereabouts"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Whereabouts Image tag",
+                    "default": "0.6.2-debian-11-r67"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "Whereabouts image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Whereabouts image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug logs should be enabled",
+                    "default": false
+                }
+            }
+        },
+        "hostCNIBinDir": {
+            "type": "string",
+            "description": "CNI binary dir in the host machine to mount",
+            "default": "/opt/cni/bin"
+        },
+        "hostCNINetDir": {
+            "type": "string",
+            "description": "CNI net.d dir in the host machine to mount",
+            "default": "/etc/cni/net.d"
+        },
+        "CNIMountPath": {
+            "type": "string",
+            "description": "Path inside the container to mount the CNI dirs",
+            "default": "/bitnami/whereabouts/host"
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Update strategy - only really applicable for deployments with RWO PVs attached",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Whereabouts pods' priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "Add deployment host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Extra environment variables",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Secret containing extra env vars (in case of sensitive data)",
+            "default": ""
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Attach additional containers to the pod (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment. Evaluated as a template.",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the init container",
+                    "default": {}
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Whereabouts pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Whereabouts pods' group ID",
+                    "default": 0
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Whereabouts containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Whereabouts containers' Security Context",
+                    "default": 0
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set Whereabouts container's Security Context runAsNonRoot",
+                    "default": false
+                },
+                "privileged": {
+                    "type": "boolean",
+                    "description": "Set Whereabouts container's Security Context privileged",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 5
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Override default startup probe",
+            "default": {}
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Override default liveness probe",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Override default readiness probe",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "LifecycleHook to set additional configuration at startup Evaluated as a template",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Pod annotations",
+            "default": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Add additional labels to the pod (evaluated as a template)",
+            "default": {}
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for Whereabouts pod",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        }
+    }
+}

--- a/bitnami/wildfly/values.schema.json
+++ b/bitnami/wildfly/values.schema.json
@@ -1,0 +1,792 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes cluster domain name",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the the deployment(s)/statefulset(s)",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "WildFly image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "WildFly image repository",
+                    "default": "bitnami/wildfly"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "WildFly image tag (immutable tags are recommended)",
+                    "default": "29.0.1-debian-11-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "WildFly image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "WildFly image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "WildFly image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Enable image debug mode",
+                    "default": false
+                }
+            }
+        },
+        "wildflyUsername": {
+            "type": "string",
+            "description": "WildFly username",
+            "default": "user"
+        },
+        "wildflyPassword": {
+            "type": "string",
+            "description": "WildFly user password",
+            "default": ""
+        },
+        "exposeManagementConsole": {
+            "type": "boolean",
+            "description": "Allows exposing the WildFly Management console outside the cluster",
+            "default": false
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the container to automate configuration before or after startup",
+            "default": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the WildFly container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of Wildfly replicas to deploy",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "WildFly deployment strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "WildFly pod host aliases",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for WildFly pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for WildFly container(s)",
+            "default": [],
+            "items": {}
+        },
+        "serviceAccountName": {
+            "type": "string",
+            "description": "Name of existing ServiceAccount to be connected",
+            "default": ""
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the WildFly pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the WildFly pods",
+            "default": [],
+            "items": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Pod priorityClassName",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Name of the k8s scheduler (other than default)",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "WildFly HTTP container port",
+                    "default": 8080
+                },
+                "mgmt": {
+                    "type": "number",
+                    "description": "WildFly HTTPS container port",
+                    "default": 9990
+                }
+            }
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Array with extra container ports to add to the WildFly container",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled WildFly pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set WildFly pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled WildFly containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set WildFly container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set WildFly container's Security Context runAsNonRoot",
+                    "default": true
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe",
+                    "default": false
+                },
+                "tcpSocket": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "string",
+                            "description": "",
+                            "default": "http"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "",
+                            "default": "/"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "",
+                            "default": "http"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "",
+                            "default": "/"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "",
+                            "default": "http"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 5
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 3
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "WildFly service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "WildFly service HTTP port",
+                            "default": 80
+                        },
+                        "mgmt": {
+                            "type": "number",
+                            "description": "WildFly service management console port",
+                            "default": 9990
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "mgmt": {
+                            "type": "string",
+                            "description": "Node port for Management console",
+                            "default": ""
+                        }
+                    }
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "WildFly service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "WildFly service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "WildFly service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "WildFly service external traffic policy",
+                    "default": "Cluster"
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose on WildFly service",
+                    "default": [],
+                    "items": {}
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for WildFly",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record",
+                    "default": "wildfly.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "mgmtIngress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Set to true to enable ingress record generation for the Management console",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "When the Management ingress is enabled, a host pointing to this will be created",
+                    "default": "management.local"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Management Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the hostname defined at `mgmtIngress.hostname` parameter",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "The list of additional hostnames to be covered with this Management ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostnames to be covered",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "TLS Secret configuration",
+                    "default": [],
+                    "items": {}
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Use a existing PVC which must be created manually before bound",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r57"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set init container's Security Context runAsUser",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitnami/wordpress/values.schema.json
+++ b/bitnami/wordpress/values.schema.json
@@ -1,212 +1,1669 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "wordpressUsername": {
-      "type": "string",
-      "title": "Username",
-      "form": true
-    },
-    "wordpressPassword": {
-      "type": "string",
-      "title": "Password",
-      "form": true,
-      "description": "Defaults to a random 10-character alphanumeric string if not set"
-    },
-    "wordpressEmail": {
-      "type": "string",
-      "title": "Admin email",
-      "form": true
-    },
-    "wordpressBlogName": {
-      "type": "string",
-      "title": "Blog Name",
-      "form": true
-    },
-    "persistence": {
-      "type": "object",
-      "properties": {
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi"
-        }
-      }
-    },
-    "mariadb": {
-      "type": "object",
-      "title": "MariaDB Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MariaDB database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
-        },
-        "primary": {
-          "type": "object",
-          "properties": {
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "title": "Volume Size",
-                  "form": true,
-                  "hidden": {
-                    "value": false,
-                    "path": "mariadb/enabled"
-                  },
-                  "render": "slider",
-                  "sliderMin": 1,
-                  "sliderMax": 100,
-                  "sliderUnit": "Gi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MariaDB is disabled. Use this section to specify the external database details",
-      "form": true,
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host",
-          "hidden": "mariadb/enabled"
         },
-        "user": {
-          "type": "string",
-          "form": true,
-          "title": "Database Username",
-          "hidden": "mariadb/enabled"
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
         },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password",
-          "hidden": "mariadb/enabled"
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
         },
-        "database": {
-          "type": "string",
-          "form": true,
-          "title": "Database Name",
-          "hidden": "mariadb/enabled"
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
         },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port",
-          "hidden": "mariadb/enabled"
-        }
-      }
-    },
-    "ingress": {
-      "type": "object",
-      "form": true,
-      "title": "Ingress Configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the WordPress installation."
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed resources",
+            "default": {}
         },
-        "hostname": {
-          "type": "string",
-          "form": true,
-          "title": "Hostname",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed resources",
+            "default": {}
         },
-        "tls": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create a TLS secret",
-          "hidden": {
-            "value": false,
-            "path": "ingress/enabled"
-          }
-        }
-      }
-    },
-    "service": {
-      "type": "object",
-      "form": true,
-      "title": "Service Configuration",
-      "properties": {
-        "type": {
-          "type": "string",
-          "form": true,
-          "title": "Service Type",
-          "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\"" 
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Required Resources",
-      "description": "Configure resource requests",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the deployment",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the deployment",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
-          }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "WordPress image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "WordPress image repository",
+                    "default": "bitnami/wordpress"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "WordPress image tag (immutable tags are recommended)",
+                    "default": "6.3.1-debian-11-r2"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "WordPress image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "WordPress image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "WordPress image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "wordpressUsername": {
+            "type": "string",
+            "description": "WordPress username",
+            "default": "user"
+        },
+        "wordpressPassword": {
+            "type": "string",
+            "description": "WordPress user password",
+            "default": ""
+        },
+        "existingSecret": {
+            "type": "string",
+            "description": "Name of existing secret containing WordPress credentials",
+            "default": ""
+        },
+        "wordpressEmail": {
+            "type": "string",
+            "description": "WordPress user email",
+            "default": "user@example.com"
+        },
+        "wordpressFirstName": {
+            "type": "string",
+            "description": "WordPress user first name",
+            "default": "FirstName"
+        },
+        "wordpressLastName": {
+            "type": "string",
+            "description": "WordPress user last name",
+            "default": "LastName"
+        },
+        "wordpressBlogName": {
+            "type": "string",
+            "description": "Blog name",
+            "default": "User's Blog!"
+        },
+        "wordpressTablePrefix": {
+            "type": "string",
+            "description": "Prefix to use for WordPress database tables",
+            "default": "wp_"
+        },
+        "wordpressScheme": {
+            "type": "string",
+            "description": "Scheme to use to generate WordPress URLs",
+            "default": "http"
+        },
+        "wordpressSkipInstall": {
+            "type": "boolean",
+            "description": "Skip wizard installation",
+            "default": false
+        },
+        "wordpressExtraConfigContent": {
+            "type": "string",
+            "description": "Add extra content to the default wp-config.php file",
+            "default": ""
+        },
+        "wordpressConfiguration": {
+            "type": "string",
+            "description": "The content for your custom wp-config.php file (advanced feature)",
+            "default": ""
+        },
+        "existingWordPressConfigurationSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with your custom wp-config.php file (advanced feature)",
+            "default": ""
+        },
+        "wordpressConfigureCache": {
+            "type": "boolean",
+            "description": "Enable W3 Total Cache plugin and configure cache settings",
+            "default": false
+        },
+        "wordpressPlugins": {
+            "type": "string",
+            "description": "Array of plugins to install and activate. Can be specified as `all` or `none`.",
+            "default": "none"
+        },
+        "apacheConfiguration": {
+            "type": "string",
+            "description": "The content for your custom httpd.conf file (advanced feature)",
+            "default": ""
+        },
+        "existingApacheConfigurationConfigMap": {
+            "type": "string",
+            "description": "The name of an existing secret with your custom httpd.conf file (advanced feature)",
+            "default": ""
+        },
+        "customPostInitScripts": {
+            "type": "object",
+            "description": "Custom post-init.d user scripts",
+            "default": {}
+        },
+        "smtpHost": {
+            "type": "string",
+            "description": "SMTP server host",
+            "default": ""
+        },
+        "smtpPort": {
+            "type": "string",
+            "description": "SMTP server port",
+            "default": ""
+        },
+        "smtpUser": {
+            "type": "string",
+            "description": "SMTP username",
+            "default": ""
+        },
+        "smtpPassword": {
+            "type": "string",
+            "description": "SMTP user password",
+            "default": ""
+        },
+        "smtpProtocol": {
+            "type": "string",
+            "description": "SMTP protocol",
+            "default": ""
+        },
+        "smtpExistingSecret": {
+            "type": "string",
+            "description": "The name of an existing secret with SMTP credentials",
+            "default": ""
+        },
+        "allowEmptyPassword": {
+            "type": "boolean",
+            "description": "Allow the container to be started with blank passwords",
+            "default": true
+        },
+        "allowOverrideNone": {
+            "type": "boolean",
+            "description": "Configure Apache to prohibit overriding directives with htaccess files",
+            "default": false
+        },
+        "overrideDatabaseSettings": {
+            "type": "boolean",
+            "description": "Allow overriding the database settings persisted in wp-config.php",
+            "default": false
+        },
+        "htaccessPersistenceEnabled": {
+            "type": "boolean",
+            "description": "Persist custom changes on htaccess files",
+            "default": false
+        },
+        "customHTAccessCM": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with custom htaccess rules",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to the WordPress container",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
+        },
+        "multisite": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean",
+                    "description": "Whether to enable WordPress Multisite configuration.",
+                    "default": false
+                },
+                "host": {
+                    "type": "string",
+                    "description": "WordPress Multisite hostname/address. This value is mandatory when enabling Multisite mode.",
+                    "default": ""
+                },
+                "networkType": {
+                    "type": "string",
+                    "description": "WordPress Multisite network type to enable. Allowed values: `subfolder`, `subdirectory` or `subdomain`.",
+                    "default": "subdomain"
+                },
+                "enableNipIoRedirect": {
+                    "type": "boolean",
+                    "description": "Whether to enable IP address redirection to nip.io wildcard DNS. Useful when running on an IP address with subdomain network type.",
+                    "default": false
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of WordPress replicas to deploy",
+            "default": 1
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "WordPress deployment strategy type",
+                    "default": "RollingUpdate"
+                }
+            }
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Alternate scheduler",
+            "default": ""
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "string",
+            "description": "In seconds, time given to the WordPress pod to terminate gracefully",
+            "default": ""
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of the existing priority class to be used by WordPress pods, priority class needs to be created beforehand",
+            "default": ""
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "hostnames": {
+                        "type": "array",
+                        "description": "",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for WordPress pods",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for WordPress container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the WordPress pod",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the WordPress pods",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for WordPress pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for WordPress pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the WordPress containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "The requested memory for the WordPress containers",
+                            "default": "512Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "The requested cpu for the WordPress containers",
+                            "default": "300m"
+                        }
+                    }
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "number",
+                    "description": "WordPress HTTP container port",
+                    "default": 8080
+                },
+                "https": {
+                    "type": "number",
+                    "description": "WordPress HTTPS container port",
+                    "default": 8443
+                }
+            }
+        },
+        "extraContainerPorts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional ports for WordPress container(s)",
+            "default": [],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled WordPress pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set WordPress pod's Security Context fsGroup",
+                    "default": 1001
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Set WordPress container's Security Context seccomp profile",
+                            "default": "RuntimeDefault"
+                        }
+                    }
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled WordPress containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set WordPress container's Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set WordPress container's Security Context runAsNonRoot",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Set WordPress container's privilege escalation",
+                    "default": false
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "description": "Set WordPress container's Security Context readOnlyRootFilesystem",
+                    "default": false
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "description": "Set WordPress container's Security Context runAsNonRoot",
+                            "default": [
+                                "ALL"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on WordPress containers",
+                    "default": true
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "",
+                            "default": "/wp-admin/install.php"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.wordpressScheme }}"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.wordpressScheme | upper }}"
+                        },
+                        "httpHeaders": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 120
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "",
+                            "default": "/wp-login.php"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.wordpressScheme }}"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.wordpressScheme | upper }}"
+                        },
+                        "httpHeaders": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on WordPress containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "",
+                            "default": "/wp-login.php"
+                        },
+                        "port": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.wordpressScheme }}"
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "description": "",
+                            "default": "{{ .Values.wordpressScheme | upper }}"
+                        },
+                        "httpHeaders": {
+                            "type": "array",
+                            "description": "",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on WordPress containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the WordPress container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "WordPress service type",
+                    "default": "LoadBalancer"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "WordPress service HTTP port",
+                            "default": 80
+                        },
+                        "https": {
+                            "type": "number",
+                            "description": "WordPress service HTTPS port",
+                            "default": 443
+                        }
+                    }
+                },
+                "httpsTargetPort": {
+                    "type": "string",
+                    "description": "Target port for HTTPS",
+                    "default": "https"
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "string",
+                            "description": "Node port for HTTP",
+                            "default": ""
+                        },
+                        "https": {
+                            "type": "string",
+                            "description": "Node port for HTTPS",
+                            "default": ""
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "WordPress service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "WordPress service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "WordPress service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "WordPress service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for WordPress service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra port to expose on WordPress service",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ingress record generation for WordPress",
+                    "default": false
+                },
+                "pathType": {
+                    "type": "string",
+                    "description": "Ingress path type",
+                    "default": "ImplementationSpecific"
+                },
+                "apiVersion": {
+                    "type": "string",
+                    "description": "Force Ingress API version (automatically detected if not set)",
+                    "default": ""
+                },
+                "ingressClassName": {
+                    "type": "string",
+                    "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                    "default": ""
+                },
+                "hostname": {
+                    "type": "string",
+                    "description": "Default host for the ingress record. The hostname is templated and thus can contain other variable references.",
+                    "default": "wordpress.local"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Default path for the ingress record",
+                    "default": "/"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                    "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Enable TLS configuration for the host defined at `ingress.hostname` parameter",
+                    "default": false
+                },
+                "tlsWwwPrefix": {
+                    "type": "boolean",
+                    "description": "Adds www subdomain to default cert",
+                    "default": false
+                },
+                "selfSigned": {
+                    "type": "boolean",
+                    "description": "Create a TLS secret for this ingress record using self-signed certificates generated by Helm",
+                    "default": false
+                },
+                "extraHosts": {
+                    "type": "array",
+                    "description": "An array with additional hostname(s) to be covered with the ingress record. The host names are templated and thus can contain other variable references.",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPaths": {
+                    "type": "array",
+                    "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                    "default": [],
+                    "items": {}
+                },
+                "extraTls": {
+                    "type": "array",
+                    "description": "TLS configuration for additional hostname(s) to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                },
+                "secrets": {
+                    "type": "array",
+                    "description": "Custom TLS certificates as secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "extraRules": {
+                    "type": "array",
+                    "description": "Additional rules to be covered with this ingress record",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable persistence using Persistent Volume Claims",
+                    "default": true
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Persistent Volume storage class",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "Persistent Volume access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "accessMode": {
+                    "type": "string",
+                    "description": "Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)",
+                    "default": "ReadWriteOnce"
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Persistent Volume size",
+                    "default": "10Gi"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "description": "Custom PVC data source",
+                    "default": {}
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "The name of an existing PVC to use for persistence",
+                    "default": ""
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for WordPress data PVC",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Persistent Volume Claim annotations",
+                    "default": {}
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r54"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "OS Shell + Utility image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "OS Shell + Utility image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the init container",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for WordPress pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable a Pod Disruption Budget creation",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "number",
+                    "description": "Minimum number/percentage of pods that should remain scheduled",
+                    "default": 1
+                },
+                "maxUnavailable": {
+                    "type": "string",
+                    "description": "Maximum number/percentage of pods that may be made unavailable",
+                    "default": ""
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Horizontal POD autoscaling for WordPress",
+                    "default": false
+                },
+                "minReplicas": {
+                    "type": "number",
+                    "description": "Minimum number of WordPress replicas",
+                    "default": 1
+                },
+                "maxReplicas": {
+                    "type": "number",
+                    "description": "Maximum number of WordPress replicas",
+                    "default": 11
+                },
+                "targetCPU": {
+                    "type": "number",
+                    "description": "Target CPU utilization percentage",
+                    "default": 50
+                },
+                "targetMemory": {
+                    "type": "number",
+                    "description": "Target Memory utilization percentage",
+                    "default": 50
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a sidecar prometheus exporter to expose metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Apache exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Apache exporter image repository",
+                            "default": "bitnami/apache-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Apache exporter image tag (immutable tags are recommended)",
+                            "default": "1.0.1-debian-11-r32"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Apache exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Apache exporter image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "Prometheus exporter container port",
+                            "default": 9117
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 15
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 3
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Prometheus exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.containerPorts.metrics }}"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "Prometheus metrics service port",
+                                    "default": 9150
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Prometheus exporter container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Prometheus exporter container",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for metrics (prometheus)",
+                            "default": false
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policy for Ingress Proxies",
+                            "default": false
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "backendOnlyAccessibleByFrontend": {
+                            "type": "boolean",
+                            "description": "Enable ingress rule that makes the backend (mariadb) only accessible by testlink's pods.",
+                            "default": false
+                        },
+                        "accessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes testlink only accessible from a particular origin",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a MariaDB server to satisfy the applications database requirements",
+                    "default": true
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "MariaDB root password",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "MariaDB custom database",
+                            "default": "bitnami_wordpress"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "MariaDB custom user name",
+                            "default": "bn_wordpress"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "MariaDB custom user password",
+                            "default": ""
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable persistence on MariaDB using PVC(s)",
+                                    "default": true
+                                },
+                                "storageClass": {
+                                    "type": "string",
+                                    "description": "Persistent Volume storage class",
+                                    "default": ""
+                                },
+                                "accessModes": {
+                                    "type": "array",
+                                    "description": "Persistent Volume access modes",
+                                    "default": [
+                                        "ReadWriteOnce"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "size": {
+                                    "type": "string",
+                                    "description": "Persistent Volume size",
+                                    "default": "8Gi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External Database server host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Database server port",
+                    "default": 3306
+                },
+                "user": {
+                    "type": "string",
+                    "description": "External Database username",
+                    "default": "bn_wordpress"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External Database user password",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "External Database database name",
+                    "default": "bitnami_wordpress"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "The name of an existing secret with database credentials. Evaluated as a template",
+                    "default": ""
+                }
+            }
+        },
+        "memcached": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Deploy a Memcached server for caching database queries",
+                    "default": false
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Memcached authentication",
+                            "default": false
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Memcached admin user",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Memcached admin password",
+                            "default": ""
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "number",
+                            "description": "Memcached service port",
+                            "default": 11211
+                        }
+                    }
+                }
+            }
+        },
+        "externalCache": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "External cache server host",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External cache server port",
+                    "default": 11211
+                }
+            }
         }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Metrics",
-          "description": "Prometheus Exporter / Metrics",
-          "form": true
-        }
-      }
     }
-  }
 }

--- a/bitnami/zookeeper/values.schema.json
+++ b/bitnami/zookeeper/values.schema.json
@@ -1,0 +1,1315 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                }
+            }
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Extra objects to deploy (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "namespaceOverride": {
+            "type": "string",
+            "description": "Override namespace for ZooKeeper resources",
+            "default": ""
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "ZooKeeper image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "ZooKeeper image repository",
+                    "default": "bitnami/zookeeper"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "ZooKeeper image tag (immutable tags are recommended)",
+                    "default": "3.9.0-debian-11-r11"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "ZooKeeper image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "ZooKeeper image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ZooKeeper client-server authentication. It uses SASL/Digest-MD5",
+                            "default": false
+                        },
+                        "clientUser": {
+                            "type": "string",
+                            "description": "User that will use ZooKeeper clients to auth",
+                            "default": ""
+                        },
+                        "clientPassword": {
+                            "type": "string",
+                            "description": "Password that will use ZooKeeper clients to auth",
+                            "default": ""
+                        },
+                        "serverUsers": {
+                            "type": "string",
+                            "description": "Comma, semicolon or whitespace separated list of user to be created",
+                            "default": ""
+                        },
+                        "serverPasswords": {
+                            "type": "string",
+                            "description": "Comma, semicolon or whitespace separated list of passwords to assign to users when created",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Use existing secret (ignores previous passwords)",
+                            "default": ""
+                        }
+                    }
+                },
+                "quorum": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ZooKeeper server-server authentication. It uses SASL/Digest-MD5",
+                            "default": false
+                        },
+                        "learnerUser": {
+                            "type": "string",
+                            "description": "User that the ZooKeeper quorumLearner will use to authenticate to quorumServers.",
+                            "default": ""
+                        },
+                        "learnerPassword": {
+                            "type": "string",
+                            "description": "Password that the ZooKeeper quorumLearner will use to authenticate to quorumServers.",
+                            "default": ""
+                        },
+                        "serverUsers": {
+                            "type": "string",
+                            "description": "Comma, semicolon or whitespace separated list of users for the quorumServers.",
+                            "default": ""
+                        },
+                        "serverPasswords": {
+                            "type": "string",
+                            "description": "Comma, semicolon or whitespace separated list of passwords to assign to users when created",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Use existing secret (ignores previous passwords)",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "tickTime": {
+            "type": "number",
+            "description": "Basic time unit (in milliseconds) used by ZooKeeper for heartbeats",
+            "default": 2000
+        },
+        "initLimit": {
+            "type": "number",
+            "description": "ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader",
+            "default": 10
+        },
+        "syncLimit": {
+            "type": "number",
+            "description": "How far out of date a server can be from a leader",
+            "default": 5
+        },
+        "preAllocSize": {
+            "type": "number",
+            "description": "Block size for transaction log file",
+            "default": 65536
+        },
+        "snapCount": {
+            "type": "number",
+            "description": "The number of transactions recorded in the transaction log before a snapshot can be taken (and the transaction log rolled)",
+            "default": 100000
+        },
+        "maxClientCnxns": {
+            "type": "number",
+            "description": "Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble",
+            "default": 60
+        },
+        "maxSessionTimeout": {
+            "type": "number",
+            "description": "Maximum session timeout (in milliseconds) that the server will allow the client to negotiate",
+            "default": 40000
+        },
+        "heapSize": {
+            "type": "number",
+            "description": "Size (in MB) for the Java Heap options (Xmx and Xms)",
+            "default": 1024
+        },
+        "fourlwCommandsWhitelist": {
+            "type": "string",
+            "description": "A list of comma separated Four Letter Words commands that can be executed",
+            "default": "srvr, mntr, ruok"
+        },
+        "minServerId": {
+            "type": "number",
+            "description": "Minimal SERVER_ID value, nodes increment their IDs respectively",
+            "default": 1
+        },
+        "listenOnAllIPs": {
+            "type": "boolean",
+            "description": "Allow ZooKeeper to listen for connections from its peers on all available IP addresses",
+            "default": false
+        },
+        "autopurge": {
+            "type": "object",
+            "properties": {
+                "snapRetainCount": {
+                    "type": "number",
+                    "description": "The most recent snapshots amount (and corresponding transaction logs) to retain",
+                    "default": 3
+                },
+                "purgeInterval": {
+                    "type": "number",
+                    "description": "The time interval (in hours) for which the purge task has to be triggered",
+                    "default": 0
+                }
+            }
+        },
+        "logLevel": {
+            "type": "string",
+            "description": "Log level for the ZooKeeper server. ERROR by default",
+            "default": "ERROR"
+        },
+        "jvmFlags": {
+            "type": "string",
+            "description": "Default JVM flags for the ZooKeeper process",
+            "default": ""
+        },
+        "dataLogDir": {
+            "type": "string",
+            "description": "Dedicated data log directory",
+            "default": ""
+        },
+        "configuration": {
+            "type": "string",
+            "description": "Configure ZooKeeper with a custom zoo.cfg file",
+            "default": ""
+        },
+        "existingConfigmap": {
+            "type": "string",
+            "description": "The name of an existing ConfigMap with your custom configuration for ZooKeeper",
+            "default": ""
+        },
+        "extraEnvVars": {
+            "type": "array",
+            "description": "Array with extra environment variables to add to ZooKeeper nodes",
+            "default": [],
+            "items": {}
+        },
+        "extraEnvVarsCM": {
+            "type": "string",
+            "description": "Name of existing ConfigMap containing extra env vars for ZooKeeper nodes",
+            "default": ""
+        },
+        "extraEnvVarsSecret": {
+            "type": "string",
+            "description": "Name of existing Secret containing extra env vars for ZooKeeper nodes",
+            "default": ""
+        },
+        "command": {
+            "type": "array",
+            "description": "Override default container command (useful when using custom images)",
+            "default": [
+                "/scripts/setup.sh"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "args": {
+            "type": "array",
+            "description": "Override default container args (useful when using custom images)",
+            "default": [],
+            "items": {}
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of ZooKeeper nodes",
+            "default": 1
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "client": {
+                    "type": "number",
+                    "description": "ZooKeeper client container port",
+                    "default": 2181
+                },
+                "tls": {
+                    "type": "number",
+                    "description": "ZooKeeper TLS container port",
+                    "default": 3181
+                },
+                "follower": {
+                    "type": "number",
+                    "description": "ZooKeeper follower container port",
+                    "default": 2888
+                },
+                "election": {
+                    "type": "number",
+                    "description": "ZooKeeper election container port",
+                    "default": 3888
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable livenessProbe on ZooKeeper containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
+                },
+                "probeCommandTimeout": {
+                    "type": "number",
+                    "description": "Probe command timeout for livenessProbe",
+                    "default": 2
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable readinessProbe on ZooKeeper containers",
+                    "default": true
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 5
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 5
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 6
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
+                },
+                "probeCommandTimeout": {
+                    "type": "number",
+                    "description": "Probe command timeout for readinessProbe",
+                    "default": 2
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable startupProbe on ZooKeeper containers",
+                    "default": false
+                },
+                "initialDelaySeconds": {
+                    "type": "number",
+                    "description": "Initial delay seconds for startupProbe",
+                    "default": 30
+                },
+                "periodSeconds": {
+                    "type": "number",
+                    "description": "Period seconds for startupProbe",
+                    "default": 10
+                },
+                "timeoutSeconds": {
+                    "type": "number",
+                    "description": "Timeout seconds for startupProbe",
+                    "default": 1
+                },
+                "failureThreshold": {
+                    "type": "number",
+                    "description": "Failure threshold for startupProbe",
+                    "default": 15
+                },
+                "successThreshold": {
+                    "type": "number",
+                    "description": "Success threshold for startupProbe",
+                    "default": 1
+                }
+            }
+        },
+        "customLivenessProbe": {
+            "type": "object",
+            "description": "Custom livenessProbe that overrides the default one",
+            "default": {}
+        },
+        "customReadinessProbe": {
+            "type": "object",
+            "description": "Custom readinessProbe that overrides the default one",
+            "default": {}
+        },
+        "customStartupProbe": {
+            "type": "object",
+            "description": "Custom startupProbe that overrides the default one",
+            "default": {}
+        },
+        "lifecycleHooks": {
+            "type": "object",
+            "description": "for the ZooKeeper container(s) to automate configuration before or after startup",
+            "default": {}
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "description": "The resources limits for the ZooKeeper containers",
+                    "default": {}
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string",
+                            "description": "The requested memory for the ZooKeeper containers",
+                            "default": "256Mi"
+                        },
+                        "cpu": {
+                            "type": "string",
+                            "description": "The requested cpu for the ZooKeeper containers",
+                            "default": "250m"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled ZooKeeper pods' Security Context",
+                    "default": true
+                },
+                "fsGroup": {
+                    "type": "number",
+                    "description": "Set ZooKeeper pod's Security Context fsGroup",
+                    "default": 1001
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enabled ZooKeeper containers' Security Context",
+                    "default": true
+                },
+                "runAsUser": {
+                    "type": "number",
+                    "description": "Set ZooKeeper containers' Security Context runAsUser",
+                    "default": 1001
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "description": "Set ZooKeeper containers' Security Context runAsNonRoot",
+                    "default": true
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "description": "Force the child process to be run as nonprivilege",
+                    "default": false
+                }
+            }
+        },
+        "hostAliases": {
+            "type": "array",
+            "description": "ZooKeeper pods host aliases",
+            "default": [],
+            "items": {}
+        },
+        "podLabels": {
+            "type": "object",
+            "description": "Extra labels for ZooKeeper pods",
+            "default": {}
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations for ZooKeeper pods",
+            "default": {}
+        },
+        "podAffinityPreset": {
+            "type": "string",
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
+        },
+        "podAntiAffinityPreset": {
+            "type": "string",
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
+        },
+        "nodeAffinityPreset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Node label key to match Ignored if `affinity` is set.",
+                    "default": ""
+                },
+                "values": {
+                    "type": "array",
+                    "description": "Node label values to match. Ignored if `affinity` is set.",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for pod assignment",
+            "default": {}
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node labels for pod assignment",
+            "default": {}
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod assignment",
+            "default": [],
+            "items": {}
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
+        "podManagementPolicy": {
+            "type": "string",
+            "description": "StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel`",
+            "default": "Parallel"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Name of the existing priority class to be used by ZooKeeper pods, priority class needs to be created beforehand",
+            "default": ""
+        },
+        "schedulerName": {
+            "type": "string",
+            "description": "Kubernetes pod scheduler registry",
+            "default": ""
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "ZooKeeper statefulset strategy type",
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "description": "ZooKeeper statefulset rolling update configuration parameters",
+                    "default": {}
+                }
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumes for the ZooKeeper pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "description": "Optionally specify extra list of additional volumeMounts for the ZooKeeper container(s)",
+            "default": [],
+            "items": {}
+        },
+        "sidecars": {
+            "type": "array",
+            "description": "Add additional sidecar containers to the ZooKeeper pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Add additional init containers to the ZooKeeper pod(s)",
+            "default": [],
+            "items": {}
+        },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Deploy a pdb object for the ZooKeeper pod",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": "string",
+                    "description": "Minimum available ZooKeeper replicas",
+                    "default": ""
+                },
+                "maxUnavailable": {
+                    "type": "number",
+                    "description": "Maximum unavailable ZooKeeper replicas",
+                    "default": 1
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Kubernetes Service type",
+                    "default": "ClusterIP"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "number",
+                            "description": "ZooKeeper client service port",
+                            "default": 2181
+                        },
+                        "tls": {
+                            "type": "number",
+                            "description": "ZooKeeper TLS service port",
+                            "default": 3181
+                        },
+                        "follower": {
+                            "type": "number",
+                            "description": "ZooKeeper follower service port",
+                            "default": 2888
+                        },
+                        "election": {
+                            "type": "number",
+                            "description": "ZooKeeper election service port",
+                            "default": 3888
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "string",
+                            "description": "Node port for clients",
+                            "default": ""
+                        },
+                        "tls": {
+                            "type": "string",
+                            "description": "Node port for TLS",
+                            "default": ""
+                        }
+                    }
+                },
+                "disableBaseClientPort": {
+                    "type": "boolean",
+                    "description": "Remove client port from service definitions.",
+                    "default": false
+                },
+                "sessionAffinity": {
+                    "type": "string",
+                    "description": "Control where client requests go, to the same pod or round-robin",
+                    "default": "None"
+                },
+                "sessionAffinityConfig": {
+                    "type": "object",
+                    "description": "Additional settings for the sessionAffinity",
+                    "default": {}
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "description": "ZooKeeper service Cluster IP",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "description": "ZooKeeper service Load Balancer IP",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array",
+                    "description": "ZooKeeper service Load Balancer sources",
+                    "default": [],
+                    "items": {}
+                },
+                "externalTrafficPolicy": {
+                    "type": "string",
+                    "description": "ZooKeeper service external traffic policy",
+                    "default": "Cluster"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for ZooKeeper service",
+                    "default": {}
+                },
+                "extraPorts": {
+                    "type": "array",
+                    "description": "Extra ports to expose in the ZooKeeper service (normally used with the `sidecar` value)",
+                    "default": [],
+                    "items": {}
+                },
+                "headless": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the Headless Service",
+                            "default": {}
+                        },
+                        "publishNotReadyAddresses": {
+                            "type": "boolean",
+                            "description": "If the ZooKeeper headless service should publish DNS records for not ready pods",
+                            "default": true
+                        },
+                        "servicenameOverride": {
+                            "type": "string",
+                            "description": "String to partially override headless service name",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Specifies whether a NetworkPolicy should be created",
+                    "default": false
+                },
+                "allowExternal": {
+                    "type": "boolean",
+                    "description": "Don't require client label for connections",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for ZooKeeper pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable ZooKeeper data persistence using PVC. If false, use emptyDir",
+                    "default": true
+                },
+                "existingClaim": {
+                    "type": "string",
+                    "description": "Name of an existing PVC to use (only when deploying a single replica)",
+                    "default": ""
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "PVC Storage Class for ZooKeeper data volume",
+                    "default": ""
+                },
+                "accessModes": {
+                    "type": "array",
+                    "description": "PVC Access modes",
+                    "default": [
+                        "ReadWriteOnce"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size": {
+                    "type": "string",
+                    "description": "PVC Storage Request for ZooKeeper data volume",
+                    "default": "8Gi"
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the PVC",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels for the PVC",
+                    "default": {}
+                },
+                "selector": {
+                    "type": "object",
+                    "description": "Selector to match an existing Persistent Volume for ZooKeeper's data PVC",
+                    "default": {}
+                },
+                "dataLogDir": {
+                    "type": "object",
+                    "properties": {
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for ZooKeeper's dedicated data log directory",
+                            "default": "8Gi"
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Provide an existing `PersistentVolumeClaim` for ZooKeeper's data log directory",
+                            "default": ""
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume for ZooKeeper's data log PVC",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r51"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled init container Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus to access ZooKeeper metrics endpoint",
+                    "default": false
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "ZooKeeper Prometheus Exporter container port",
+                    "default": 9141
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "ZooKeeper Prometheus Exporter service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "ZooKeeper Prometheus Exporter service port",
+                            "default": 9141
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "io/scrape": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "true"
+                                        },
+                                        "io/port": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "{{ .Values.metrics.service.port }}"
+                                        },
+                                        "io/path": {
+                                            "type": "string",
+                                            "description": "",
+                                            "default": "/metrics"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a PrometheusRule for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "PrometheusRule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS for client connections",
+                            "default": false
+                        },
+                        "auth": {
+                            "type": "string",
+                            "description": "SSL Client auth. Can be \"none\", \"want\" or \"need\".",
+                            "default": "none"
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Generate automatically self-signed TLS certificates for ZooKeeper client communications",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for ZooKeeper client communications",
+                            "default": ""
+                        },
+                        "existingSecretKeystoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.client.existingSecret containing the Keystore.",
+                            "default": ""
+                        },
+                        "existingSecretTruststoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.client.existingSecret containing the Truststore.",
+                            "default": ""
+                        },
+                        "keystorePath": {
+                            "type": "string",
+                            "description": "Location of the KeyStore file used for Client connections",
+                            "default": "/opt/bitnami/zookeeper/config/certs/client/zookeeper.keystore.jks"
+                        },
+                        "truststorePath": {
+                            "type": "string",
+                            "description": "Location of the TrustStore file used for Client connections",
+                            "default": "/opt/bitnami/zookeeper/config/certs/client/zookeeper.truststore.jks"
+                        },
+                        "passwordsSecretName": {
+                            "type": "string",
+                            "description": "Existing secret containing Keystore and truststore passwords",
+                            "default": ""
+                        },
+                        "passwordsSecretKeystoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.client.passwordsSecretName containing the password for the Keystore.",
+                            "default": ""
+                        },
+                        "passwordsSecretTruststoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.client.passwordsSecretName containing the password for the Truststore.",
+                            "default": ""
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access KeyStore if needed",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access TrustStore if needed",
+                            "default": ""
+                        }
+                    }
+                },
+                "quorum": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable TLS for quorum protocol",
+                            "default": false
+                        },
+                        "auth": {
+                            "type": "string",
+                            "description": "SSL Quorum Client auth. Can be \"none\", \"want\" or \"need\".",
+                            "default": "none"
+                        },
+                        "autoGenerated": {
+                            "type": "boolean",
+                            "description": "Create self-signed TLS certificates. Currently only supports PEM certificates.",
+                            "default": false
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of the existing secret containing the TLS certificates for ZooKeeper quorum protocol",
+                            "default": ""
+                        },
+                        "existingSecretKeystoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.quorum.existingSecret containing the Keystore.",
+                            "default": ""
+                        },
+                        "existingSecretTruststoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.quorum.existingSecret containing the Truststore.",
+                            "default": ""
+                        },
+                        "keystorePath": {
+                            "type": "string",
+                            "description": "Location of the KeyStore file used for Quorum protocol",
+                            "default": "/opt/bitnami/zookeeper/config/certs/quorum/zookeeper.keystore.jks"
+                        },
+                        "truststorePath": {
+                            "type": "string",
+                            "description": "Location of the TrustStore file used for Quorum protocol",
+                            "default": "/opt/bitnami/zookeeper/config/certs/quorum/zookeeper.truststore.jks"
+                        },
+                        "passwordsSecretName": {
+                            "type": "string",
+                            "description": "Existing secret containing Keystore and truststore passwords",
+                            "default": ""
+                        },
+                        "passwordsSecretKeystoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.quorum.passwordsSecretName containing the password for the Keystore.",
+                            "default": ""
+                        },
+                        "passwordsSecretTruststoreKey": {
+                            "type": "string",
+                            "description": "The secret key from the tls.quorum.passwordsSecretName containing the password for the Truststore.",
+                            "default": ""
+                        },
+                        "keystorePassword": {
+                            "type": "string",
+                            "description": "Password to access KeyStore if needed",
+                            "default": ""
+                        },
+                        "truststorePassword": {
+                            "type": "string",
+                            "description": "Password to access TrustStore if needed",
+                            "default": ""
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the TLS init container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the TLS init container",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of the change

This PR simply performs a bulk update on every chart, generating (or updating) the json-schema file for the `values.yaml` using the [readme-generator-for-helm tool](https://github.com/bitnami-labs/readme-generator-for-helm).

### Benefits

The charts will have an up-to-date values.schema.json file, which, apart from the intrinsic validation benefits, will ease the UX while deploying them using [Kubeapps](https://kubeapps.dev/).

### Possible drawbacks

In the past, we (Kubeapps) ran into issues like https://github.com/bitnami-labs/readme-generator-for-helm/issues/15, but in recent versions, this should no longer be an issue.

### Applicable issues

N/A

### Additional information

TBD

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)