### PR TITLE
[bitnami/redis-cluster] Allow set Helm/ArgoCD hook for updateJob

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 9.0.4
+version: 9.0.5

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -237,33 +237,33 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Cluster update job parameters
 
-| Name                                  | Description                                                                                                     | Value          |
-|---------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------|
-| `updateJob.activeDeadlineSeconds`     | Number of seconds the Job to create the cluster will be waiting for the Nodes to be ready.                      | `600`          |
-| `updateJob.command`                   | Container command (using container default if not set)                                                          | `[]`           |
-| `updateJob.args`                      | Container args (using container default if not set)                                                             | `[]`           |
-| `updateJob.hostAliases`               | Deployment pod host aliases                                                                                     | `[]`           |
-| `updateJob.helmHook`                  | Job Helm hook                                                                                                   | `post-upgrade` |
-| `updateJob.annotations`               | Job annotations                                                                                                 | `{}`           |
-| `updateJob.podAnnotations`            | Job pod annotations                                                                                             | `{}`           |
-| `updateJob.podLabels`                 | Pod extra labels                                                                                                | `{}`           |
-| `updateJob.extraEnvVars`              | An array to add extra environment variables                                                                     | `[]`           |
-| `updateJob.extraEnvVarsCM`            | ConfigMap containing extra environment variables                                                                | `""`           |
-| `updateJob.extraEnvVarsSecret`        | Secret containing extra environment variables                                                                   | `""`           |
-| `updateJob.extraVolumes`              | Extra volumes to add to the deployment                                                                          | `[]`           |
-| `updateJob.extraVolumeMounts`         | Extra volume mounts to add to the container                                                                     | `[]`           |
-| `updateJob.initContainers`            | Extra init containers to add to the deployment                                                                  | `[]`           |
-| `updateJob.podAffinityPreset`         | Update job pod affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`        | `""`           |
-| `updateJob.podAntiAffinityPreset`     | Update job pod anti-affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`   | `soft`         |
-| `updateJob.nodeAffinityPreset.type`   | Update job node affinity preset type. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`  | `""`           |
-| `updateJob.nodeAffinityPreset.key`    | Update job node label key to match Ignored if `updateJob.affinity` is set.                                      | `""`           |
-| `updateJob.nodeAffinityPreset.values` | Update job node label values to match. Ignored if `updateJob.affinity` is set.                                  | `[]`           |
-| `updateJob.affinity`                  | Affinity for update job pods assignment                                                                         | `{}`           |
-| `updateJob.nodeSelector`              | Node labels for update job pods assignment                                                                      | `{}`           |
-| `updateJob.tolerations`               | Tolerations for update job pods assignment                                                                      | `[]`           |
-| `updateJob.priorityClassName`         | Priority class name                                                                                             | `""`           |
-| `updateJob.resources.limits`          | The resources limits for the container                                                                          | `{}`           |
-| `updateJob.resources.requests`        | The requested resources for the container                                                                       | `{}`           |
+| Name                                  | Description                                                                                                    | Value          |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- |
+| `updateJob.activeDeadlineSeconds`     | Number of seconds the Job to create the cluster will be waiting for the Nodes to be ready.                     | `600`          |
+| `updateJob.command`                   | Container command (using container default if not set)                                                         | `[]`           |
+| `updateJob.args`                      | Container args (using container default if not set)                                                            | `[]`           |
+| `updateJob.hostAliases`               | Deployment pod host aliases                                                                                    | `[]`           |
+| `updateJob.helmHook`                  | Job Helm hook                                                                                                  | `post-upgrade` |
+| `updateJob.annotations`               | Job annotations                                                                                                | `{}`           |
+| `updateJob.podAnnotations`            | Job pod annotations                                                                                            | `{}`           |
+| `updateJob.podLabels`                 | Pod extra labels                                                                                               | `{}`           |
+| `updateJob.extraEnvVars`              | An array to add extra environment variables                                                                    | `[]`           |
+| `updateJob.extraEnvVarsCM`            | ConfigMap containing extra environment variables                                                               | `""`           |
+| `updateJob.extraEnvVarsSecret`        | Secret containing extra environment variables                                                                  | `""`           |
+| `updateJob.extraVolumes`              | Extra volumes to add to the deployment                                                                         | `[]`           |
+| `updateJob.extraVolumeMounts`         | Extra volume mounts to add to the container                                                                    | `[]`           |
+| `updateJob.initContainers`            | Extra init containers to add to the deployment                                                                 | `[]`           |
+| `updateJob.podAffinityPreset`         | Update job pod affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`       | `""`           |
+| `updateJob.podAntiAffinityPreset`     | Update job pod anti-affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`  | `soft`         |
+| `updateJob.nodeAffinityPreset.type`   | Update job node affinity preset type. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard` | `""`           |
+| `updateJob.nodeAffinityPreset.key`    | Update job node label key to match Ignored if `updateJob.affinity` is set.                                     | `""`           |
+| `updateJob.nodeAffinityPreset.values` | Update job node label values to match. Ignored if `updateJob.affinity` is set.                                 | `[]`           |
+| `updateJob.affinity`                  | Affinity for update job pods assignment                                                                        | `{}`           |
+| `updateJob.nodeSelector`              | Node labels for update job pods assignment                                                                     | `{}`           |
+| `updateJob.tolerations`               | Tolerations for update job pods assignment                                                                     | `[]`           |
+| `updateJob.priorityClassName`         | Priority class name                                                                                            | `""`           |
+| `updateJob.resources.limits`          | The resources limits for the container                                                                         | `{}`           |
+| `updateJob.resources.requests`        | The requested resources for the container                                                                      | `{}`           |
 
 ### Cluster management parameters
 

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -237,32 +237,33 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Cluster update job parameters
 
