### PR TITLE
[bitnami/common] new macro to checksum config resources

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.11.1
+appVersion: 2.12.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.11.1
+version: 2.12.0

--- a/bitnami/common/templates/_utils.tpl
+++ b/bitnami/common/templates/_utils.tpl
@@ -67,11 +67,11 @@ Usage:
 {{- end -}}
 
 {{/*
-Checksum a template containing a *single* resource (ConfigMap,Secret) for use in pod annotations, excluding the metadata (see #18376).
+Checksum a template at "path" containing a *single* resource (ConfigMap,Secret) for use in pod annotations, excluding the metadata (see #18376).
 Usage:
-{{ include "common.utils.checksum" (dict "template" "/configmap.yaml" "context" $) }}
+{{ include "common.utils.checksumTemplate" (dict "path" "/configmap.yaml" "context" $) }}
 */}}
-{{- define "common.utils.checksum" -}}
-{{- $obj := include (print .context.Template.BasePath .template) .context | fromYaml -}}
+{{- define "common.utils.checksumTemplate" -}}
+{{- $obj := include (print .context.Template.BasePath .path) .context | fromYaml -}}
 {{ omit $obj "apiVersion" "kind" "metadata" | toYaml | sha256sum }}
 {{- end -}}

--- a/bitnami/common/templates/_utils.tpl
+++ b/bitnami/common/templates/_utils.tpl
@@ -65,3 +65,13 @@ Usage:
 {{- end -}}
 {{- printf "%s" $key -}} 
 {{- end -}}
+
+{{/*
+Checksum a template containing a *single* resource (ConfigMap,Secret) for use in pod annotations, excluding the metadata (see #18376).
+Usage:
+{{ include "common.utils.checksum" (dict "template" "/configmap.yaml" "context" $) }}
+*/}}
+{{- define "common.utils.checksum" -}}
+{{- $obj := include (print .context.Template.BasePath .template) .context | fromYaml -}}
+{{ omit $obj "apiVersion" "kind" "metadata" | toYaml | sha256sum }}
+{{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The pattern to rollout workloads on config change, described in [helm docs](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments), has the issue that it will trigger a reload of the pods when the chart version change, even it the pod template and configmap data are not changed.

This happens because the version of the chart is included in "helm.sh/chart" in metadata.labels (printf "%s-%s" .Chart.Name .Chart.Version) of the configmap and the checksum is done on the whole file.

This new macro calculates the checksum by omitting metadata.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #18376

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
