### PR TITLE
[bitnami/mastodon] Add `ProxyPreserveHost on` and remove duplicated `VirtualHost` in apache-configmap.yaml

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 2.1.3
+version: 2.1.4

--- a/bitnami/mastodon/templates/apache-configmap.yaml
+++ b/bitnami/mastodon/templates/apache-configmap.yaml
@@ -16,12 +16,13 @@ metadata:
   {{- end }}
 data:
   mastodon-vhost.conf: |-
-    <VirtualHost VirtualHost 127.0.0.1:{{ .Values.apache.containerPorts.http }} _default_:{{ .Values.apache.containerPorts.http }}>
+    <VirtualHost 127.0.0.1:{{ .Values.apache.containerPorts.http }} _default_:{{ .Values.apache.containerPorts.http }}>
       ServerName {{ include "mastodon.web.domain" . }}
       ServerAlias *
       <Location "/">
         ProxyPass http://{{ include "mastodon.web.fullname" . }}:{{ .Values.web.service.ports.http }}/
         ProxyPassReverse {{ include "mastodon.web.domain" . }}
+        ProxyPreserveHost on
         Order allow,deny
         Allow from all
       </Location>


### PR DESCRIPTION
### Description of the change
The change removes a duplicated `VirtualHost` entry in the Apache config map and adds the `ProxyPreserveHost on` option

### Benefits
Removing the duplicated `VirtualHost` entry from the config map removes an "Unrecognized VirtualHost VirtualHost" error in the Apache pod logs.

Enabling `ProxyPreserveHost` allows Mastodon federation functionalities to work properly when behind Apache. According to the [documentation](https://docs.joinmastodon.org/spec/security/#http), Mastodon requires a signature based partially on the `Host` header. That signature then gets deciphered upon receiving. However, if Apache overwrites the host header (the default behavior), the deciphered signature does not match the source one and incoming federation operations throw a `401 unauthorized` error in Apache logs.

### Possible drawbacks
None that I'm aware of.

### Applicable issues
None

### Additional information
None

### Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