-| Name                                  | Description                                                                                                    | Value  |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------ |
-| `updateJob.activeDeadlineSeconds`     | Number of seconds the Job to create the cluster will be waiting for the Nodes to be ready.                     | `600`  |
-| `updateJob.command`                   | Container command (using container default if not set)                                                         | `[]`   |
-| `updateJob.args`                      | Container args (using container default if not set)                                                            | `[]`   |
-| `updateJob.hostAliases`               | Deployment pod host aliases                                                                                    | `[]`   |
-| `updateJob.annotations`               | Job annotations                                                                                                | `{}`   |
-| `updateJob.podAnnotations`            | Job pod annotations                                                                                            | `{}`   |
-| `updateJob.podLabels`                 | Pod extra labels                                                                                               | `{}`   |
-| `updateJob.extraEnvVars`              | An array to add extra environment variables                                                                    | `[]`   |
-| `updateJob.extraEnvVarsCM`            | ConfigMap containing extra environment variables                                                               | `""`   |
-| `updateJob.extraEnvVarsSecret`        | Secret containing extra environment variables                                                                  | `""`   |
-| `updateJob.extraVolumes`              | Extra volumes to add to the deployment                                                                         | `[]`   |
-| `updateJob.extraVolumeMounts`         | Extra volume mounts to add to the container                                                                    | `[]`   |
-| `updateJob.initContainers`            | Extra init containers to add to the deployment                                                                 | `[]`   |
-| `updateJob.podAffinityPreset`         | Update job pod affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`       | `""`   |
-| `updateJob.podAntiAffinityPreset`     | Update job pod anti-affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`  | `soft` |
-| `updateJob.nodeAffinityPreset.type`   | Update job node affinity preset type. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard` | `""`   |
-| `updateJob.nodeAffinityPreset.key`    | Update job node label key to match Ignored if `updateJob.affinity` is set.                                     | `""`   |
-| `updateJob.nodeAffinityPreset.values` | Update job node label values to match. Ignored if `updateJob.affinity` is set.                                 | `[]`   |
-| `updateJob.affinity`                  | Affinity for update job pods assignment                                                                        | `{}`   |
-| `updateJob.nodeSelector`              | Node labels for update job pods assignment                                                                     | `{}`   |
-| `updateJob.tolerations`               | Tolerations for update job pods assignment                                                                     | `[]`   |
-| `updateJob.priorityClassName`         | Priority class name                                                                                            | `""`   |
-| `updateJob.resources.limits`          | The resources limits for the container                                                                         | `{}`   |
-| `updateJob.resources.requests`        | The requested resources for the container                                                                      | `{}`   |
+| Name                                  | Description                                                                                                     | Value          |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------|
+| `updateJob.activeDeadlineSeconds`     | Number of seconds the Job to create the cluster will be waiting for the Nodes to be ready.                      | `600`          |
+| `updateJob.command`                   | Container command (using container default if not set)                                                          | `[]`           |
+| `updateJob.args`                      | Container args (using container default if not set)                                                             | `[]`           |
+| `updateJob.hostAliases`               | Deployment pod host aliases                                                                                     | `[]`           |
+| `updateJob.helmHook`                  | Job Helm hook                                                                                                   | `post-upgrade` |
+| `updateJob.annotations`               | Job annotations                                                                                                 | `{}`           |
+| `updateJob.podAnnotations`            | Job pod annotations                                                                                             | `{}`           |
+| `updateJob.podLabels`                 | Pod extra labels                                                                                                | `{}`           |
+| `updateJob.extraEnvVars`              | An array to add extra environment variables                                                                     | `[]`           |
+| `updateJob.extraEnvVarsCM`            | ConfigMap containing extra environment variables                                                                | `""`           |
+| `updateJob.extraEnvVarsSecret`        | Secret containing extra environment variables                                                                   | `""`           |
+| `updateJob.extraVolumes`              | Extra volumes to add to the deployment                                                                          | `[]`           |
+| `updateJob.extraVolumeMounts`         | Extra volume mounts to add to the container                                                                     | `[]`           |
+| `updateJob.initContainers`            | Extra init containers to add to the deployment                                                                  | `[]`           |
+| `updateJob.podAffinityPreset`         | Update job pod affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`        | `""`           |
+| `updateJob.podAntiAffinityPreset`     | Update job pod anti-affinity preset. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`   | `soft`         |
+| `updateJob.nodeAffinityPreset.type`   | Update job node affinity preset type. Ignored if `updateJob.affinity` is set. Allowed values: `soft` or `hard`  | `""`           |
+| `updateJob.nodeAffinityPreset.key`    | Update job node label key to match Ignored if `updateJob.affinity` is set.                                      | `""`           |
+| `updateJob.nodeAffinityPreset.values` | Update job node label values to match. Ignored if `updateJob.affinity` is set.                                  | `[]`           |
+| `updateJob.affinity`                  | Affinity for update job pods assignment                                                                         | `{}`           |
+| `updateJob.nodeSelector`              | Node labels for update job pods assignment                                                                      | `{}`           |
+| `updateJob.tolerations`               | Tolerations for update job pods assignment                                                                      | `[]`           |
+| `updateJob.priorityClassName`         | Priority class name                                                                                             | `""`           |
+| `updateJob.resources.limits`          | The resources limits for the container                                                                          | `{}`           |
+| `updateJob.resources.requests`        | The requested resources for the container                                                                       | `{}`           |
 
 ### Cluster management parameters
 

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-upgrade
+    "helm.sh/hook": {{ .Values.updateJob.helmHook }}
     {{- if or .Values.updateJob.annotations .Values.commonAnnotations }}
     {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.updateJob.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -654,6 +654,10 @@ updateJob:
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
+  ## @param updateJob.helmHook Job Helm hook
+  ## https://helm.sh/docs/topics/charts_hooks/#the-available-hooks
+  ##
+  helmHook: post-upgrade
   ## @param updateJob.annotations Job annotations
   ##
   annotations: {}


### PR DESCRIPTION
### Description of the change

Ability to setup other Helm hook rather than hard coded one.

### Benefits

On ArgoCD side, a hard coded `"helm.sh/hook": post-upgrade` hook is equivalent to `argocd.argoproj.io/hook: PostSync`, which means, hook will be launched only when ArgoCD application is fully synced.

But it never does as new added node runs in standalone mode and as the default `readinessProbe` is [checking for cluster info](https://github.com/bitnami/charts/blob/main/bitnami/redis-cluster/templates/scripts-configmap.yaml#L52-L77) it will always fail.

Ability to setup other Helm hook would help to launch the script on ArgoCD side.

### Possible drawbacks

N/A

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/18924

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
